### PR TITLE
fix: Preserve changed/new state for beforeCommit w/RQFs.

### DIFF
--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -84,23 +84,15 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
    * is no longer new; this only flips to `false` after the `flush` transaction has been committed.
    */
   get isNewEntity(): boolean {
-    return this.#orm.isNew;
+    return this.#orm.isNewEntity;
   }
 
   get isDeletedEntity(): boolean {
-    return this.#orm.deleted !== undefined;
+    return this.#orm.isDeletedEntity;
   }
 
   get isDirtyEntity(): boolean {
-    return Object.keys(this.#orm.originalData).length > 0;
-  }
-
-  get isPendingFlush(): boolean {
-    return this.isNewEntity || this.isDirtyEntity || this.isPendingDelete || this.#orm.isTouched;
-  }
-
-  get isPendingDelete(): boolean {
-    return this.#orm.deleted === "pending";
+    return this.#orm.isDirtyEntity;
   }
 
   toString(): string {

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -20,8 +20,6 @@ export interface Entity {
   readonly isNewEntity: boolean;
   readonly isDeletedEntity: boolean;
   readonly isDirtyEntity: boolean;
-  readonly isPendingFlush: boolean;
-  readonly isPendingDelete: boolean;
   set(opts: Partial<OptsOf<this>>): void;
   setPartial(values: PartialOrNull<OptsOf<this>>): void;
   /**
@@ -37,7 +35,7 @@ export interface Entity {
 export class EntityOrmField {
   /** All entities must be associated to an `EntityManager` to handle lazy loading/etc. */
   readonly em: EntityManager;
-  /** A point to our entity type's metadata. */
+  /** A pointer to our entity type's metadata. */
   readonly metadata: EntityMetadata;
   /** A bag for our lazy-initialized relations. */
   relations: Record<any, any> = {};
@@ -47,6 +45,8 @@ export class EntityOrmField {
   data: Record<string, any>;
   /** A bag to keep the original values, lazily populated as fields are mutated. */
   originalData: Record<any, any> = {};
+  /** A bag to keep the flushed-to-database values, only for ReactiveQueryField reactivity. */
+  flushedData: Record<any, any> | undefined;
   /**
    * Whether our entity has been deleted or not.
    *
@@ -54,36 +54,103 @@ export class EntityOrmField {
    * - `flushed` means we've flushed a `DELETE` but `em.flush` hasn't fully completed yet, likely due to ReactiveQueryField calcs
    * - `deleted` means we've been flushed and `em.flush` has completed
    */
-  deleted?: "pending" | "deleted" | "flushed";
+  #deleted?: "pending" | "deleted" | "flushed";
   /** Whether our entity is new or not. */
-  isNew: boolean = true;
+  #new?: "pending" | "flushed";
   /** Whether our entity should flush regardless of any other changes. */
   isTouched: boolean = false;
   /** Whether we were created in this EM, even if we've since been flushed. */
   wasNew: boolean = false;
 
-  /** Creates the `#orm` field; defaultValues is only provided when instantiating new entities. */
+  /** Creates the `#orm` field. */
   constructor(em: EntityManager, metadata: EntityMetadata, isNew: boolean) {
     this.em = em;
     this.metadata = metadata;
     if (isNew) {
-      this.isNew = true;
+      this.#new = "pending";
       this.data = {};
       this.row = {};
+      this.flushedData = undefined;
     } else {
-      this.isNew = false;
+      this.#new = undefined;
       this.data = {};
+      this.flushedData = undefined;
     }
   }
 
-  resetAfterFlushed(isCalculatingReactiveQueryFields: boolean = false) {
+  /** If `em.flush` has detected a dirty RQF, reset our internal dirty state, w/o reseting our external-dirty state. */
+  resetForRqfLoop() {
+    this.flushedData = {};
+    if (this.#new === "pending") this.#new = "flushed";
+    if (this.#deleted === "pending") this.#deleted = "flushed";
+  }
+
+  resetAfterFlushed() {
     this.originalData = {};
+    this.flushedData = undefined;
     this.isTouched = false;
-    this.wasNew ||= this.isNew;
-    this.isNew = false;
-    if (this.deleted === "pending" || this.deleted === "flushed") {
-      this.deleted = isCalculatingReactiveQueryFields ? "flushed" : "deleted";
+    this.wasNew ||= !!this.#new;
+    this.#new = undefined;
+    if (this.#deleted === "pending" || this.#deleted === "flushed") {
+      this.#deleted = "deleted";
     }
+  }
+
+  /** Our public-facing `isNewEntity`. */
+  get isNewEntity(): boolean {
+    return !!this.#new;
+  }
+
+  /** Our public-facing `isDeletedEntity`. */
+  get isDeletedEntity(): boolean {
+    return !!this.#deleted;
+  }
+
+  /** Our public-facing `isDirtyEntity`. */
+  get isDirtyEntity(): boolean {
+    return Object.keys(this.originalData).length > 0;
+  }
+
+  /** This is our internal "is pending flush", which is aware of RQF micro-flush loops. */
+  get pendingOperation(): "insert" | "update" | "delete" | "none" {
+    if (this.#deleted) {
+      // Skip entities that were created and them immediately `em.delete`-d; granted this is
+      // probably rare, but we shouldn't run hooks or have the driver try and delete these.
+      return this.#deleted === "pending" && !this.#new ? "delete" : "none";
+    } else if (this.#new === "pending") {
+      // Per ^, if `#new === flushed`, we fall through to check if micro-flush UPDATEs are required
+      return "insert";
+    } else if (this.flushedData) {
+      return Object.keys(this.flushedData).length > 0 ? "update" : "none";
+    } else {
+      return this.isTouched || Object.keys(this.originalData).length > 0 ? "update" : "none";
+    }
+  }
+
+  get changedFields(): string[] {
+    return this.flushedData ? Object.keys(this.flushedData) : Object.keys(this.originalData);
+  }
+
+  /** Called when an `em.load` tries to find the entity and it's just gone from the db. */
+  markDeleteBecauseNotFound(): void {
+    this.#deleted = "deleted";
+  }
+
+  /** Called by `em.delete`, returns true if this is new information. */
+  markDeleted(): boolean {
+    if (!this.#deleted) {
+      this.#deleted = "pending";
+      return true;
+    }
+    return false;
+  }
+
+  fixupCreatedThenDeleted(): void {
+    this.#deleted = "deleted";
+  }
+
+  get isDeletedAndFlushed(): boolean {
+    return this.#deleted === "deleted";
   }
 }
 

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -98,12 +98,12 @@ export class EntityOrmField {
 
   /** Our public-facing `isNewEntity`. */
   get isNewEntity(): boolean {
-    return !!this.#new;
+    return this.#new !== undefined;
   }
 
   /** Our public-facing `isDeletedEntity`. */
   get isDeletedEntity(): boolean {
-    return !!this.#deleted;
+    return this.#deleted !== undefined;
   }
 
   /** Our public-facing `isDirtyEntity`. */
@@ -132,13 +132,13 @@ export class EntityOrmField {
   }
 
   /** Called when an `em.load` tries to find the entity and it's just gone from the db. */
-  markDeleteBecauseNotFound(): void {
+  markDeletedBecauseNotFound(): void {
     this.#deleted = "deleted";
   }
 
   /** Called by `em.delete`, returns true if this is new information. */
   markDeleted(): boolean {
-    if (!this.#deleted) {
+    if (this.#deleted === undefined) {
       this.#deleted = "pending";
       return true;
     }

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -958,7 +958,11 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
     // I'm tempted to throw an error here, because at least internal callers should ideally pre-check
     // that `list > 0` and `Object.keys(hint).length > 0` before calling `populate`, just as an optimization.
     // But since it's a public API, we should just early exit.
-    const list = toArray(entityOrList).filter((e) => e !== undefined && !e.isDeletedEntity);
+    const list = toArray(entityOrList).filter((e) => {
+      // Check `isDeletedAndFlushed` so that pending-delete entities are still populated,
+      // because their hooks might do `getWithDeleted` calls and expect them to be loaded.
+      return e !== undefined && !getOrmField(e).isDeletedAndFlushed
+    });
     if (list.length === 0) {
       return !fn ? (entityOrList as any) : fn(entityOrList as any);
     }

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1059,8 +1059,8 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
    */
   delete(entity: Entity): void {
     // Early return if already deleted.
-    const changed = getOrmField(entity).markDeleted();
-    if (!changed) return;
+    const alreadyMarked = getOrmField(entity).markDeleted();
+    if (!alreadyMarked) return;
     // Any derived fields that read this entity will need recalc-d
     this.#rm.queueAllDownstreamFields(entity);
     // Synchronously unhook the entity if the relations are loaded

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1243,7 +1243,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
         // is going to make multiple `em.flush()` calls?
         await afterCommit(this.ctx, allFlushedEntities);
 
-        // Update the `__orm` to reflect the new state
+        // Update the `#orm` field to reflect the new state
         for (const e of allFlushedEntities) {
           if (e.isNewEntity && !e.isDeletedEntity) this.#entityIndex.set(e.idTagged, e);
           getOrmField(e).resetAfterFlushed();

--- a/packages/orm/src/dataloaders/loadDataLoader.ts
+++ b/packages/orm/src/dataloaders/loadDataLoader.ts
@@ -49,7 +49,7 @@ export function loadDataLoader<T extends Entity>(
       if (entity === undefined) {
         const existingEntity = em.findExistingInstance<T>(id);
         if (existingEntity) {
-          getOrmField(existingEntity).deleted = "deleted";
+          getOrmField(existingEntity).markDeleteBecauseNotFound();
         }
       }
       return entity;

--- a/packages/orm/src/dataloaders/loadDataLoader.ts
+++ b/packages/orm/src/dataloaders/loadDataLoader.ts
@@ -49,7 +49,7 @@ export function loadDataLoader<T extends Entity>(
       if (entity === undefined) {
         const existingEntity = em.findExistingInstance<T>(id);
         if (existingEntity) {
-          getOrmField(existingEntity).markDeleteBecauseNotFound();
+          getOrmField(existingEntity).markDeletedBecauseNotFound();
         }
       }
       return entity;

--- a/packages/orm/src/drivers/EntityWriter.ts
+++ b/packages/orm/src/drivers/EntityWriter.ts
@@ -118,7 +118,7 @@ function newUpdateOp(meta: EntityMetadata, entities: Entity[]): UpdateOp | undef
   // to always use the same fields, to take advantage of Prepared Statements.
   const changedFields = new Set<string>();
   for (const entity of entities) {
-    Object.keys(getOrmField(entity).originalData).forEach((key) => changedFields.add(key));
+    for (const fieldName of getOrmField(entity).changedFields) changedFields.add(fieldName);
   }
   // Sometimes with derived fields, an instance will be marked as an update, but if the derived field hasn't
   // actually changed, it'll be a noop, so just short-circuit if it looks like that happened. Unless touched.

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -211,7 +211,7 @@ export function setOpts<T extends Entity>(
 }
 
 export function ensureNotDeleted(entity: Entity, ignore?: "pending"): void {
-  if (entity.isDeletedEntity && (ignore === undefined || getOrmField(entity).deleted === "deleted")) {
+  if (entity.isDeletedEntity && (ignore === undefined || getOrmField(entity).isDeletedAndFlushed)) {
     fail(`${entity} is marked as deleted`);
   }
 }

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -85,5 +85,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.151.9"
+  "version": "1.151.11"
 }

--- a/packages/tests/integration/src/EntityManager.test.ts
+++ b/packages/tests/integration/src/EntityManager.test.ts
@@ -541,7 +541,7 @@ describe("EntityManager", () => {
     // When we refresh the entity
     await em.refresh(a1);
     // Then we're marked as deleted
-    expect(getOrmField(a1).deleted).toEqual("deleted");
+    expect(getOrmField(a1).isDeletedAndFlushed).toBe(true);
     expect(a1.isDeletedEntity).toEqual(true);
   });
 

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -226,9 +226,7 @@ describe("Author", () => {
     expect(a1.transientFields.beforeCommitRan).toBe(true);
     expect(a1.transientFields.afterCommitRan).toBe(true);
     expect(a1.transientFields.afterCommitIdIsSet).toBe(true);
-    // Because we had a ReactiveQueryField to calc, and so flushed twice, the author no
-    // longer looked new when we called afterCommit.
-    expect(a1.transientFields.afterCommitIsNewEntity).toBe(false);
+    expect(a1.transientFields.afterCommitIsNewEntity).toBe(true);
     a1.firstName = "new name";
     a1.transientFields.beforeCreateRan = false;
     await em.flush();

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -612,7 +612,7 @@ describe("Author", () => {
     // And b2 still knows that author is/was its parent
     expect(b2.author.get).toBe(a);
     // Even though its deleted
-    expect(b2.isPendingDelete).toBe(true);
+    expect(b2.isDeletedEntity).toBe(true);
   });
 
   it("isLoaded returns correctly when a field is nullable", async () => {

--- a/packages/tests/integration/src/entities/Publisher.ts
+++ b/packages/tests/integration/src/entities/Publisher.ts
@@ -20,7 +20,11 @@ import {
 const allImagesHint = { images: [], authors: { image: [], books: "image" } } as const;
 
 export abstract class Publisher extends PublisherCodegen {
-  transientFields = { numberOfBookReviewEvals: 0 };
+  transientFields = {
+    numberOfBookReviewEvals: 0,
+    wasNewInBeforeCommit: undefined as boolean | undefined,
+    changedInBeforeCommit: [] as string[],
+  };
 
   /** Example of a reactive query. */
   readonly numberOfBookReviews: ReactiveField<Publisher, number> = hasReactiveQueryField(
@@ -108,3 +112,9 @@ config.addRule(["name", "numberOfBookReviews"], (p) => {
 
 // Example of an abstract/base CTI cascade deleting
 config.cascadeDelete("bookAdvances");
+
+/** For testing beforeCommits observe the right data with RQFs. */
+config.beforeCommit((p) => {
+  p.transientFields.wasNewInBeforeCommit = p.isNewEntity;
+  p.transientFields.changedInBeforeCommit = [...p.changes.fields];
+});

--- a/packages/tests/integration/src/entities/codegen/metadata.ts
+++ b/packages/tests/integration/src/entities/codegen/metadata.ts
@@ -432,11 +432,7 @@ export const commentMeta: EntityMetadata<Comment> = {
       fieldName: "parent",
       fieldIdName: "parentId",
       required: true,
-      components: [{ otherMetadata: () => authorMeta, otherFieldName: "comments", columnName: "parent_author_id" }, { otherMetadata: () => bookMeta, otherFieldName: "comments", columnName: "parent_book_id" }, {
-        otherMetadata: () => bookReviewMeta,
-        otherFieldName: "comment",
-        columnName: "parent_book_review_id",
-      }, {
+      components: [{ otherMetadata: () => authorMeta, otherFieldName: "comments", columnName: "parent_author_id" }, { otherMetadata: () => bookMeta, otherFieldName: "comments", columnName: "parent_book_id" }, { otherMetadata: () => bookReviewMeta, otherFieldName: "comment", columnName: "parent_book_review_id" }, {
         otherMetadata: () => publisherMeta,
         otherFieldName: "comments",
         columnName: "parent_publisher_id",

--- a/packages/tests/integration/src/relations/OneToManyCollection.test.ts
+++ b/packages/tests/integration/src/relations/OneToManyCollection.test.ts
@@ -335,7 +335,7 @@ describe("OneToManyCollection", () => {
     // And getWithDeleted still shows both b1 and b2
     expect(b1.reviews.getWithDeleted.length).toBe(2);
     // And r1 is marked for deletion
-    expect(r1.isPendingDelete).toBe(true);
+    expect(r1.isDeletedEntity).toBe(true);
     await em.flush();
     const rows = await select("book_reviews");
     expect(rows.length).toEqual(1);

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.151.9"
+  "version": "1.151.11"
 }

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.151.9"
+  "version": "1.151.11"
 }

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.151.9"
+  "version": "1.151.11"
 }

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.151.9"
+  "version": "1.151.11"
 }


### PR DESCRIPTION
With the introduction of ReactiveQueryFields, the `em.flush` method basically needs it's "own dirty tracking", such that after we've done the 1st "micro-flush" (new term) to INSERT/UPDATE the entities, and then detect an RQF needs recalced we need to:

* Reset our "internal dirty state" on all of the just-flushed changes, but

* Preseve the "external dirty state" until the very end of em.flush, i.e. after `beforeCommit` hooks run.

Such that, after calling the RQF.recalc we can tell:

* What, if anything, has actually changed in this 2nd micro-flush loop, vs. the 1st micro-flush loop (i.e. in our internal dirty state), but

* External observation, i.e. hooks like `beforeCommit`, that are not called until *all micro-flushes have finished*, can tell what the flush-wide changed/state was (i.e. the external dirty state).

And ideally we'd keep track of both without a lot of duplicative bookkeeping when RQFs just aren't in use.

We achieve this by adding an `#orm.flushedData` hash, that is nearly always `undefined`/ignored, but when we're specifically in an RQF series of micro-flushes, we enable it to record only the "diffs from the last micro-flush".

I also added some wider cleanup to `EntityOrmField`, i.e. making it's `isNew` and `deleted` flags private, and updating code appropriately.