### PR TITLE
feat: Unify database/config default handling.

### DIFF
--- a/.idea/joist-ts.iml
+++ b/.idea/joist-ts.iml
@@ -20,6 +20,7 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/tests/integration/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages/tests/integration/.clinic" />
       <excludeFolder url="file://$MODULE_DIR$/packages/tests/uuid-ids/build" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/tests/schema-misc/build" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -35,12 +35,12 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
   }
   readonly #orm!: EntityOrmField;
 
-  protected constructor(em: EM, metadata: any, defaultValues: object, optsOrId: any) {
+  protected constructor(em: EM, metadata: any, optsOrId: any) {
     // Only do em.register for em.create-d entities, otherwise defer to hydrate to em.register
     if (typeof optsOrId === "string") {
-      this.#orm = new EntityOrmField(em, metadata, undefined);
+      this.#orm = new EntityOrmField(em, metadata, false);
     } else {
-      this.#orm = new EntityOrmField(em, metadata, defaultValues);
+      this.#orm = new EntityOrmField(em, metadata, true);
       em.register(this);
     }
     currentlyInstantiatingEntity = this;

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -63,17 +63,16 @@ export class EntityOrmField {
   wasNew: boolean = false;
 
   /** Creates the `#orm` field; defaultValues is only provided when instantiating new entities. */
-  constructor(em: EntityManager, metadata: EntityMetadata, defaultValues: Record<any, any> | undefined) {
+  constructor(em: EntityManager, metadata: EntityMetadata, isNew: boolean) {
     this.em = em;
     this.metadata = metadata;
-    if (defaultValues) {
-      // Our default values are driven from the database `DEFAULT`s, so we can use it for the row
-      this.data = { ...defaultValues };
-      this.row = { ...defaultValues };
+    if (isNew) {
+      this.isNew = true;
+      this.data = {};
+      this.row = {};
     } else {
       this.isNew = false;
       this.data = {};
-      // em.hydrate will populate this.row
     }
   }
 

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -72,7 +72,6 @@ import { MaybePromise, assertNever, fail, getOrSet, partition, toArray } from ".
 export interface EntityConstructor<T> {
   new (em: EntityManager<any, any>, opts: any): T;
 
-  defaultValues: object;
   // Use any for now to pass the `.includes` test in `EntityConstructor.test.ts`. We could
   // probably do some sort of `tagOf(T)` look up, similar to filter types, which would return
   // either the string literal for a real `T`, or `any` if using `EntityConstructor<any>`.

--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -165,17 +165,19 @@ export class ConfigApi<T extends Entity, C> {
       ctx: C,
     ) => FieldsOf<T>[K] extends EntityField ? MaybePromise<FieldsOf<T>[K]["type"] | undefined> : never,
   ): void;
-  setDefault<K extends keyof SettableFields<FieldsOf<T>> & string>(fieldName: K, hintOrFn: any, fn?: any): void {
+  setDefault<K extends keyof SettableFields<FieldsOf<T>> & string>(fieldName: K, hintOrFnOrValue: any, fn?: any): void {
     this.ensurePreBoot();
     if (fn) {
+      // If we're called once by the codegen, and again by the user, override the syncDefault
+      delete this.__data.syncDefaults[fieldName];
       this.__data.asyncDefaults[fieldName] = async (entity: T, ctx: C) => {
         // Ideally we'd convert this once outside `fn`, but we don't have `metadata` yet
-        const loadHint = convertToLoadHint(getMetadata(entity), hintOrFn);
+        const loadHint = convertToLoadHint(getMetadata(entity), hintOrFnOrValue);
         const loaded = await entity.em.populate(entity, loadHint);
         return fn(loaded, ctx);
       };
     } else {
-      this.__data.syncDefaults[fieldName] = hintOrFn;
+      this.__data.syncDefaults[fieldName] = hintOrFnOrValue;
     }
   }
 

--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -149,6 +149,11 @@ export class ConfigApi<T extends Entity, C> {
   /** Adds a synchronous default for `fieldName`. */
   setDefault<K extends keyof SettableFields<FieldsOf<T>> & string>(
     fieldName: K,
+    value: FieldsOf<T>[K] extends EntityField ? FieldsOf<T>[K]["type"] | FieldsOf<T>[K]["nullable"] : never,
+  ): void;
+  /** Adds a synchronous default for `fieldName`. */
+  setDefault<K extends keyof SettableFields<FieldsOf<T>> & string>(
+    fieldName: K,
     fn: (entity: T) => FieldsOf<T>[K] extends EntityField ? FieldsOf<T>[K]["type"] | FieldsOf<T>[K]["nullable"] : never,
   ): void;
   /** Adds an asynchronous default for `fieldName`. */
@@ -252,7 +257,7 @@ export class ConfigData<T extends Entity, C> {
     afterCommit: [],
   };
   /** Synchronous defaults for this entity type, invoked on `em.create`. */
-  syncDefaults: Record<string, (entity: T) => void> = {};
+  syncDefaults: Record<string, ((entity: T) => void) | unknown> = {};
   /** Asynchronous defaults for this entity type, invoked on `em.flush`. */
   asyncDefaults: Record<string, (entity: T, ctx: C) => MaybePromise<T>> = {};
 

--- a/packages/orm/src/defaults.ts
+++ b/packages/orm/src/defaults.ts
@@ -12,9 +12,9 @@ export function hasDefaultValue(meta: EntityMetadata, fieldName: string): boolea
 /** Run the sync defaults for `entity`. */
 export function setSyncDefaults(entity: Entity): void {
   getBaseAndSelfMetas(getMetadata(entity)).forEach((m) => {
-    for (const [field, fn] of Object.entries(m.config.__data.syncDefaults)) {
+    for (const [field, maybeFn] of Object.entries(m.config.__data.syncDefaults)) {
       if ((entity as any)[field] === undefined) {
-        (entity as any)[field] = fn(entity);
+        (entity as any)[field] = maybeFn instanceof Function ? maybeFn(entity) : maybeFn;
       }
     }
   });

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -129,8 +129,7 @@ export function newTestInstance<T extends Entity>(
         !field.derived &&
         !field.protected
       ) {
-        const codegenDefault = getCodegenDefault(cstr, field.fieldName);
-        return [fieldName, codegenDefault ?? defaultValueForField(em, cstr, field)];
+        return [fieldName, defaultValueForField(em, cstr, field)];
       } else if (field.kind === "m2o" && !field.derived) {
         // If neither the user nor the factory (i.e. for an explicit "fan out" case) set this field,
         // then look in `use` and for an "obvious" there-is-only-one default (even for optional fields)
@@ -156,8 +155,7 @@ export function newTestInstance<T extends Entity>(
           }
         }
       } else if (field.kind === "enum" && required) {
-        const codegenDefault = getCodegenDefault(cstr, field.fieldName);
-        return [fieldName, codegenDefault ?? field.enumDetailType.getValues()[0]];
+        return [fieldName, field.enumDetailType.getValues()[0]];
       } else if (field.kind === "poly" && required) {
         return [fieldName, resolveFactoryOpt(em, opts, field, undefined, undefined)];
       }
@@ -697,18 +695,6 @@ function mergeOpts(meta: EntityMetadata, testOpts: Record<string, any>, factoryO
     }
   });
   return opts;
-}
-
-function getCodegenDefault(cstr: any, fieldName: string): any {
-  const m = getMetadata(cstr);
-  if (!m.baseType) {
-    return (m.cstr as any).defaultValues[fieldName];
-  } else {
-    // Look for defaults for fields in base types
-    return getBaseAndSelfMetas(m)
-      .map((m) => (m.cstr as any).defaultValues[fieldName])
-      .filter((v) => v !== undefined)[0];
-  }
 }
 
 // As we branch out to children, going down the tree, give each branch its own playground of entities

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -79,5 +79,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.149.3"
+  "version": "1.149.4"
 }

--- a/packages/tests/integration/src/EntityManager.defaults.test.ts
+++ b/packages/tests/integration/src/EntityManager.defaults.test.ts
@@ -31,16 +31,17 @@ describe("EntityManager.defaults", () => {
   it("can default an asynchronous field", async () => {
     const em = newEntityManager();
     // Given we create two books with their own author
-    const b1 = newBook(em, { author: {}, order: undefined });
-    const b2 = newBook(em, { author: {}, order: undefined });
-    // And we kept the factory from applying the default
+    const a = newAuthor(em);
+    const b1 = newBook(em, { author: a, order: undefined });
+    const b2 = newBook(em, { author: a, order: undefined });
+    // And the factory/sync default didn't get applied
     expect(b1.order).toBeUndefined();
     expect(b2.order).toBeUndefined();
     // When we flush
     await em.flush();
     // Then the async default kicked in
-    expect(b1.order).toBe(1);
-    expect(b2.order).toBe(1);
+    expect(b1.order).toBe(2);
+    expect(b2.order).toBe(2);
   });
 
   it("can default an asynchronous m2o field", async () => {

--- a/packages/tests/integration/src/entities/Book.test.ts
+++ b/packages/tests/integration/src/entities/Book.test.ts
@@ -15,7 +15,7 @@ describe("Book", () => {
     const em = newEntityManager();
     const a1 = em.create(Author, { firstName: "a1" });
     const b1 = em.create(Book, { title: "b1", author: a1 });
-    expect(b1.order).toEqual(1);
+    expect(b1.notes).toEqual("Notes for b1");
   });
 
   it("does not reset default values on load", async () => {

--- a/packages/tests/integration/src/entities/Book.ts
+++ b/packages/tests/integration/src/entities/Book.ts
@@ -46,7 +46,7 @@ config.addRule({ author: "numberOfBooks2" }, (b) => {
 config.setDefault("notes", (b) => `Notes for ${b.title}`);
 
 /** Example of an asynchronous default. */
-config.setDefault("order", { author: "books" }, (b) => b.author.get.books.get.length);
+config.setDefault("order", { author: "books" }, (b) => b.author.get?.books.get.length);
 
 /** Example of an asynchronous default that returns an entity. */
 config.setDefault("author", "title", async (b, { em }) => {

--- a/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
@@ -71,7 +71,6 @@ export const adminUserConfig = new ConfigApi<AdminUser, Context>();
 adminUserConfig.addRule(newRequiredRule("role"));
 
 export abstract class AdminUserCodegen extends User implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "u";
   static readonly metadata: EntityMetadata<AdminUser>;
 
@@ -87,7 +86,7 @@ export abstract class AdminUserCodegen extends User implements Entity {
 
   constructor(em: EntityManager, opts: AdminUserOpts) {
     // @ts-ignore
-    super(em, adminUserMeta, AdminUserCodegen.defaultValues, opts);
+    super(em, adminUserMeta, opts);
     setOpts(this as any as AdminUser, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
@@ -297,7 +297,6 @@ authorConfig.addRule(newRequiredRule("createdAt"));
 authorConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "a";
   static readonly metadata: EntityMetadata<Author>;
 
@@ -314,7 +313,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   abstract readonly favoriteBook: PersistedAsyncReference<Author, Book, undefined>;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, authorMeta, AuthorCodegen.defaultValues, opts);
+    super(em, authorMeta, opts);
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
@@ -95,7 +95,6 @@ authorScheduleConfig.addRule(newRequiredRule("updatedAt"));
 authorScheduleConfig.addRule(newRequiredRule("author"));
 
 export abstract class AuthorScheduleCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "authorSchedule";
   static readonly metadata: EntityMetadata<AuthorSchedule>;
 
@@ -110,7 +109,7 @@ export abstract class AuthorScheduleCodegen extends BaseEntity<EntityManager, st
   };
 
   constructor(em: EntityManager, opts: AuthorScheduleOpts) {
-    super(em, authorScheduleMeta, AuthorScheduleCodegen.defaultValues, opts);
+    super(em, authorScheduleMeta, opts);
     setOpts(this as any as AuthorSchedule, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
@@ -135,7 +135,6 @@ authorStatConfig.addRule(newRequiredRule("createdAt"));
 authorStatConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class AuthorStatCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "as";
   static readonly metadata: EntityMetadata<AuthorStat>;
 
@@ -150,7 +149,7 @@ export abstract class AuthorStatCodegen extends BaseEntity<EntityManager, string
   };
 
   constructor(em: EntityManager, opts: AuthorStatOpts) {
-    super(em, authorStatMeta, AuthorStatCodegen.defaultValues, opts);
+    super(em, authorStatMeta, opts);
     setOpts(this as any as AuthorStat, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
@@ -109,7 +109,6 @@ bookAdvanceConfig.addRule(newRequiredRule("book"));
 bookAdvanceConfig.addRule(newRequiredRule("publisher"));
 
 export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "ba";
   static readonly metadata: EntityMetadata<BookAdvance>;
 
@@ -124,7 +123,7 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, strin
   };
 
   constructor(em: EntityManager, opts: BookAdvanceOpts) {
-    super(em, bookAdvanceMeta, BookAdvanceCodegen.defaultValues, opts);
+    super(em, bookAdvanceMeta, opts);
     setOpts(this as any as BookAdvance, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookCodegen.ts
@@ -154,9 +154,9 @@ bookConfig.addRule(newRequiredRule("order"));
 bookConfig.addRule(newRequiredRule("createdAt"));
 bookConfig.addRule(newRequiredRule("updatedAt"));
 bookConfig.addRule(newRequiredRule("author"));
+bookConfig.setDefault("order", 1);
 
 export abstract class BookCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = { order: 1 };
   static readonly tagName = "b";
   static readonly metadata: EntityMetadata<Book>;
 
@@ -171,7 +171,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: BookOpts) {
-    super(em, bookMeta, BookCodegen.defaultValues, opts);
+    super(em, bookMeta, opts);
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
@@ -127,7 +127,6 @@ bookReviewConfig.addRule(newRequiredRule("updatedAt"));
 bookReviewConfig.addRule(newRequiredRule("book"));
 
 export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "br";
   static readonly metadata: EntityMetadata<BookReview>;
 
@@ -142,7 +141,7 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string
   };
 
   constructor(em: EntityManager, opts: BookReviewOpts) {
-    super(em, bookReviewMeta, BookReviewCodegen.defaultValues, opts);
+    super(em, bookReviewMeta, opts);
     setOpts(this as any as BookReview, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
@@ -91,7 +91,6 @@ childConfig.addRule(newRequiredRule("createdAt"));
 childConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class ChildCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "child";
   static readonly metadata: EntityMetadata<Child>;
 
@@ -106,7 +105,7 @@ export abstract class ChildCodegen extends BaseEntity<EntityManager, string> imp
   };
 
   constructor(em: EntityManager, opts: ChildOpts) {
-    super(em, childMeta, ChildCodegen.defaultValues, opts);
+    super(em, childMeta, opts);
     setOpts(this as any as Child, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
@@ -115,7 +115,6 @@ childGroupConfig.addRule(newRequiredRule("childGroupId"));
 childGroupConfig.addRule(newRequiredRule("parentGroup"));
 
 export abstract class ChildGroupCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "cg";
   static readonly metadata: EntityMetadata<ChildGroup>;
 
@@ -130,7 +129,7 @@ export abstract class ChildGroupCodegen extends BaseEntity<EntityManager, string
   };
 
   constructor(em: EntityManager, opts: ChildGroupOpts) {
-    super(em, childGroupMeta, ChildGroupCodegen.defaultValues, opts);
+    super(em, childGroupMeta, opts);
     setOpts(this as any as ChildGroup, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
@@ -106,7 +106,6 @@ childItemConfig.addRule(newRequiredRule("childGroup"));
 childItemConfig.addRule(newRequiredRule("parentItem"));
 
 export abstract class ChildItemCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "ci";
   static readonly metadata: EntityMetadata<ChildItem>;
 
@@ -121,7 +120,7 @@ export abstract class ChildItemCodegen extends BaseEntity<EntityManager, string>
   };
 
   constructor(em: EntityManager, opts: ChildItemOpts) {
-    super(em, childItemMeta, ChildItemCodegen.defaultValues, opts);
+    super(em, childItemMeta, opts);
     setOpts(this as any as ChildItem, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
@@ -123,7 +123,6 @@ commentConfig.addRule(newRequiredRule("updatedAt"));
 commentConfig.addRule(newRequiredRule("parent"));
 
 export abstract class CommentCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "comment";
   static readonly metadata: EntityMetadata<Comment>;
 
@@ -138,7 +137,7 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> i
   };
 
   constructor(em: EntityManager, opts: CommentOpts) {
-    super(em, commentMeta, CommentCodegen.defaultValues, opts);
+    super(em, commentMeta, opts);
     setOpts(this as any as Comment, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
@@ -123,7 +123,6 @@ criticConfig.addRule(newRequiredRule("createdAt"));
 criticConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class CriticCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "c";
   static readonly metadata: EntityMetadata<Critic>;
 
@@ -138,7 +137,7 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> im
   };
 
   constructor(em: EntityManager, opts: CriticOpts) {
-    super(em, criticMeta, CriticCodegen.defaultValues, opts);
+    super(em, criticMeta, opts);
     setOpts(this as any as Critic, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
@@ -96,7 +96,6 @@ criticColumnConfig.addRule(newRequiredRule("updatedAt"));
 criticColumnConfig.addRule(newRequiredRule("critic"));
 
 export abstract class CriticColumnCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "cc";
   static readonly metadata: EntityMetadata<CriticColumn>;
 
@@ -111,7 +110,7 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager, stri
   };
 
   constructor(em: EntityManager, opts: CriticColumnOpts) {
-    super(em, criticColumnMeta, CriticColumnCodegen.defaultValues, opts);
+    super(em, criticColumnMeta, opts);
     setOpts(this as any as CriticColumn, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
@@ -124,7 +124,6 @@ imageConfig.addRule(newRequiredRule("updatedAt"));
 imageConfig.addRule(newRequiredRule("type"));
 
 export abstract class ImageCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "i";
   static readonly metadata: EntityMetadata<Image>;
 
@@ -139,7 +138,7 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> imp
   };
 
   constructor(em: EntityManager, opts: ImageOpts) {
-    super(em, imageMeta, ImageCodegen.defaultValues, opts);
+    super(em, imageMeta, opts);
     setOpts(this as any as Image, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -89,7 +89,6 @@ export interface LargePublisherOrder extends PublisherOrder {
 export const largePublisherConfig = new ConfigApi<LargePublisher, Context>();
 
 export abstract class LargePublisherCodegen extends Publisher implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "p";
   static readonly metadata: EntityMetadata<LargePublisher>;
 
@@ -105,7 +104,7 @@ export abstract class LargePublisherCodegen extends Publisher implements Entity 
 
   constructor(em: EntityManager, opts: LargePublisherOpts) {
     // @ts-ignore
-    super(em, largePublisherMeta, LargePublisherCodegen.defaultValues, opts);
+    super(em, largePublisherMeta, opts);
     setOpts(this as any as LargePublisher, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
@@ -98,7 +98,6 @@ parentGroupConfig.addRule(newRequiredRule("createdAt"));
 parentGroupConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class ParentGroupCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "parentGroup";
   static readonly metadata: EntityMetadata<ParentGroup>;
 
@@ -113,7 +112,7 @@ export abstract class ParentGroupCodegen extends BaseEntity<EntityManager, strin
   };
 
   constructor(em: EntityManager, opts: ParentGroupOpts) {
-    super(em, parentGroupMeta, ParentGroupCodegen.defaultValues, opts);
+    super(em, parentGroupMeta, opts);
     setOpts(this as any as ParentGroup, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
@@ -104,7 +104,6 @@ parentItemConfig.addRule(newRequiredRule("updatedAt"));
 parentItemConfig.addRule(newRequiredRule("parentGroup"));
 
 export abstract class ParentItemCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "pi";
   static readonly metadata: EntityMetadata<ParentItem>;
 
@@ -119,7 +118,7 @@ export abstract class ParentItemCodegen extends BaseEntity<EntityManager, string
   };
 
   constructor(em: EntityManager, opts: ParentItemOpts) {
-    super(em, parentItemMeta, ParentItemCodegen.defaultValues, opts);
+    super(em, parentItemMeta, opts);
     setOpts(this as any as ParentItem, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
@@ -178,9 +178,9 @@ publisherConfig.addRule(newRequiredRule("name"));
 publisherConfig.addRule(newRequiredRule("createdAt"));
 publisherConfig.addRule(newRequiredRule("updatedAt"));
 publisherConfig.addRule(newRequiredRule("type"));
+publisherConfig.setDefault("type", PublisherType.Big);
 
 export abstract class PublisherCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = { type: PublisherType.Big };
   static readonly tagName = "p";
   static readonly metadata: EntityMetadata<Publisher>;
 
@@ -195,11 +195,11 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
   };
 
   constructor(em: EntityManager, opts: PublisherOpts) {
-    if (arguments.length === 4) {
+    if (arguments.length === 3) {
       // @ts-ignore
-      super(em, arguments[1], { ...arguments[2], ...PublisherCodegen.defaultValues }, arguments[3]);
+      super(em, arguments[1], arguments[2]);
     } else {
-      super(em, publisherMeta, PublisherCodegen.defaultValues, opts);
+      super(em, publisherMeta, opts);
       setOpts(this as any as Publisher, opts, { calledFromConstructor: true });
     }
 

--- a/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
@@ -100,7 +100,6 @@ publisherGroupConfig.addRule(newRequiredRule("createdAt"));
 publisherGroupConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "pg";
   static readonly metadata: EntityMetadata<PublisherGroup>;
 
@@ -115,7 +114,7 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
   };
 
   constructor(em: EntityManager, opts: PublisherGroupOpts) {
-    super(em, publisherGroupMeta, PublisherGroupCodegen.defaultValues, opts);
+    super(em, publisherGroupMeta, opts);
     setOpts(this as any as PublisherGroup, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -90,7 +90,6 @@ export const smallPublisherConfig = new ConfigApi<SmallPublisher, Context>();
 smallPublisherConfig.addRule(newRequiredRule("city"));
 
 export abstract class SmallPublisherCodegen extends Publisher implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "p";
   static readonly metadata: EntityMetadata<SmallPublisher>;
 
@@ -106,7 +105,7 @@ export abstract class SmallPublisherCodegen extends Publisher implements Entity 
 
   constructor(em: EntityManager, opts: SmallPublisherOpts) {
     // @ts-ignore
-    super(em, smallPublisherMeta, SmallPublisherCodegen.defaultValues, opts);
+    super(em, smallPublisherMeta, opts);
     setOpts(this as any as SmallPublisher, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TagCodegen.ts
@@ -103,7 +103,6 @@ tagConfig.addRule(newRequiredRule("createdAt"));
 tagConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class TagCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "t";
   static readonly metadata: EntityMetadata<Tag>;
 
@@ -118,7 +117,7 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> imple
   };
 
   constructor(em: EntityManager, opts: TagOpts) {
-    super(em, tagMeta, TagCodegen.defaultValues, opts);
+    super(em, tagMeta, opts);
     setOpts(this as any as Tag, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
@@ -111,7 +111,6 @@ taskConfig.addRule(newRequiredRule("updatedAt"));
 taskConfig.addRule(cannotBeUpdated("type"));
 
 export abstract class TaskCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "task";
   static readonly metadata: EntityMetadata<Task>;
 
@@ -126,11 +125,11 @@ export abstract class TaskCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: TaskOpts) {
-    if (arguments.length === 4) {
+    if (arguments.length === 3) {
       // @ts-ignore
-      super(em, arguments[1], { ...arguments[2], ...TaskCodegen.defaultValues }, arguments[3]);
+      super(em, arguments[1], arguments[2]);
     } else {
-      super(em, taskMeta, TaskCodegen.defaultValues, opts);
+      super(em, taskMeta, opts);
       setOpts(this as any as Task, opts, { calledFromConstructor: true });
     }
   }

--- a/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
@@ -110,7 +110,6 @@ taskItemConfig.addRule("newTask", mustBeSubType("newTask"));
 taskItemConfig.addRule("oldTask", mustBeSubType("oldTask"));
 
 export abstract class TaskItemCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "ti";
   static readonly metadata: EntityMetadata<TaskItem>;
 
@@ -125,7 +124,7 @@ export abstract class TaskItemCodegen extends BaseEntity<EntityManager, string> 
   };
 
   constructor(em: EntityManager, opts: TaskItemOpts) {
-    super(em, taskItemMeta, TaskItemCodegen.defaultValues, opts);
+    super(em, taskItemMeta, opts);
     setOpts(this as any as TaskItem, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
@@ -84,7 +84,6 @@ export interface TaskNewOrder extends TaskOrder {
 export const taskNewConfig = new ConfigApi<TaskNew, Context>();
 
 export abstract class TaskNewCodegen extends Task implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "task";
   static readonly metadata: EntityMetadata<TaskNew>;
 
@@ -100,7 +99,7 @@ export abstract class TaskNewCodegen extends Task implements Entity {
 
   constructor(em: EntityManager, opts: TaskNewOpts) {
     // @ts-ignore
-    super(em, taskNewMeta, TaskNewCodegen.defaultValues, opts);
+    super(em, taskNewMeta, opts);
     setOpts(this as any as TaskNew, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -84,7 +84,6 @@ export const taskOldConfig = new ConfigApi<TaskOld, Context>();
 taskOldConfig.addRule(newRequiredRule("specialOldField"));
 
 export abstract class TaskOldCodegen extends Task implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "task";
   static readonly metadata: EntityMetadata<TaskOld>;
 
@@ -100,7 +99,7 @@ export abstract class TaskOldCodegen extends Task implements Entity {
 
   constructor(em: EntityManager, opts: TaskOldOpts) {
     // @ts-ignore
-    super(em, taskOldMeta, TaskOldCodegen.defaultValues, opts);
+    super(em, taskOldMeta, opts);
     setOpts(this as any as TaskOld, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -158,9 +158,9 @@ userConfig.addRule(newRequiredRule("bio"));
 userConfig.addRule(newRequiredRule("originalEmail"));
 userConfig.addRule(newRequiredRule("createdAt"));
 userConfig.addRule(newRequiredRule("updatedAt"));
+userConfig.setDefault("bio", "");
 
 export abstract class UserCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = { bio: "" };
   static readonly tagName = "u";
   static readonly metadata: EntityMetadata<User>;
 
@@ -175,11 +175,11 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: UserOpts) {
-    if (arguments.length === 4) {
+    if (arguments.length === 3) {
       // @ts-ignore
-      super(em, arguments[1], { ...arguments[2], ...UserCodegen.defaultValues }, arguments[3]);
+      super(em, arguments[1], arguments[2]);
     } else {
-      super(em, userMeta, UserCodegen.defaultValues, opts);
+      super(em, userMeta, opts);
       setOpts(this as any as User, opts, { calledFromConstructor: true });
     }
   }

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.149.3"
+  "version": "1.149.4"
 }

--- a/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
@@ -88,7 +88,6 @@ authorConfig.addRule(newRequiredRule("createdAt"));
 authorConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class AuthorCodegen extends BaseEntity<EntityManager, number> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "a";
   static readonly metadata: EntityMetadata<Author>;
 
@@ -103,7 +102,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, number> im
   };
 
   constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, authorMeta, AuthorCodegen.defaultValues, opts);
+    super(em, authorMeta, opts);
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
@@ -86,7 +86,6 @@ bookConfig.addRule(newRequiredRule("updatedAt"));
 bookConfig.addRule(newRequiredRule("author"));
 
 export abstract class BookCodegen extends BaseEntity<EntityManager, number> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "b";
   static readonly metadata: EntityMetadata<Book>;
 
@@ -101,7 +100,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, number> impl
   };
 
   constructor(em: EntityManager, opts: BookOpts) {
-    super(em, bookMeta, BookCodegen.defaultValues, opts);
+    super(em, bookMeta, opts);
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.149.3"
+  "version": "1.149.4"
 }

--- a/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
@@ -89,7 +89,6 @@ artistConfig.addRule(newRequiredRule("createdAt"));
 artistConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class ArtistCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "artist";
   static readonly metadata: EntityMetadata<Artist>;
 
@@ -104,7 +103,7 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager, string> im
   };
 
   constructor(em: EntityManager, opts: ArtistOpts) {
-    super(em, artistMeta, ArtistCodegen.defaultValues, opts);
+    super(em, artistMeta, opts);
     setOpts(this as any as Artist, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
@@ -95,7 +95,6 @@ authorConfig.addRule(newRequiredRule("createdAt"));
 authorConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "a";
   static readonly metadata: EntityMetadata<Author>;
 
@@ -110,7 +109,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   };
 
   constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, authorMeta, AuthorCodegen.defaultValues, opts);
+    super(em, authorMeta, opts);
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
@@ -76,7 +76,6 @@ bookConfig.addRule(newRequiredRule("title"));
 bookConfig.addRule(newRequiredRule("author"));
 
 export abstract class BookCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "b";
   static readonly metadata: EntityMetadata<Book>;
 
@@ -91,7 +90,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: BookOpts) {
-    super(em, bookMeta, BookCodegen.defaultValues, opts);
+    super(em, bookMeta, opts);
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
@@ -62,7 +62,6 @@ export const databaseOwnerConfig = new ConfigApi<DatabaseOwner, Context>();
 databaseOwnerConfig.addRule(newRequiredRule("name"));
 
 export abstract class DatabaseOwnerCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "do";
   static readonly metadata: EntityMetadata<DatabaseOwner>;
 
@@ -77,7 +76,7 @@ export abstract class DatabaseOwnerCodegen extends BaseEntity<EntityManager, str
   };
 
   constructor(em: EntityManager, opts: DatabaseOwnerOpts) {
-    super(em, databaseOwnerMeta, DatabaseOwnerCodegen.defaultValues, opts);
+    super(em, databaseOwnerMeta, opts);
     setOpts(this as any as DatabaseOwner, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/schema-misc/src/entities/codegen/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/PaintingCodegen.ts
@@ -96,7 +96,6 @@ paintingConfig.addRule(newRequiredRule("updatedAt"));
 paintingConfig.addRule(newRequiredRule("artist"));
 
 export abstract class PaintingCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "p";
   static readonly metadata: EntityMetadata<Painting>;
 
@@ -111,7 +110,7 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager, string> 
   };
 
   constructor(em: EntityManager, opts: PaintingOpts) {
-    super(em, paintingMeta, PaintingCodegen.defaultValues, opts);
+    super(em, paintingMeta, opts);
     setOpts(this as any as Painting, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.149.3"
+  "version": "1.149.4"
 }

--- a/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
@@ -104,7 +104,6 @@ authorConfig.addRule(newRequiredRule("createdAt"));
 authorConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "a";
   static readonly metadata: EntityMetadata<Author>;
 
@@ -119,7 +118,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   };
 
   constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, authorMeta, AuthorCodegen.defaultValues, opts);
+    super(em, authorMeta, opts);
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
@@ -105,7 +105,6 @@ bookConfig.addRule(newRequiredRule("updatedAt"));
 bookConfig.addRule(newRequiredRule("author"));
 
 export abstract class BookCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "b";
   static readonly metadata: EntityMetadata<Book>;
 
@@ -120,7 +119,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: BookOpts) {
-    super(em, bookMeta, BookCodegen.defaultValues, opts);
+    super(em, bookMeta, opts);
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
@@ -94,7 +94,6 @@ commentConfig.addRule(newRequiredRule("updatedAt"));
 commentConfig.addRule(newRequiredRule("parent"));
 
 export abstract class CommentCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "c";
   static readonly metadata: EntityMetadata<Comment>;
 
@@ -109,7 +108,7 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> i
   };
 
   constructor(em: EntityManager, opts: CommentOpts) {
-    super(em, commentMeta, CommentCodegen.defaultValues, opts);
+    super(em, commentMeta, opts);
     setOpts(this as any as Comment, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.149.3"
+  "version": "1.149.4"
 }

--- a/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
@@ -88,7 +88,6 @@ authorConfig.addRule(newRequiredRule("createdAt"));
 authorConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "a";
   static readonly metadata: EntityMetadata<Author>;
 
@@ -103,7 +102,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   };
 
   constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, authorMeta, AuthorCodegen.defaultValues, opts);
+    super(em, authorMeta, opts);
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/uuid-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/BookCodegen.ts
@@ -105,7 +105,6 @@ bookConfig.addRule(newRequiredRule("status"));
 bookConfig.addRule(newRequiredRule("author"));
 
 export abstract class BookCodegen extends BaseEntity<EntityManager, string> implements Entity {
-  static defaultValues: object = {};
   static readonly tagName = "b";
   static readonly metadata: EntityMetadata<Book>;
 
@@ -120,7 +119,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: BookOpts) {
-    super(em, bookMeta, BookCodegen.defaultValues, opts);
+    super(em, bookMeta, opts);
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 


### PR DESCRIPTION
Originally we put database-sourced defaults into a `defaultValues` hash and passed it around the constructors, which ended up being pretty crufty.

Recently we introduced a config.setDefault API for users to use, and in retrospect we can have the database defaults use this as well.