### PR TITLE
fix: Simplify constructors.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -407,38 +407,13 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
     }`
     : "";
 
-  let cstr;
-  if (baseEntity) {
-    cstr = code`
-      constructor(em: ${EntityManager}, opts: ${entityName}Opts) {
-        // @ts-ignore
-        super(em, ${metadata}, opts);
-        ${setOpts}(this as any as ${entityName}, opts, { calledFromConstructor: true });
-        ${maybePreventBaseTypeInstantiation}
-      }
-    `;
-  } else if (subEntities.length > 0) {
-    cstr = code`
-      constructor(em: ${EntityManager}, opts: ${entityName}Opts) {
-        if (arguments.length === 3) {
-          // @ts-ignore
-          super(em, arguments[1], arguments[2]);
-        } else {
-          super(em, ${metadata}, opts);
-          ${setOpts}(this as any as ${entityName}, opts, { calledFromConstructor: true });
-        }
-        ${maybePreventBaseTypeInstantiation}
-      }
-    `;
-  } else {
-    cstr = code`
-      constructor(em: ${EntityManager}, opts: ${entityName}Opts) {
-        super(em, ${metadata}, opts);
-        ${setOpts}(this as any as ${entityName}, opts, { calledFromConstructor: true });
-        ${maybePreventBaseTypeInstantiation}
-      }
-    `;
-  }
+  const cstr = code`
+    constructor(em: ${EntityManager}, opts: ${entityName}Opts) {
+      super(em, opts);
+      ${setOpts}(this as any as ${entityName}, opts, { calledFromConstructor: true });
+      ${maybePreventBaseTypeInstantiation}
+    }
+  `;
 
   let maybeOtherTypeChanges;
   if (subEntities.length > 0) {

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -35,12 +35,12 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
   }
   readonly #orm!: EntityOrmField;
 
-  protected constructor(em: EM, metadata: any, optsOrId: any) {
+  protected constructor(em: EM, optsOrId: any) {
     // Only do em.register for em.create-d entities, otherwise defer to hydrate to em.register
     if (typeof optsOrId === "string") {
-      this.#orm = new EntityOrmField(em, metadata, false);
+      this.#orm = new EntityOrmField(em, (this.constructor as any).metadata, false);
     } else {
-      this.#orm = new EntityOrmField(em, metadata, true);
+      this.#orm = new EntityOrmField(em, (this.constructor as any).metadata, true);
       em.register(this);
     }
     currentlyInstantiatingEntity = this;

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -79,5 +79,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.149.4"
+  "version": "1.150.0"
 }

--- a/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
@@ -85,8 +85,7 @@ export abstract class AdminUserCodegen extends User implements Entity {
   };
 
   constructor(em: EntityManager, opts: AdminUserOpts) {
-    // @ts-ignore
-    super(em, adminUserMeta, opts);
+    super(em, opts);
     setOpts(this as any as AdminUser, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
@@ -313,7 +313,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   abstract readonly favoriteBook: PersistedAsyncReference<Author, Book, undefined>;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, authorMeta, opts);
+    super(em, opts);
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
@@ -109,7 +109,7 @@ export abstract class AuthorScheduleCodegen extends BaseEntity<EntityManager, st
   };
 
   constructor(em: EntityManager, opts: AuthorScheduleOpts) {
-    super(em, authorScheduleMeta, opts);
+    super(em, opts);
     setOpts(this as any as AuthorSchedule, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
@@ -149,7 +149,7 @@ export abstract class AuthorStatCodegen extends BaseEntity<EntityManager, string
   };
 
   constructor(em: EntityManager, opts: AuthorStatOpts) {
-    super(em, authorStatMeta, opts);
+    super(em, opts);
     setOpts(this as any as AuthorStat, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
@@ -123,7 +123,7 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, strin
   };
 
   constructor(em: EntityManager, opts: BookAdvanceOpts) {
-    super(em, bookAdvanceMeta, opts);
+    super(em, opts);
     setOpts(this as any as BookAdvance, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookCodegen.ts
@@ -171,7 +171,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: BookOpts) {
-    super(em, bookMeta, opts);
+    super(em, opts);
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
@@ -141,7 +141,7 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string
   };
 
   constructor(em: EntityManager, opts: BookReviewOpts) {
-    super(em, bookReviewMeta, opts);
+    super(em, opts);
     setOpts(this as any as BookReview, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
@@ -105,7 +105,7 @@ export abstract class ChildCodegen extends BaseEntity<EntityManager, string> imp
   };
 
   constructor(em: EntityManager, opts: ChildOpts) {
-    super(em, childMeta, opts);
+    super(em, opts);
     setOpts(this as any as Child, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
@@ -129,7 +129,7 @@ export abstract class ChildGroupCodegen extends BaseEntity<EntityManager, string
   };
 
   constructor(em: EntityManager, opts: ChildGroupOpts) {
-    super(em, childGroupMeta, opts);
+    super(em, opts);
     setOpts(this as any as ChildGroup, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
@@ -120,7 +120,7 @@ export abstract class ChildItemCodegen extends BaseEntity<EntityManager, string>
   };
 
   constructor(em: EntityManager, opts: ChildItemOpts) {
-    super(em, childItemMeta, opts);
+    super(em, opts);
     setOpts(this as any as ChildItem, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
@@ -137,7 +137,7 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> i
   };
 
   constructor(em: EntityManager, opts: CommentOpts) {
-    super(em, commentMeta, opts);
+    super(em, opts);
     setOpts(this as any as Comment, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
@@ -137,7 +137,7 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> im
   };
 
   constructor(em: EntityManager, opts: CriticOpts) {
-    super(em, criticMeta, opts);
+    super(em, opts);
     setOpts(this as any as Critic, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
@@ -110,7 +110,7 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager, stri
   };
 
   constructor(em: EntityManager, opts: CriticColumnOpts) {
-    super(em, criticColumnMeta, opts);
+    super(em, opts);
     setOpts(this as any as CriticColumn, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
@@ -138,7 +138,7 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> imp
   };
 
   constructor(em: EntityManager, opts: ImageOpts) {
-    super(em, imageMeta, opts);
+    super(em, opts);
     setOpts(this as any as Image, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -103,8 +103,7 @@ export abstract class LargePublisherCodegen extends Publisher implements Entity 
   };
 
   constructor(em: EntityManager, opts: LargePublisherOpts) {
-    // @ts-ignore
-    super(em, largePublisherMeta, opts);
+    super(em, opts);
     setOpts(this as any as LargePublisher, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
@@ -112,7 +112,7 @@ export abstract class ParentGroupCodegen extends BaseEntity<EntityManager, strin
   };
 
   constructor(em: EntityManager, opts: ParentGroupOpts) {
-    super(em, parentGroupMeta, opts);
+    super(em, opts);
     setOpts(this as any as ParentGroup, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
@@ -118,7 +118,7 @@ export abstract class ParentItemCodegen extends BaseEntity<EntityManager, string
   };
 
   constructor(em: EntityManager, opts: ParentItemOpts) {
-    super(em, parentItemMeta, opts);
+    super(em, opts);
     setOpts(this as any as ParentItem, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
@@ -195,13 +195,8 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
   };
 
   constructor(em: EntityManager, opts: PublisherOpts) {
-    if (arguments.length === 3) {
-      // @ts-ignore
-      super(em, arguments[1], arguments[2]);
-    } else {
-      super(em, publisherMeta, opts);
-      setOpts(this as any as Publisher, opts, { calledFromConstructor: true });
-    }
+    super(em, opts);
+    setOpts(this as any as Publisher, opts, { calledFromConstructor: true });
 
     if (this.constructor === Publisher && !(em as any).fakeInstance) {
       throw new Error(`Publisher ${typeof opts === "string" ? opts : ""} must be instantiated via a subtype`);

--- a/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
@@ -114,7 +114,7 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
   };
 
   constructor(em: EntityManager, opts: PublisherGroupOpts) {
-    super(em, publisherGroupMeta, opts);
+    super(em, opts);
     setOpts(this as any as PublisherGroup, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -104,8 +104,7 @@ export abstract class SmallPublisherCodegen extends Publisher implements Entity 
   };
 
   constructor(em: EntityManager, opts: SmallPublisherOpts) {
-    // @ts-ignore
-    super(em, smallPublisherMeta, opts);
+    super(em, opts);
     setOpts(this as any as SmallPublisher, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TagCodegen.ts
@@ -117,7 +117,7 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> imple
   };
 
   constructor(em: EntityManager, opts: TagOpts) {
-    super(em, tagMeta, opts);
+    super(em, opts);
     setOpts(this as any as Tag, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
@@ -125,13 +125,8 @@ export abstract class TaskCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: TaskOpts) {
-    if (arguments.length === 3) {
-      // @ts-ignore
-      super(em, arguments[1], arguments[2]);
-    } else {
-      super(em, taskMeta, opts);
-      setOpts(this as any as Task, opts, { calledFromConstructor: true });
-    }
+    super(em, opts);
+    setOpts(this as any as Task, opts, { calledFromConstructor: true });
   }
 
   get id(): TaskId {

--- a/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
@@ -124,7 +124,7 @@ export abstract class TaskItemCodegen extends BaseEntity<EntityManager, string> 
   };
 
   constructor(em: EntityManager, opts: TaskItemOpts) {
-    super(em, taskItemMeta, opts);
+    super(em, opts);
     setOpts(this as any as TaskItem, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
@@ -98,8 +98,7 @@ export abstract class TaskNewCodegen extends Task implements Entity {
   };
 
   constructor(em: EntityManager, opts: TaskNewOpts) {
-    // @ts-ignore
-    super(em, taskNewMeta, opts);
+    super(em, opts);
     setOpts(this as any as TaskNew, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -98,8 +98,7 @@ export abstract class TaskOldCodegen extends Task implements Entity {
   };
 
   constructor(em: EntityManager, opts: TaskOldOpts) {
-    // @ts-ignore
-    super(em, taskOldMeta, opts);
+    super(em, opts);
     setOpts(this as any as TaskOld, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -175,13 +175,8 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: UserOpts) {
-    if (arguments.length === 3) {
-      // @ts-ignore
-      super(em, arguments[1], arguments[2]);
-    } else {
-      super(em, userMeta, opts);
-      setOpts(this as any as User, opts, { calledFromConstructor: true });
-    }
+    super(em, opts);
+    setOpts(this as any as User, opts, { calledFromConstructor: true });
   }
 
   get id(): UserId {

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.149.4"
+  "version": "1.150.0"
 }

--- a/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
@@ -102,7 +102,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, number> im
   };
 
   constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, authorMeta, opts);
+    super(em, opts);
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
@@ -100,7 +100,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, number> impl
   };
 
   constructor(em: EntityManager, opts: BookOpts) {
-    super(em, bookMeta, opts);
+    super(em, opts);
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.149.4"
+  "version": "1.150.0"
 }

--- a/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
@@ -103,7 +103,7 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager, string> im
   };
 
   constructor(em: EntityManager, opts: ArtistOpts) {
-    super(em, artistMeta, opts);
+    super(em, opts);
     setOpts(this as any as Artist, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
@@ -109,7 +109,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   };
 
   constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, authorMeta, opts);
+    super(em, opts);
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
@@ -90,7 +90,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: BookOpts) {
-    super(em, bookMeta, opts);
+    super(em, opts);
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
@@ -76,7 +76,7 @@ export abstract class DatabaseOwnerCodegen extends BaseEntity<EntityManager, str
   };
 
   constructor(em: EntityManager, opts: DatabaseOwnerOpts) {
-    super(em, databaseOwnerMeta, opts);
+    super(em, opts);
     setOpts(this as any as DatabaseOwner, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/schema-misc/src/entities/codegen/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/PaintingCodegen.ts
@@ -110,7 +110,7 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager, string> 
   };
 
   constructor(em: EntityManager, opts: PaintingOpts) {
-    super(em, paintingMeta, opts);
+    super(em, opts);
     setOpts(this as any as Painting, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.149.4"
+  "version": "1.150.0"
 }

--- a/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
@@ -118,7 +118,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   };
 
   constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, authorMeta, opts);
+    super(em, opts);
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
@@ -119,7 +119,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: BookOpts) {
-    super(em, bookMeta, opts);
+    super(em, opts);
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
@@ -108,7 +108,7 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> i
   };
 
   constructor(em: EntityManager, opts: CommentOpts) {
-    super(em, commentMeta, opts);
+    super(em, opts);
     setOpts(this as any as Comment, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.149.4"
+  "version": "1.150.0"
 }

--- a/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
@@ -102,7 +102,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   };
 
   constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, authorMeta, opts);
+    super(em, opts);
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 

--- a/packages/tests/uuid-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/BookCodegen.ts
@@ -119,7 +119,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   };
 
   constructor(em: EntityManager, opts: BookOpts) {
-    super(em, bookMeta, opts);
+    super(em, opts);
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 


### PR DESCRIPTION
Instead of passing in `metadata` from each class, we can get at it through this.constructor.metadata.