### PR TITLE
feat: Add ReactiveGetters.

### DIFF
--- a/packages/orm/src/relations/ReactiveGetter.ts
+++ b/packages/orm/src/relations/ReactiveGetter.ts
@@ -1,0 +1,56 @@
+import { currentlyInstantiatingEntity } from "../BaseEntity";
+import { Entity } from "../Entity";
+import { Reacted, ShallowReactiveHint } from "../reactiveHints";
+import { AsyncPropertyT } from "./hasAsyncProperty";
+
+/**
+ * A `ReactiveGetter` is a getter that declares what primitive fields it depends on.
+ *
+ * This is very similar to a `ReactiveAsyncProperty`, except because it's limited to
+ * only immediate fields on the entity, it can always have `.get` called, and doesn't
+ * need to be loaded.
+ *
+ * The benefit over a pure getter is that `ReactiveGetter` can be used in reactive
+ * rules and reactive fields, which would otherwise need to use `fullNonReactiveAccess`
+ * to access getter, and risk missing reactivity.
+ */
+export interface ReactiveGetter<T extends Entity, V> {
+  [AsyncPropertyT]: T;
+  get: V;
+}
+
+/** Creates a `ReactiveGetter`, for simple "getters" that still trackable for reactivity. */
+export function hasReactiveGetter<T extends Entity, const H extends ShallowReactiveHint<T>, V>(
+  fieldName: keyof T & string,
+  hint: H,
+  fn: (entity: Reacted<T, H>) => V,
+): ReactiveGetter<T, V> {
+  const entity = currentlyInstantiatingEntity as T;
+  return new ReactiveGetterImpl(entity, fieldName, hint, fn);
+}
+
+export class ReactiveGetterImpl<T extends Entity, const H extends ShallowReactiveHint<T>, V>
+  implements ReactiveGetter<T, V>
+{
+  readonly #entity: T;
+  readonly #fieldName: keyof T & string;
+  readonly #hint: H;
+  readonly #fn: (entity: Reacted<T, H>) => V;
+
+  constructor(entity: T, fieldName: keyof T & string, hint: H, fn: (entity: Reacted<T, H>) => V) {
+    this.#entity = entity;
+    this.#fieldName = fieldName;
+    this.#hint = hint;
+    this.#fn = fn;
+  }
+
+  get get(): V {
+    return this.#fn(this.#entity as any);
+  }
+
+  get reactiveHint(): H {
+    return this.#hint;
+  }
+
+  [AsyncPropertyT] = undefined as any as T;
+}

--- a/packages/orm/src/relations/index.ts
+++ b/packages/orm/src/relations/index.ts
@@ -21,6 +21,7 @@ export {
   isPolymorphicReference,
 } from "./PolymorphicReference";
 export { ReactiveField, hasReactiveField, isReactiveField } from "./ReactiveField";
+export { ReactiveGetter, hasReactiveGetter } from "./ReactiveGetter";
 export { hasReactiveQueryField, isReactiveQueryField } from "./ReactiveQueryField";
 export { ReactiveReference, ReactiveReferenceImpl, hasReactiveReference } from "./ReactiveReference";
 export { LoadedReference, Reference, isLoadedReference, isReference } from "./Reference";

--- a/packages/tests/integration/src/Entity.test.ts
+++ b/packages/tests/integration/src/Entity.test.ts
@@ -88,6 +88,7 @@ describe("Entity", () => {
            "books": {
              "comments": "text",
            },
+           "hasLowerCaseFirstName": {},
          },
        },
        "booksTitles": {
@@ -113,6 +114,7 @@ describe("Entity", () => {
          },
          "undefined": null,
        },
+       "hasLowerCaseFirstName": {},
        "latestComment": {
          "loadPromise": undefined,
          "opts": {

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -4,6 +4,7 @@ import {
   Collection,
   Loaded,
   ReactiveField,
+  ReactiveGetter,
   ReactiveReference,
   Reference,
   cannotBeUpdated,
@@ -14,6 +15,7 @@ import {
   hasOneDerived,
   hasReactiveAsyncProperty,
   hasReactiveField,
+  hasReactiveGetter,
   hasReactiveReference,
   isDefined,
   withLoaded,
@@ -188,7 +190,8 @@ export class Author extends AuthorCodegen {
   /** Example of a derived async property that can be calculated via a populate hint through a polymorphic reference. */
   readonly bookComments: ReactiveField<Author, string> = hasReactiveField(
     "bookComments",
-    { books: { comments: "text" } },
+    // ...and throw in hasLowerCaseFirstName to test ReactiveGetters
+    { books: { comments: "text" }, hasLowerCaseFirstName: {} },
     (a) => {
       a.transientFields.bookCommentsCalcInvoked++;
       return a.books.get
@@ -246,6 +249,13 @@ export class Author extends AuthorCodegen {
   // explicitly called, vs. AsyncProperties that implicitly call `.get` whenever loaded.
   readonly booksTitles: AsyncMethod<Author, [], string> = hasAsyncMethod("books", (a) =>
     a.books.get.map((b) => b.title).join(", "),
+  );
+
+  // Example of a reactive getter that can always be gotten
+  readonly hasLowerCaseFirstName: ReactiveGetter<Author, boolean> = hasReactiveGetter(
+    "hasLowerCaseFirstName",
+    "firstName",
+    (a) => a.firstName.toLowerCase() === a.firstName,
   );
 }
 

--- a/packages/tests/integration/src/relations/ReactiveGetter.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveGetter.test.ts
@@ -1,0 +1,28 @@
+import { Author } from "src/entities";
+import { insertAuthor } from "src/entities/inserts";
+import { newEntityManager } from "src/testEm";
+
+describe("ReactiveGetter", () => {
+  it("can be called without being loaded", async () => {
+    await insertAuthor({ first_name: "a1" });
+    const em = newEntityManager();
+    const a1 = await em.load(Author, "a:1");
+    expect(a1.hasLowerCaseFirstName.get).toBe(true);
+  });
+
+  it("exposes the reactiveHint", async () => {
+    await insertAuthor({ first_name: "a1" });
+    const em = newEntityManager();
+    const a1 = await em.load(Author, "a:1");
+    expect((a1.hasLowerCaseFirstName as any).reactiveHint).toBe("firstName");
+  });
+
+  it("causes downstream ReactiveFields to recalc", async () => {
+    await insertAuthor({ first_name: "a1" });
+    const em = newEntityManager();
+    const a1 = await em.load(Author, "a:1");
+    a1.firstName = "a2";
+    await em.flush();
+    expect(a1.transientFields.bookCommentsCalcInvoked).toBe(1);
+  });
+});


### PR DESCRIPTION
These provide a way to have dumb/simple/always-get-able getters, but still denote/advertise the underlying primitive fields that are being used, so that the reactivity infra can setup dependency tracking appropriately.

Fixes #1007 