### PR TITLE
fix: Fix not loading o2os in createOrUpdatePartial.

### DIFF
--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -711,7 +711,10 @@ export type ParsedValueFilter<V> =
   | { kind: "between"; value: [V, V] };
 
 /**
- * Parses the many/hodgepdoge (ergonomic!) patterns of value filters into a `ParsedValueFilter`.
+ * Parses the many/hodgepdoge (ergonomic!) patterns of value filters into a `ParsedValueFilter[]`.
+ *
+ * Note we return an array because filter might be a `ValueGraphQLFilter` that is allowed to have
+ * multiple conditions, i.e. `{ lt: 10, gt: 5 }`.
  */
 export function parseValueFilter<V>(filter: ValueFilter<V, any>): ParsedValueFilter<V>[] {
   if (filter === null) {

--- a/packages/orm/src/createOrUpdatePartial.ts
+++ b/packages/orm/src/createOrUpdatePartial.ts
@@ -2,7 +2,7 @@ import { Entity, isEntity } from "./Entity";
 import { EntityManager, IdOf, MaybeAbstractEntityConstructor, OptIdsOf, OptsOf, isKey } from "./EntityManager";
 import { getMetadata } from "./EntityMetadata";
 import { PartialOrNull, asConcreteCstr, getConstructorFromTaggedId, getProperties } from "./index";
-import { NullOrDefinedOr } from "./utils";
+import { NullOrDefinedOr, toArray } from "./utils";
 
 /**
  * The type for `EntityManager.createOrUpdateUnsafe` that allows "upsert"-ish behavior.
@@ -48,7 +48,7 @@ export async function createOrUpdatePartial<T extends Entity>(
   const { id, ...others } = opts as any;
   const meta = getMetadata(constructor);
   const isNew = id === null || id === undefined;
-  const collectionsToLoad: string[] = [];
+  const relationsToLoad: string[] = [];
 
   // The values in others might be themselves partials, so walk through and resolve them to entities.
   const p = Object.entries(others).map(async ([key, value]) => {
@@ -109,7 +109,7 @@ export async function createOrUpdatePartial<T extends Entity>(
         const entity = await createOrUpdatePartial(em, field.otherMetadata().cstr, value as any);
         return [name, entity];
       }
-    } else if (field.kind === "o2m" || field.kind === "m2m") {
+    } else if (field.kind === "o2m" || field.kind === "m2m" || field.kind === "o2o") {
       // Look for one-to-many/many-to-many partials
 
       // `null` is handled later, and treated as `[]`, which needs the collection loaded
@@ -122,37 +122,41 @@ export async function createOrUpdatePartial<T extends Entity>(
       const allowDelete = !field.otherMetadata().fields["delete"];
       const allowRemove = !field.otherMetadata().fields["remove"];
       const allowOp = !field.otherMetadata().fields["op"];
-      collectionsToLoad.push(field.fieldName);
+      relationsToLoad.push(field.fieldName);
 
-      const entities = !value
-        ? []
-        : (value as Array<any>).map(async (value) => {
-            if (!value || isEntity(value)) {
+      const entities = await Promise.all(
+        toArray(value).map(async (value: any) => {
+          if (!value || isEntity(value)) {
+            return value;
+          } else if (isKey(value)) {
+            return await em.load(field.otherMetadata().cstr, value);
+          } else {
+            // Look for `delete: true/false` and `remove: true/false` markers
+            const deleteMarker: any = allowDelete && value["delete"];
+            const removeMarker: any = allowRemove && value["remove"];
+            const opMarker: any = allowOp && value["op"];
+            // If this is the incremental marker, just leave it in as-is so that setOpts can see it
+            if (opMarker === "incremental") {
               return value;
-            } else if (isKey(value)) {
-              return await em.load(field.otherMetadata().cstr, value);
-            } else {
-              // Look for `delete: true/false` and `remove: true/false` markers
-              const deleteMarker: any = allowDelete && value["delete"];
-              const removeMarker: any = allowRemove && value["remove"];
-              const opMarker: any = allowOp && value["op"];
-              // If this is the incremental marker, just leave it in as-is so that setOpts can see it
-              if (opMarker === "incremental") {
-                return value;
-              }
-              // Remove the markers, regardless of true/false, before recursing into createOrUpdatePartial to avoid unknown fields
-              if (deleteMarker !== undefined) delete value.delete;
-              if (removeMarker !== undefined) delete value.remove;
-              if (opMarker !== undefined) delete value.op;
-              const entity = await createOrUpdatePartial(em, field.otherMetadata().cstr, value as any);
-              // Put the markers back for setOpts to find
-              if (deleteMarker === true) entity.delete = true;
-              if (removeMarker === true) entity.remove = true;
-              if (opMarker) entity.op = opMarker;
-              return entity;
             }
-          });
-      return [name, await Promise.all(entities)];
+            // Remove the markers, regardless of true/false, before recursing into createOrUpdatePartial to avoid unknown fields
+            if (deleteMarker !== undefined) delete value.delete;
+            if (removeMarker !== undefined) delete value.remove;
+            if (opMarker !== undefined) delete value.op;
+            const entity = await createOrUpdatePartial(em, field.otherMetadata().cstr, value as any);
+            // Put the markers back for setOpts to find
+            if (deleteMarker === true) entity.delete = true;
+            if (removeMarker === true) entity.remove = true;
+            if (opMarker) entity.op = opMarker;
+            return entity;
+          }
+        }),
+      );
+      return [
+        name,
+        // Unwrap & keep null for o2o fields
+        field.kind === "o2o" ? (value === null ? null : entities[0]) : entities,
+      ];
     } else {
       return [name, value];
     }
@@ -169,7 +173,7 @@ export async function createOrUpdatePartial<T extends Entity>(
     // for a parent's mutation to control the lifecycle of a child entity (i.e. line items).
     // Musing: Maybe this should happen implicitly, like if a LineItem.parent is set to null, that
     // LineItem knows to just `em.delete` itself? Instead of relying on hints from GraphQL mutations.
-    await Promise.all(collectionsToLoad.map((fieldName) => (entity as any)[fieldName].load()));
+    await Promise.all(relationsToLoad.map((fieldName) => (entity as any)[fieldName].load()));
     entity.setPartial(_opts);
     return entity;
   }

--- a/packages/orm/src/utils.ts
+++ b/packages/orm/src/utils.ts
@@ -118,8 +118,8 @@ export function partition<T>(array: ReadonlyArray<T>, f: (el: T) => boolean): [T
 }
 
 // Utility function to wrap an object or value in an array, unless it's already an array
-export function toArray<T>(maybeArray: T | T[] | undefined): T[] {
-  return Array.isArray(maybeArray) ? maybeArray : maybeArray === undefined ? [] : [maybeArray];
+export function toArray<T>(maybeArray: T | T[] | undefined | null): T[] {
+  return Array.isArray(maybeArray) ? maybeArray : maybeArray === undefined || maybeArray === null ? [] : [maybeArray];
 }
 
 // Utility type to strip off null and defined and infer only T.

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -83,5 +83,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.148.1"
+  "version": "1.149.0"
 }

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -83,5 +83,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.149.0"
+  "version": "1.149.1"
 }

--- a/packages/tests/integration/src/EntityManager.createOrUpdatePartial.test.ts
+++ b/packages/tests/integration/src/EntityManager.createOrUpdatePartial.test.ts
@@ -7,10 +7,11 @@ import {
   insertBook,
   insertBookReview,
   insertBookToTag,
+  insertImage,
   insertTag,
   select,
 } from "@src/entities/inserts";
-import { Author, Book } from "./entities";
+import { Author, Book, ImageType } from "./entities";
 
 import { newEntityManager } from "@src/testEm";
 
@@ -41,282 +42,334 @@ describe("EntityManager.createOrUpdatePartial", () => {
     await expect(em.flush()).rejects.toThrow("firstName is required");
   });
 
-  it("can create new children with valid data", async () => {
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, {
-      firstName: "a1",
-      mentor: { firstName: "m1" },
-      books: [{ title: "b1" }],
+  describe("m2o", () => {
+    it("can create new reference with valid data", async () => {
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, {
+        firstName: "a1",
+        mentor: { firstName: "m1" },
+        // technically testing o2m while we're at it
+        books: [{ title: "b1" }],
+      });
+      expect(a1.firstName).toEqual("a1");
+      expect((await a1.mentor.load())!.firstName).toEqual("m1");
+      expect((await a1.books.load())![0].title).toEqual("b1");
     });
-    expect(a1.firstName).toEqual("a1");
-    expect((await a1.mentor.load())!.firstName).toEqual("m1");
-    expect((await a1.books.load())![0].title).toEqual("b1");
-  });
 
-  it("can update existing references with valid data", async () => {
-    await insertAuthor({ first_name: "m1" });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, {
-      firstName: "a1",
-      mentor: { id: "1", firstName: "m2" },
+    it("can update existing references with valid data", async () => {
+      await insertAuthor({ first_name: "m1" });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, {
+        firstName: "a1",
+        mentor: { id: "1", firstName: "m2" },
+      });
+      expect(a1.firstName).toEqual("a1");
+      expect((await a1.mentor.load())!.firstName).toEqual("m2");
+      await em.flush();
+      expect(await countOfAuthors()).toEqual(2);
     });
-    expect(a1.firstName).toEqual("a1");
-    expect((await a1.mentor.load())!.firstName).toEqual("m2");
-    await em.flush();
-    expect(await countOfAuthors()).toEqual(2);
-  });
 
-  it("can update existing references without an id", async () => {
-    await insertAuthor({ first_name: "m1" });
-    await insertAuthor({ first_name: "a1", mentor_id: 1 });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, {
-      id: "a:2",
-      firstName: "a2",
-      mentor: { firstName: "m2" },
+    it("can update existing references without an id", async () => {
+      await insertAuthor({ first_name: "m1" });
+      await insertAuthor({ first_name: "a1", mentor_id: 1 });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, {
+        id: "a:2",
+        firstName: "a2",
+        mentor: { firstName: "m2" },
+      });
+      expect(a1.firstName).toEqual("a2");
+      expect((await a1.mentor.load())!.firstName).toEqual("m2");
+      await em.flush();
+      expect(await countOfAuthors()).toEqual(2);
     });
-    expect(a1.firstName).toEqual("a2");
-    expect((await a1.mentor.load())!.firstName).toEqual("m2");
-    await em.flush();
-    expect(await countOfAuthors()).toEqual(2);
-  });
 
-  it("can update existing references without an id that is not set", async () => {
-    await insertAuthor({ first_name: "a1" });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, {
-      id: "a:1",
-      firstName: "a2",
-      mentor: { firstName: "m2" },
+    it("can update existing references without an id that is not set", async () => {
+      await insertAuthor({ first_name: "a1" });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, {
+        id: "a:1",
+        firstName: "a2",
+        mentor: { firstName: "m2" },
+      });
+      expect(a1.firstName).toEqual("a2");
+      expect((await a1.mentor.load())!.firstName).toEqual("m2");
+      await em.flush();
+      expect(await countOfAuthors()).toEqual(2);
     });
-    expect(a1.firstName).toEqual("a2");
-    expect((await a1.mentor.load())!.firstName).toEqual("m2");
-    await em.flush();
-    expect(await countOfAuthors()).toEqual(2);
-  });
 
-  it("references can refer to entities by id", async () => {
-    await insertAuthor({ first_name: "m1" });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: "1" });
-    expect((await a1.mentor.load())!.firstName).toEqual("m1");
-  });
-
-  it("references can refer to entities by id opt", async () => {
-    await insertAuthor({ first_name: "m1" });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentorId: "1" });
-    expect((await a1.mentor.load())!.firstName).toEqual("m1");
-  });
-
-  it("references can refer to null", async () => {
-    await insertAuthor({ first_name: "m1" });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: null });
-    expect(a1.mentor.isSet).toBe(false);
-  });
-
-  it("references can refer to undefined", async () => {
-    await insertAuthor({ first_name: "m1" });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: undefined });
-    expect(a1.mentor.isSet).toBe(false);
-  });
-
-  it("references can refer to entity", async () => {
-    await insertAuthor({ first_name: "m1" });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: await em.load(Author, "1") });
-    expect(a1.mentor.id).toEqual("a:1");
-  });
-
-  it("collections can refer to entities by id", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", books: ["1"] });
-    expect((await a1.books.load())[0].title).toEqual("b1");
-  });
-
-  it("collections can refer to entities by id opts", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", bookIds: ["1"] });
-    expect((await a1.books.load())[0].title).toEqual("b1");
-  });
-
-  it("collections can refer to null", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", books: null });
-    expect(await a1.books.load()).toEqual([]);
-  });
-
-  it("collections can refer to undefined", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", books: undefined });
-    expect(await a1.books.load()).toHaveLength(1);
-  });
-
-  it("collections are not upserted", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, {
-      id: "a:1",
-      // b2 will be added as a new book, and b1 will be orphaned from the author
-      books: [{ id: "b:1", delete: true }, { title: "b2" }],
+    it("references can refer to entities by id", async () => {
+      await insertAuthor({ first_name: "m1" });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: "1" });
+      expect((await a1.mentor.load())!.firstName).toEqual("m1");
     });
-    await em.flush();
-    const books = await a1.books.load();
-    expect(books.length).toEqual(1);
-    const [b2] = books;
-    expect(b2.title).toEqual("b2");
-  });
 
-  it("collections can delete children with delete flag", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertBook({ title: "b2", author_id: 1 });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, {
-      id: "a:1",
-      books: [{ id: "b:1", delete: true }, { id: "b:2" }],
+    it("references can refer to entities by id opt", async () => {
+      await insertAuthor({ first_name: "m1" });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentorId: "1" });
+      expect((await a1.mentor.load())!.firstName).toEqual("m1");
     });
-    const loaded = await em.populate(a1, "books");
-    // get shows only b1
-    expect(loaded.books.get.length).toBe(1);
-    // getWithDeleted still shows both b1 and b2
-    expect(loaded.books.getWithDeleted.length).toBe(2);
-    await em.flush();
-    const rows = await select("books");
-    expect(rows.length).toEqual(1);
-  });
 
-  it("collections can delete children w/o delete flag if they are owned", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertBookReview({ book_id: 1, rating: 5 });
-    await insertBookReview({ book_id: 1, rating: 5 });
-    const em = newEntityManager();
-    const b1 = await em.createOrUpdatePartial(Book, {
-      id: "b:1",
-      reviews: [{ id: "br:2" }],
+    it("references can refer to null", async () => {
+      await insertAuthor({ first_name: "m1" });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: null });
+      expect(a1.mentor.isSet).toBe(false);
     });
-    const loaded = await em.populate(b1, "reviews");
-    // get shows only br1
-    expect(loaded.reviews.get.length).toBe(1);
-    // getWithDeleted still shows both b1 and b2
-    expect(loaded.reviews.getWithDeleted.length).toBe(2);
-    await em.flush();
-    const rows = await select("book_reviews");
-    expect(rows.length).toEqual(1);
-  });
 
-  it("collections wont delete children when delete is false", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertBook({ title: "b2", author_id: 1 });
-    const em = newEntityManager();
-    await em.createOrUpdatePartial(Author, {
-      id: "a:1",
-      books: [{ id: "b:1", title: "b1changed", delete: false }, { id: "b:2" }],
+    it("references can refer to undefined", async () => {
+      await insertAuthor({ first_name: "m1" });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: undefined });
+      expect(a1.mentor.isSet).toBe(false);
     });
-    await em.flush();
-    expect(await countOfBooks()).toEqual(2);
-    const b1 = await em.load(Book, "b:1");
-    expect(b1.title).toEqual("b1changed");
+
+    it("references can refer to entity", async () => {
+      await insertAuthor({ first_name: "m1" });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: await em.load(Author, "1") });
+      expect(a1.mentor.id).toEqual("a:1");
+    });
   });
 
-  it("collections can remove children", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertTag({ name: "t1" });
-    await insertTag({ name: "t2" });
-    await insertBookToTag({ tag_id: 1, book_id: 1 });
-    await insertBookToTag({ tag_id: 2, book_id: 1 });
-    const em = newEntityManager();
-    await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ id: "t:2", remove: true }] });
-    await em.flush();
-    expect(await countOfTags()).toEqual(2);
-    expect(await countOfBookToTags()).toEqual(0);
+  describe("o2o", () => {
+    it("can create new child when creating new parent", async () => {
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, {
+        firstName: "a1",
+        image: { type: ImageType.AuthorImage },
+      });
+      expect(a1.firstName).toEqual("a1");
+      expect((await a1.image.load())!.type).toEqual(ImageType.AuthorImage);
+    });
+
+    it("can find existing child when creating new parent", async () => {
+      await insertImage({ type_id: 2, file_name: "author.png" });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, {
+        firstName: "a1",
+        image: { id: "i:1" },
+      });
+      expect(a1.firstName).toEqual("a1");
+      expect((await a1.image.load())!.type).toEqual(ImageType.AuthorImage);
+    });
+
+    it("can be updated", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertImage({ id: 1, type_id: 2, file_name: "author.png", author_id: 1 });
+      await insertImage({ id: 2, type_id: 2, file_name: "author.png" });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, {
+        id: "a:1",
+        image: { id: "i:2" },
+      });
+      expect((await a1.image.load())!.id).toBe("i:2");
+    });
+
+    it("can be unset", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertImage({ id: 1, type_id: 2, file_name: "author.png", author_id: 1 });
+      await insertImage({ id: 2, type_id: 2, file_name: "author.png" });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, {
+        id: "a:1",
+        image: null,
+      });
+      expect((await a1.image.load())).toBeUndefined();
+    });
   });
 
-  it("collections can incrementally remove children", async () => {
-    // Given a book with two tags
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertTag({ name: "t1" });
-    await insertTag({ name: "t2" });
-    await insertBookToTag({ tag_id: 1, book_id: 1 });
-    await insertBookToTag({ tag_id: 2, book_id: 1 });
-    const em = newEntityManager();
-    // When we incrementally remove a single tag
-    const b = await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ id: "t:2", op: "remove" }] });
-    await em.flush();
-    // Then we removed only that one m2m row
-    expect((await b.tags.load()).map((t) => t.id)).toEqual(["t:1"]);
-    // And we still have both tags
-    expect(await countOfTags()).toEqual(2);
-  });
+  describe("o2m", () => {
+    it("collections can refer to entities by id", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", books: ["1"] });
+      expect((await a1.books.load())[0].title).toEqual("b1");
+    });
 
-  it("collections can incrementally delete children", async () => {
-    // Given a book with two tag
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertTag({ name: "t1" });
-    await insertTag({ name: "t2" });
-    await insertBookToTag({ tag_id: 1, book_id: 1 });
-    await insertBookToTag({ tag_id: 2, book_id: 1 });
-    const em = newEntityManager();
-    // When we incrementally delete a single tag
-    const b = await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ id: "t:2", op: "delete" }] });
-    await em.flush();
-    // Then we removed only that one m2m row
-    expect((await b.tags.load()).map((t) => t.id)).toEqual(["t:1"]);
-    // And we also deleted its entity
-    expect(await countOfBookToTags()).toEqual(1);
-  });
+    it("collections can refer to entities by id opts", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", bookIds: ["1"] });
+      expect((await a1.books.load())[0].title).toEqual("b1");
+    });
 
-  it("collections can incrementally add children", async () => {
-    // Given a book with one tag
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertTag({ name: "t1" });
-    await insertTag({ name: "t2" });
-    await insertBookToTag({ tag_id: 1, book_id: 1 });
-    const em = newEntityManager();
-    // When we incrementally add a single tag
-    await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ id: "t:2", op: "include" }] });
-    await em.flush();
-    // Then we have both m2m rows
-    expect(await countOfBookToTags()).toEqual(2);
-  });
+    it("collections can refer to null", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", books: null });
+      expect(await a1.books.load()).toEqual([]);
+    });
 
-  it("collections can incrementally not clear collections by seeing a marker", async () => {
-    // Given a book with one tag
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertTag({ name: "t1" });
-    await insertBookToTag({ tag_id: 1, book_id: 1 });
-    const em = newEntityManager();
-    // When we incrementally "set" tags to empty
-    await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ op: "incremental" }] });
-    await em.flush();
-    // Then we have the m2m row
-    expect(await countOfBookToTags()).toEqual(1);
-  });
+    it("collections can refer to undefined", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", books: undefined });
+      expect(await a1.books.load()).toHaveLength(1);
+    });
 
-  it("collections can refer to entities", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertBook({ title: "b1", author_id: 1 });
-    const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { firstName: "a2", books: [await em.load(Book, "1")] });
-    expect((await a1.books.load())[0].title).toEqual("b1");
+    it("collections are not upserted", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, {
+        id: "a:1",
+        // b2 will be added as a new book, and b1 will be orphaned from the author
+        books: [{ id: "b:1", delete: true }, { title: "b2" }],
+      });
+      await em.flush();
+      const books = await a1.books.load();
+      expect(books.length).toEqual(1);
+      const [b2] = books;
+      expect(b2.title).toEqual("b2");
+    });
+
+    it("collections can delete children with delete flag", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBook({ title: "b2", author_id: 1 });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, {
+        id: "a:1",
+        books: [{ id: "b:1", delete: true }, { id: "b:2" }],
+      });
+      const loaded = await em.populate(a1, "books");
+      // get shows only b1
+      expect(loaded.books.get.length).toBe(1);
+      // getWithDeleted still shows both b1 and b2
+      expect(loaded.books.getWithDeleted.length).toBe(2);
+      await em.flush();
+      const rows = await select("books");
+      expect(rows.length).toEqual(1);
+    });
+
+    it("collections can delete children w/o delete flag if they are owned", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBookReview({ book_id: 1, rating: 5 });
+      await insertBookReview({ book_id: 1, rating: 5 });
+      const em = newEntityManager();
+      const b1 = await em.createOrUpdatePartial(Book, {
+        id: "b:1",
+        reviews: [{ id: "br:2" }],
+      });
+      const loaded = await em.populate(b1, "reviews");
+      // get shows only br1
+      expect(loaded.reviews.get.length).toBe(1);
+      // getWithDeleted still shows both b1 and b2
+      expect(loaded.reviews.getWithDeleted.length).toBe(2);
+      await em.flush();
+      const rows = await select("book_reviews");
+      expect(rows.length).toEqual(1);
+    });
+
+    it("collections wont delete children when delete is false", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBook({ title: "b2", author_id: 1 });
+      const em = newEntityManager();
+      await em.createOrUpdatePartial(Author, {
+        id: "a:1",
+        books: [{ id: "b:1", title: "b1changed", delete: false }, { id: "b:2" }],
+      });
+      await em.flush();
+      expect(await countOfBooks()).toEqual(2);
+      const b1 = await em.load(Book, "b:1");
+      expect(b1.title).toEqual("b1changed");
+    });
+
+    it("collections can remove children", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertTag({ name: "t1" });
+      await insertTag({ name: "t2" });
+      await insertBookToTag({ tag_id: 1, book_id: 1 });
+      await insertBookToTag({ tag_id: 2, book_id: 1 });
+      const em = newEntityManager();
+      await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ id: "t:2", remove: true }] });
+      await em.flush();
+      expect(await countOfTags()).toEqual(2);
+      expect(await countOfBookToTags()).toEqual(0);
+    });
+
+    it("collections can incrementally remove children", async () => {
+      // Given a book with two tags
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertTag({ name: "t1" });
+      await insertTag({ name: "t2" });
+      await insertBookToTag({ tag_id: 1, book_id: 1 });
+      await insertBookToTag({ tag_id: 2, book_id: 1 });
+      const em = newEntityManager();
+      // When we incrementally remove a single tag
+      const b = await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ id: "t:2", op: "remove" }] });
+      await em.flush();
+      // Then we removed only that one m2m row
+      expect((await b.tags.load()).map((t) => t.id)).toEqual(["t:1"]);
+      // And we still have both tags
+      expect(await countOfTags()).toEqual(2);
+    });
+
+    it("collections can incrementally delete children", async () => {
+      // Given a book with two tag
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertTag({ name: "t1" });
+      await insertTag({ name: "t2" });
+      await insertBookToTag({ tag_id: 1, book_id: 1 });
+      await insertBookToTag({ tag_id: 2, book_id: 1 });
+      const em = newEntityManager();
+      // When we incrementally delete a single tag
+      const b = await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ id: "t:2", op: "delete" }] });
+      await em.flush();
+      // Then we removed only that one m2m row
+      expect((await b.tags.load()).map((t) => t.id)).toEqual(["t:1"]);
+      // And we also deleted its entity
+      expect(await countOfBookToTags()).toEqual(1);
+    });
+
+    it("collections can incrementally add children", async () => {
+      // Given a book with one tag
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertTag({ name: "t1" });
+      await insertTag({ name: "t2" });
+      await insertBookToTag({ tag_id: 1, book_id: 1 });
+      const em = newEntityManager();
+      // When we incrementally add a single tag
+      await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ id: "t:2", op: "include" }] });
+      await em.flush();
+      // Then we have both m2m rows
+      expect(await countOfBookToTags()).toEqual(2);
+    });
+
+    it("collections can incrementally not clear collections by seeing a marker", async () => {
+      // Given a book with one tag
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertTag({ name: "t1" });
+      await insertBookToTag({ tag_id: 1, book_id: 1 });
+      const em = newEntityManager();
+      // When we incrementally "set" tags to empty
+      await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ op: "incremental" }] });
+      await em.flush();
+      // Then we have the m2m row
+      expect(await countOfBookToTags()).toEqual(1);
+    });
+
+    it("collections can refer to entities", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      const em = newEntityManager();
+      const a1 = await em.createOrUpdatePartial(Author, { firstName: "a2", books: [await em.load(Book, "1")] });
+      expect((await a1.books.load())[0].title).toEqual("b1");
+    });
   });
 
   it("createOrUpdatePartial doesnt allow unknown fields to be passed", async () => {

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.148.1"
+  "version": "1.149.0"
 }

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.149.0"
+  "version": "1.149.1"
 }

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.149.0"
+  "version": "1.149.1"
 }

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.148.1"
+  "version": "1.149.0"
 }

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.148.1"
+  "version": "1.149.0"
 }

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.149.0"
+  "version": "1.149.1"
 }

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.149.0"
+  "version": "1.149.1"
 }

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.148.1"
+  "version": "1.149.0"
 }


### PR DESCRIPTION
Calling `setOpts(...)` with a o2o requires the o2o to be loaded, much like setting o2m collections.

However we weren't checking for o2os in the `createOrUpdatePartial` code that partitions out opts from "primitives / relations".
