### PR TITLE
fix: Let entityResolver pick up base type relations.

### DIFF
--- a/packages/graphql-resolver-utils/src/entityResolver.ts
+++ b/packages/graphql-resolver-utils/src/entityResolver.ts
@@ -47,11 +47,11 @@ export type EntityResolver<T extends Entity> = {
     ? Resolver<T, Record<string, any>, IdOf<T>>
     : T[P] extends GraphQLPrimitive | GraphQLPrimitive[]
       ? Resolver<T, Record<string, any>, T[P]>
-      : T[P] extends Collection<T, infer U>
+      : T[P] extends Collection<any, infer U>
         ? Resolver<T, Record<string, any>, U[]>
-        : T[P] extends Reference<T, infer U, infer N>
+        : T[P] extends Reference<any, infer U, infer N>
           ? Resolver<T, Record<string, any>, U>
-          : T[P] extends AsyncProperty<T, infer V>
+          : T[P] extends AsyncProperty<any, infer V>
             ? Resolver<T, Record<string, any>, V>
             : T[P] extends Promise<infer V>
               ? Resolver<T, Record<string, any>, V>

--- a/packages/tests/integration/src/generated/graphql-types.ts
+++ b/packages/tests/integration/src/generated/graphql-types.ts
@@ -60,6 +60,9 @@ export type LargePublisherResolvers = {
 export type SmallPublisherResolvers = {
   name: Resolver<SmallPublisher, any, string>;
   city: Resolver<SmallPublisher, any, string>;
+  group: Resolver<SmallPublisher, any, PublisherGroup>;
+  authors: Resolver<SmallPublisher, any, Author[]>;
+
 };
 export type PublisherGroupResolvers = {
   name: Resolver<PublisherGroup, any, string | undefined>;


### PR DESCRIPTION
The check for `Relation<T, ...` where T was a subtype was too strict, because the relation from the base of like `Relation<Publisher, ...>` didn't match the `extends Relation<SmallPublisher, ...>`.

The first generic doesn't actually matter for these checks, so we can `any` it.