### PR TITLE
fix: Move ReactiveRelation config into relations.

### DIFF
--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -8,7 +8,6 @@
         "address": { "superstruct": "address@src/entities/types" },
         "bookComments": { "derived": "async" },
         "businessAddress": { "zodSchema": "AddressSchema@src/entities/types" },
-        "favoriteBook": { "derived": "async" },
         "ignoreEnumFk": { "ignore": true },
         "ignoreEnumFkRequiredWithDefault": { "ignore": true },
         "ignoreUsedToBeUseful": { "ignore": true },
@@ -25,7 +24,7 @@
         "tsSearch": { "ignore": true },
         "wasEverPopular": { "protected": true }
       },
-      "relations": { "books": { "orderBy": "order" } },
+      "relations": { "books": { "orderBy": "order" }, "favoriteBook": { "derived": "async" } },
       "tag": "a"
     },
     "AuthorSchedule": { "tag": "authorSchedule" },


### PR DESCRIPTION
Within joist-config.json, configurating references had ended up in the "fields" section, which they are kind of fields, but they are more so relations, so them them there.

This one doesn't have a codemod, but users should see the warning of "unrecognized config" and hopefully will move their FK field config over into relations.