### PR TITLE
Refactor static methods to this.orm API.

### DIFF
--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -67,7 +67,7 @@ export function isFieldIgnored(
 
   if (ignore && notNull && !hasDefault) {
     fail(
-      "notNull fields cannot be ignored. Alter the column to be optional or have a default value prior to ignoring it.",
+      `notNull field ${entity.name}.${fieldName} cannot be ignored. Alter the column to be optional or have a default value prior to ignoring it.`,
     );
   }
   return ignore;

--- a/packages/codegen/src/symbols.ts
+++ b/packages/codegen/src/symbols.ts
@@ -12,6 +12,7 @@ export const EntityOrmField = imp("EntityOrmField@joist-orm");
 export const EntityManager = imp("EntityManager@joist-orm");
 export const EntityMetadata = imp("EntityMetadata@joist-orm");
 export const Lens = imp("Lens@joist-orm");
+export const OrmApi = imp("OrmApi@joist-orm");
 export const PrimaryKeySerde = imp("PrimaryKeySerde@joist-orm");
 export const ManyToOneReference = imp("ManyToOneReference@joist-orm");
 export const PolymorphicReference = imp("PolymorphicReference@joist-orm");

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -3,7 +3,6 @@ import {
   BooleanFilter,
   BooleanGraphQLFilter,
   Changes,
-  Collection,
   ConfigApi,
   EntityFilter,
   EntityGraphQLFilter,
@@ -13,19 +12,15 @@ import {
   Flavor,
   getEm,
   GraphQLFilterOf,
-  hasMany,
-  hasOne,
-  hasOneToOne,
   Lens,
   Loaded,
   LoadHint,
   loadLens,
-  ManyToOneReference,
   newChangesProxy,
   newRequiredRule,
-  OneToOneReference,
   OptsOf,
   OrderBy,
+  OrmApi,
   PartialOrNull,
   setField,
   setOpts,
@@ -153,16 +148,17 @@ export abstract class AuthorCodegen extends BaseEntity {
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
   } = null!;
+  protected readonly orm = new OrmApi(this as any as Author);
 
-  readonly authors: Collection<Author, Author> = hasMany(authorMeta, "authors", "mentor", "mentor_id");
+  readonly authors = this.orm.hasMany(authorMeta, "authors", "mentor", "mentor_id");
 
-  readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "author", "author_id");
+  readonly books = this.orm.hasMany(bookMeta, "books", "author", "author_id");
 
-  readonly mentor: ManyToOneReference<Author, Author, undefined> = hasOne(authorMeta, "mentor", "authors");
+  readonly mentor = this.orm.hasOne(authorMeta, "mentor", "authors", false);
 
-  readonly publisher: ManyToOneReference<Author, Publisher, undefined> = hasOne(publisherMeta, "publisher", "authors");
+  readonly publisher = this.orm.hasOne(publisherMeta, "publisher", "authors", false);
 
-  readonly image: OneToOneReference<Author, Image> = hasOneToOne(imageMeta, "image", "author", "author_id");
+  readonly image = this.orm.hasOneToOne(imageMeta, "image", "author", "author_id");
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, {}, opts);

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -10,16 +10,15 @@ import {
   Flavor,
   getEm,
   GraphQLFilterOf,
-  hasOne,
   Lens,
   Loaded,
   LoadHint,
   loadLens,
-  ManyToOneReference,
   newChangesProxy,
   newRequiredRule,
   OptsOf,
   OrderBy,
+  OrmApi,
   PartialOrNull,
   setField,
   setOpts,
@@ -101,14 +100,11 @@ export abstract class BookAdvanceCodegen extends BaseEntity {
     optIdsType: BookAdvanceIdsOpts;
     factoryOptsType: Parameters<typeof newBookAdvance>[1];
   } = null!;
+  protected readonly orm = new OrmApi(this as any as BookAdvance);
 
-  readonly book: ManyToOneReference<BookAdvance, Book, never> = hasOne(bookMeta, "book", "advances");
+  readonly book = this.orm.hasOne(bookMeta, "book", "advances", true);
 
-  readonly publisher: ManyToOneReference<BookAdvance, Publisher, never> = hasOne(
-    publisherMeta,
-    "publisher",
-    "bookAdvances",
-  );
+  readonly publisher = this.orm.hasOne(publisherMeta, "publisher", "bookAdvances", true);
 
   constructor(em: EntityManager, opts: BookAdvanceOpts) {
     super(em, bookAdvanceMeta, {}, opts);

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -1,7 +1,6 @@
 import {
   BaseEntity,
   Changes,
-  Collection,
   ConfigApi,
   EntityFilter,
   EntityGraphQLFilter,
@@ -10,20 +9,15 @@ import {
   Flavor,
   getEm,
   GraphQLFilterOf,
-  hasMany,
-  hasManyToMany,
-  hasOne,
-  hasOneToOne,
   Lens,
   Loaded,
   LoadHint,
   loadLens,
-  ManyToOneReference,
   newChangesProxy,
   newRequiredRule,
-  OneToOneReference,
   OptsOf,
   OrderBy,
+  OrmApi,
   PartialOrNull,
   setField,
   setOpts,
@@ -125,18 +119,19 @@ export abstract class BookCodegen extends BaseEntity {
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
   } = null!;
+  protected readonly orm = new OrmApi(this as any as Book);
 
-  readonly advances: Collection<Book, BookAdvance> = hasMany(bookAdvanceMeta, "advances", "book", "book_id");
+  readonly advances = this.orm.hasMany(bookAdvanceMeta, "advances", "book", "book_id");
 
-  readonly reviews: Collection<Book, BookReview> = hasMany(bookReviewMeta, "reviews", "book", "book_id");
+  readonly reviews = this.orm.hasMany(bookReviewMeta, "reviews", "book", "book_id");
 
-  readonly comments: Collection<Book, Comment> = hasMany(commentMeta, "comments", "parent", "parent_book_id");
+  readonly comments = this.orm.hasMany(commentMeta, "comments", "parent", "parent_book_id");
 
-  readonly author: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "author", "books");
+  readonly author = this.orm.hasOne(authorMeta, "author", "books", true);
 
-  readonly image: OneToOneReference<Book, Image> = hasOneToOne(imageMeta, "image", "book", "book_id");
+  readonly image = this.orm.hasOneToOne(imageMeta, "image", "book", "book_id");
 
-  readonly tags: Collection<Book, Tag> = hasManyToMany("books_to_tags", "tags", "book_id", tagMeta, "books", "tag_id");
+  readonly tags = this.orm.hasManyToMany("books_to_tags", "tags", "book_id", tagMeta, "books", "tag_id");
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, bookDefaultValues, opts);

--- a/packages/integration-tests/src/entities/BookReview.ts
+++ b/packages/integration-tests/src/entities/BookReview.ts
@@ -1,13 +1,19 @@
-import { hasOneDerived, hasOneThrough, Reference } from "joist-orm";
-import { Author, BookReviewCodegen, bookReviewConfig, Publisher } from "./entities";
+import { Lens, OrmApi, Reference } from "joist-orm";
+import { BookReviewCodegen, bookReviewConfig, Publisher } from "./entities";
+
+type T = Lens<BookReview>;
+const a: T = null!;
+const b = a.book.author;
+
+const orm = new OrmApi(null!);
 
 export class BookReview extends BookReviewCodegen {
-  // Currently this infers as Reference<BookReview, Author, undefined> --> it should be never...
-  readonly author: Reference<BookReview, Author, never> = hasOneThrough((review) => review.book.author);
+  // Be sure this infers as Reference<BookReview, Author, never>
+  readonly author = this.orm.hasOneThrough((review) => review.book.author);
 
   // This is kind of silly domain wise, but used as an example of hasOneDerived with a load hint. We don't
   // technically have any conditional logic in `get` so could use a lens, but we want to test hasOneDerived.
-  readonly publisher: Reference<BookReview, Publisher, undefined> = hasOneDerived(
+  readonly publisher: Reference<BookReview, Publisher, undefined> = this.orm.hasOneDerived(
     { book: { author: "publisher" } },
     (review) => review.book.get.author.get.publisher.get,
   );

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -11,18 +11,15 @@ import {
   Flavor,
   getEm,
   GraphQLFilterOf,
-  hasOne,
-  hasOneToOne,
   Lens,
   Loaded,
   LoadHint,
   loadLens,
-  ManyToOneReference,
   newChangesProxy,
   newRequiredRule,
-  OneToOneReference,
   OptsOf,
   OrderBy,
+  OrmApi,
   PartialOrNull,
   setField,
   setOpts,
@@ -102,15 +99,11 @@ export abstract class BookReviewCodegen extends BaseEntity {
     optIdsType: BookReviewIdsOpts;
     factoryOptsType: Parameters<typeof newBookReview>[1];
   } = null!;
+  protected readonly orm = new OrmApi(this as any as BookReview);
 
-  readonly book: ManyToOneReference<BookReview, Book, never> = hasOne(bookMeta, "book", "reviews");
+  readonly book = this.orm.hasOne(bookMeta, "book", "reviews", true);
 
-  readonly comment: OneToOneReference<BookReview, Comment> = hasOneToOne(
-    commentMeta,
-    "comment",
-    "parent",
-    "parent_book_review_id",
-  );
+  readonly comment = this.orm.hasOneToOne(commentMeta, "comment", "parent", "parent_book_review_id");
 
   constructor(em: EntityManager, opts: BookReviewOpts) {
     super(em, bookReviewMeta, {}, opts);

--- a/packages/integration-tests/src/entities/CommentCodegen.ts
+++ b/packages/integration-tests/src/entities/CommentCodegen.ts
@@ -9,7 +9,6 @@ import {
   EntityManager,
   Flavor,
   getEm,
-  hasOnePolymorphic,
   IdOf,
   Lens,
   Loaded,
@@ -19,8 +18,8 @@ import {
   newRequiredRule,
   OptsOf,
   OrderBy,
+  OrmApi,
   PartialOrNull,
-  PolymorphicReference,
   setField,
   setOpts,
   ValueFilter,
@@ -90,8 +89,9 @@ export abstract class CommentCodegen extends BaseEntity {
     optIdsType: CommentIdsOpts;
     factoryOptsType: Parameters<typeof newComment>[1];
   } = null!;
+  protected readonly orm = new OrmApi(this as any as Comment);
 
-  readonly parent: PolymorphicReference<Comment, CommentParent, never> = hasOnePolymorphic("parent");
+  readonly parent = this.orm.hasOnePolymorphic("parent", true);
 
   constructor(em: EntityManager, opts: CommentOpts) {
     super(em, commentMeta, {}, opts);

--- a/packages/integration-tests/src/entities/CriticCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticCodegen.ts
@@ -13,6 +13,7 @@ import {
   newRequiredRule,
   OptsOf,
   OrderBy,
+  OrmApi,
   PartialOrNull,
   setField,
   setOpts,
@@ -66,6 +67,7 @@ export abstract class CriticCodegen extends BaseEntity {
     optIdsType: CriticIdsOpts;
     factoryOptsType: Parameters<typeof newCritic>[1];
   } = null!;
+  protected readonly orm = new OrmApi(this as any as Critic);
 
   constructor(em: EntityManager, opts: CriticOpts) {
     super(em, criticMeta, {}, opts);

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -10,16 +10,15 @@ import {
   Flavor,
   getEm,
   GraphQLFilterOf,
-  hasOne,
   Lens,
   Loaded,
   LoadHint,
   loadLens,
-  ManyToOneReference,
   newChangesProxy,
   newRequiredRule,
   OptsOf,
   OrderBy,
+  OrmApi,
   PartialOrNull,
   setField,
   setOpts,
@@ -113,12 +112,13 @@ export abstract class ImageCodegen extends BaseEntity {
     optIdsType: ImageIdsOpts;
     factoryOptsType: Parameters<typeof newImage>[1];
   } = null!;
+  protected readonly orm = new OrmApi(this as any as Image);
 
-  readonly author: ManyToOneReference<Image, Author, undefined> = hasOne(authorMeta, "author", "image");
+  readonly author = this.orm.hasOne(authorMeta, "author", "image", false);
 
-  readonly book: ManyToOneReference<Image, Book, undefined> = hasOne(bookMeta, "book", "image");
+  readonly book = this.orm.hasOne(bookMeta, "book", "image", false);
 
-  readonly publisher: ManyToOneReference<Image, Publisher, undefined> = hasOne(publisherMeta, "publisher", "images");
+  readonly publisher = this.orm.hasOne(publisherMeta, "publisher", "images", false);
 
   constructor(em: EntityManager, opts: ImageOpts) {
     super(em, imageMeta, {}, opts);

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -1,13 +1,11 @@
 import {
   BaseEntity,
   Changes,
-  Collection,
   ConfigApi,
   EntityManager,
   EnumGraphQLFilter,
   Flavor,
   getEm,
-  hasMany,
   Lens,
   Loaded,
   LoadHint,
@@ -16,6 +14,7 @@ import {
   newRequiredRule,
   OptsOf,
   OrderBy,
+  OrmApi,
   PartialOrNull,
   setField,
   setOpts,
@@ -117,17 +116,13 @@ export abstract class PublisherCodegen extends BaseEntity {
     optIdsType: PublisherIdsOpts;
     factoryOptsType: Parameters<typeof newPublisher>[1];
   } = null!;
+  protected readonly orm = new OrmApi(this as any as Publisher);
 
-  readonly authors: Collection<Publisher, Author> = hasMany(authorMeta, "authors", "publisher", "publisher_id");
+  readonly authors = this.orm.hasMany(authorMeta, "authors", "publisher", "publisher_id");
 
-  readonly bookAdvances: Collection<Publisher, BookAdvance> = hasMany(
-    bookAdvanceMeta,
-    "bookAdvances",
-    "publisher",
-    "publisher_id",
-  );
+  readonly bookAdvances = this.orm.hasMany(bookAdvanceMeta, "bookAdvances", "publisher", "publisher_id");
 
-  readonly images: Collection<Publisher, Image> = hasMany(imageMeta, "images", "publisher", "publisher_id");
+  readonly images = this.orm.hasMany(imageMeta, "images", "publisher", "publisher_id");
 
   constructor(em: EntityManager, opts: PublisherOpts) {
     super(em, publisherMeta, publisherDefaultValues, opts);

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -1,12 +1,10 @@
 import {
   BaseEntity,
   Changes,
-  Collection,
   ConfigApi,
   EntityManager,
   Flavor,
   getEm,
-  hasManyToMany,
   Lens,
   Loaded,
   LoadHint,
@@ -15,6 +13,7 @@ import {
   newRequiredRule,
   OptsOf,
   OrderBy,
+  OrmApi,
   PartialOrNull,
   setField,
   setOpts,
@@ -71,15 +70,9 @@ export abstract class TagCodegen extends BaseEntity {
     optIdsType: TagIdsOpts;
     factoryOptsType: Parameters<typeof newTag>[1];
   } = null!;
+  protected readonly orm = new OrmApi(this as any as Tag);
 
-  readonly books: Collection<Tag, Book> = hasManyToMany(
-    "books_to_tags",
-    "books",
-    "tag_id",
-    bookMeta,
-    "tags",
-    "book_id",
-  );
+  readonly books = this.orm.hasManyToMany("books_to_tags", "books", "tag_id", bookMeta, "tags", "book_id");
 
   constructor(em: EntityManager, opts: TagOpts) {
     super(em, tagMeta, {}, opts);

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -1,38 +1,8 @@
-import {
-  Collection,
-  currentlyInstantiatingEntity,
-  ensureNotDeleted,
-  Entity,
-  EntityMetadata,
-  getEm,
-  getMetadata,
-  IdOf,
-} from "../";
+import { Collection, ensureNotDeleted, Entity, EntityMetadata, getEm, getMetadata, IdOf } from "../";
 import { manyToManyDataLoader } from "../dataloaders/manyToManyDataLoader";
 import { getOrSet, remove } from "../utils";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { RelationT, RelationU } from "./Relation";
-
-/** An alias for creating `ManyToManyCollections`s. */
-export function hasManyToMany<T extends Entity, U extends Entity>(
-  joinTableName: string,
-  fieldName: keyof T,
-  columnName: string,
-  otherMeta: EntityMetadata<U>,
-  otherFieldName: keyof U,
-  otherColumnName: string,
-): Collection<T, U> {
-  const entity = currentlyInstantiatingEntity as T;
-  return new ManyToManyCollection<T, U>(
-    joinTableName,
-    entity,
-    fieldName,
-    columnName,
-    otherMeta,
-    otherFieldName,
-    otherColumnName,
-  );
-}
 
 export class ManyToManyCollection<T extends Entity, U extends Entity>
   extends AbstractRelationImpl<U[]>

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -1,4 +1,4 @@
-import { currentlyInstantiatingEntity, Entity, EntityMetadata, IdOf, isEntity } from "../EntityManager";
+import { Entity, EntityMetadata, IdOf, isEntity } from "../EntityManager";
 import {
   deTagIds,
   ensureNotDeleted,
@@ -13,16 +13,6 @@ import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { OneToManyCollection } from "./OneToManyCollection";
 import { ReferenceN } from "./Reference";
 import { RelationT, RelationU } from "./Relation";
-
-/** An alias for creating `ManyToOneReference`s. */
-export function hasOne<T extends Entity, U extends Entity, N extends never | undefined>(
-  otherMeta: EntityMetadata<U>,
-  fieldName: keyof T,
-  otherFieldName: keyof U,
-): ManyToOneReference<T, U, N> {
-  const entity = currentlyInstantiatingEntity as T;
-  return new ManyToOneReferenceImpl<T, U, N>(entity, otherMeta, fieldName, otherFieldName);
-}
 
 /** Type guard utility for determining if an entity field is a ManyToOneReference. */
 export function isManyToOneReference(maybeReference: any): maybeReference is ManyToOneReference<any, any, any> {

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -1,7 +1,6 @@
 import { oneToManyDataLoader } from "../dataloaders/oneToManyDataLoader";
 import {
   Collection,
-  currentlyInstantiatingEntity,
   ensureNotDeleted,
   Entity,
   EntityMetadata,
@@ -14,17 +13,6 @@ import { remove } from "../utils";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { ManyToOneReferenceImpl } from "./ManyToOneReference";
 import { RelationT, RelationU } from "./Relation";
-
-/** An alias for creating `OneToManyCollection`s. */
-export function hasMany<T extends Entity, U extends Entity>(
-  otherMeta: EntityMetadata<U>,
-  fieldName: keyof T,
-  otherFieldName: keyof U,
-  otherColumnName: string,
-): Collection<T, U> {
-  const entity = currentlyInstantiatingEntity as T;
-  return new OneToManyCollection(entity, otherMeta, fieldName, otherFieldName, otherColumnName);
-}
 
 export class OneToManyCollection<T extends Entity, U extends Entity>
   extends AbstractRelationImpl<U[]>

--- a/packages/orm/src/relations/OneToOneReference.ts
+++ b/packages/orm/src/relations/OneToOneReference.ts
@@ -1,13 +1,4 @@
-import {
-  currentlyInstantiatingEntity,
-  deTagIds,
-  ensureNotDeleted,
-  fail,
-  getEm,
-  IdOf,
-  LoadedReference,
-  setField,
-} from "../";
+import { deTagIds, ensureNotDeleted, fail, getEm, IdOf, LoadedReference, setField } from "../";
 import { oneToOneDataLoader } from "../dataloaders/oneToOneDataLoader";
 import { Entity, EntityMetadata, getMetadata } from "../EntityManager";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
@@ -53,17 +44,6 @@ export function isLoadedOneToOneReference(
   maybeReference: any,
 ): maybeReference is Reference<any, any, any> & LoadedOneToOneReference<any, any> {
   return isOneToOneReference(maybeReference) && maybeReference.isLoaded;
-}
-
-/** An alias for creating `OneToOneReference`s. */
-export function hasOneToOne<T extends Entity, U extends Entity>(
-  otherMeta: EntityMetadata<U>,
-  fieldName: keyof T,
-  otherFieldName: keyof U,
-  otherColumnName: string,
-): OneToOneReference<T, U> {
-  const entity = currentlyInstantiatingEntity as T;
-  return new OneToOneReferenceImpl<T, U>(entity, otherMeta, fieldName, otherFieldName, otherColumnName);
 }
 
 /**

--- a/packages/orm/src/relations/PolymorphicReference.ts
+++ b/packages/orm/src/relations/PolymorphicReference.ts
@@ -1,11 +1,4 @@
-import {
-  currentlyInstantiatingEntity,
-  Entity,
-  getMetadata,
-  IdOf,
-  isEntity,
-  PolymorphicFieldComponent,
-} from "../EntityManager";
+import { Entity, getMetadata, IdOf, isEntity, PolymorphicFieldComponent } from "../EntityManager";
 import {
   deTagId,
   ensureNotDeleted,
@@ -23,13 +16,6 @@ import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { OneToManyCollection } from "./OneToManyCollection";
 import { ReferenceN } from "./Reference";
 import { RelationT, RelationU } from "./Relation";
-
-export function hasOnePolymorphic<T extends Entity, U extends Entity, N extends never | undefined>(
-  fieldName: keyof T,
-): PolymorphicReference<T, U, N> {
-  const entity = currentlyInstantiatingEntity as T;
-  return new PolymorphicReferenceImpl<T, U, N>(entity, fieldName);
-}
 
 /** Type guard utility for determining if an entity field is a PolymorphicReference. */
 export function isPolymorphicReference(maybeReference: any): maybeReference is PolymorphicReference<any, any, any> {

--- a/packages/orm/src/relations/index.ts
+++ b/packages/orm/src/relations/index.ts
@@ -12,21 +12,16 @@ export { hasManyDerived } from "./hasManyDerived";
 export { hasManyThrough } from "./hasManyThrough";
 export { hasOneDerived } from "./hasOneDerived";
 export { hasOneThrough } from "./hasOneThrough";
-export { hasManyToMany, ManyToManyCollection } from "./ManyToManyCollection";
-export { hasOne, isManyToOneReference, ManyToOneReference, ManyToOneReferenceImpl } from "./ManyToOneReference";
-export { hasMany, OneToManyCollection } from "./OneToManyCollection";
+export { ManyToManyCollection } from "./ManyToManyCollection";
+export { isManyToOneReference, ManyToOneReference, ManyToOneReferenceImpl } from "./ManyToOneReference";
+export { OneToManyCollection } from "./OneToManyCollection";
 export {
-  hasOneToOne,
   isLoadedOneToOneReference,
   isOneToOneReference,
   OneToOneReference,
   OneToOneReferenceImpl,
 } from "./OneToOneReference";
-export {
-  hasOnePolymorphic,
-  isPolymorphicReference,
-  PolymorphicReference,
-  PolymorphicReferenceImpl,
-} from "./PolymorphicReference";
+export { OrmApi } from "./ormApi";
+export { isPolymorphicReference, PolymorphicReference, PolymorphicReferenceImpl } from "./PolymorphicReference";
 export { isLoadedReference, isReference, LoadedReference, Reference } from "./Reference";
 export { isRelation, Relation } from "./Relation";

--- a/packages/orm/src/relations/ormApi.ts
+++ b/packages/orm/src/relations/ormApi.ts
@@ -1,0 +1,107 @@
+import { Entity, EntityMetadata, Loaded, LoadHint } from "../EntityManager";
+import { getEm } from "../index";
+import { getLens, Lens, loadLens } from "../loadLens";
+import {
+  Collection,
+  CustomReference,
+  ManyToManyCollection,
+  ManyToOneReference,
+  ManyToOneReferenceImpl,
+  OneToManyCollection,
+  OneToOneReference,
+  OneToOneReferenceImpl,
+  PolymorphicReference,
+  PolymorphicReferenceImpl,
+  Reference,
+} from "./index";
+
+export class OrmApi<T extends Entity> {
+  constructor(private readonly entity: T) {}
+
+  hasMany<U extends Entity>(
+    otherMeta: EntityMetadata<U>,
+    fieldName: keyof T,
+    otherFieldName: keyof U,
+    otherColumnName: string,
+  ): Collection<T, U> {
+    return new OneToManyCollection(this.entity, otherMeta, fieldName, otherFieldName, otherColumnName);
+  }
+
+  hasOne<U extends Entity>(
+    otherMeta: EntityMetadata<U>,
+    fieldName: keyof T,
+    otherFieldName: keyof U,
+    notNull: true,
+  ): ManyToOneReference<T, U, never>;
+  hasOne<U extends Entity>(
+    otherMeta: EntityMetadata<U>,
+    fieldName: keyof T,
+    otherFieldName: keyof U,
+    notNull: false,
+  ): ManyToOneReference<T, U, undefined>;
+  hasOne<U extends Entity, N extends never | undefined>(
+    otherMeta: EntityMetadata<U>,
+    fieldName: keyof T,
+    otherFieldName: keyof U,
+  ): ManyToOneReference<T, U, N> {
+    return new ManyToOneReferenceImpl<T, U, N>(this.entity, otherMeta, fieldName, otherFieldName);
+  }
+
+  hasOneToOne<U extends Entity>(
+    otherMeta: EntityMetadata<U>,
+    fieldName: keyof T,
+    otherFieldName: keyof U,
+    otherColumnName: string,
+  ): OneToOneReference<T, U> {
+    return new OneToOneReferenceImpl<T, U>(this.entity, otherMeta, fieldName, otherFieldName, otherColumnName);
+  }
+
+  hasManyToMany<U extends Entity>(
+    joinTableName: string,
+    fieldName: keyof T,
+    columnName: string,
+    otherMeta: EntityMetadata<U>,
+    otherFieldName: keyof U,
+    otherColumnName: string,
+  ): Collection<T, U> {
+    return new ManyToManyCollection<T, U>(
+      joinTableName,
+      this.entity,
+      fieldName,
+      columnName,
+      otherMeta,
+      otherFieldName,
+      otherColumnName,
+    );
+  }
+
+  hasOnePolymorphic<U extends Entity>(fieldName: keyof T, notNull: true): PolymorphicReference<T, U, never>;
+  hasOnePolymorphic<U extends Entity>(fieldName: keyof T, notNull: false): PolymorphicReference<T, U, undefined>;
+  hasOnePolymorphic<U extends Entity, N extends never | undefined>(fieldName: keyof T): PolymorphicReference<T, U, N> {
+    return new PolymorphicReferenceImpl<T, U, N>(this.entity, fieldName);
+  }
+
+  // Note w/o the conditional `V extends undefined` return type, BookReview.author infers as undefined instead of never
+  hasOneThrough<U extends Entity, N extends undefined | never, V extends U | N>(
+    lens: (lens: Lens<T>) => Lens<V>,
+  ): V extends undefined ? Reference<T, U, undefined> : Reference<T, U, never> {
+    return new CustomReference<T, U, N>(this.entity, {
+      load: async (entity) => {
+        await loadLens(entity, lens);
+      },
+      get: () => getLens(this.entity, lens),
+    }) as any;
+  }
+
+  hasOneDerived<U extends Entity, N extends never | undefined, V extends U | N, H extends LoadHint<T>>(
+    loadHint: H,
+    get: (entity: Loaded<T, H>) => V,
+  ): Reference<T, U, N> {
+    return new CustomReference<T, U, N>(this.entity, {
+      load: async (entity) => {
+        await getEm(entity).populate(entity, loadHint);
+      },
+      get: () => get(this.entity as Loaded<T, H>),
+    });
+  }
+}

--- a/packages/orm/src/reverseHint.ts
+++ b/packages/orm/src/reverseHint.ts
@@ -14,7 +14,8 @@ export function reverseHint<T extends Entity>(
     // For a simple string hint, i.e. Book "author", find the Book.author field,
     // and use the metdata to find the otherFieldName, i.e. Author "books"
     const meta = getMetadata(entityType);
-    const field = meta.fields.find((f) => f.fieldName === hint) || fail(`Invalid hint ${JSON.stringify(hint)}`);
+    const field =
+      meta.fields.find((f) => f.fieldName === hint) || fail(`Invalid hint ${entityType.name} ${JSON.stringify(hint)}`);
     if (field.kind !== "m2m" && field.kind !== "m2o" && field.kind !== "o2m" && field.kind !== "o2o") {
       throw new Error("Invalid hint");
     }
@@ -30,7 +31,8 @@ export function reverseHint<T extends Entity>(
     // key in the hash, and then combine
     return Object.entries(hint).flatMap(([key, hint]) => {
       const meta = getMetadata(entityType);
-      const field = meta.fields.find((f) => f.fieldName === key) || fail(`Invalid hint ${JSON.stringify(hint)}`);
+      const field =
+        meta.fields.find((f) => f.fieldName === key) || fail(`Invalid hint ${entityType.name} ${JSON.stringify(hint)}`);
       if (field.kind !== "m2m" && field.kind !== "m2o" && field.kind !== "o2m" && field.kind !== "o2o") {
         throw new Error("Invalid hint");
       }


### PR DESCRIPTION
Unfortunately I'm trying to change:

```
export class BookReview extends BookReviewCodegen {
  // had been explicitly typed as `: Reference<BookReview, Publisher, undefined>`
  readonly publisher = this.orm.hasOneDerived(
    { book: { author: "publisher" } },
    (review) => review.book.get.author.get.publisher.get,
  );
}
```

To drop the explicit `: Reference<...>` but get a compile error:

```
TS2615: Type of property 'publisher' circularly references itself in mapped type '{ readonly author: "author"; readonly publisher: "publisher"; readonly __types: never; readonly book: "book"; readonly comment: "comment"; readonly id: never; rating: never; readonly isPublic: never; ... 18 more ...; [Symbol.toStringTag]: never; }'.
```

Which I think unfortunately but intuitively makes sense ... the return type of `hasOneDerived` will fundamentally effect the type signature of `BookReview`, but `hasOneDerived` itself wants to accept a `LoadHint<BookReview>` that itself needs to know "what does `BookReview` look like?".

I was able to convert over `hasOne` / `hasMany` / etc., and it was only `hasOneDerived` that I hit this constraint ... not sure if that means we should just drop the whole approach or not.
