### PR TITLE
fix: Fix columns shared across CTI subtypes.

### DIFF
--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -28,7 +28,7 @@
     "joist-utils": "workspace:*",
     "jscodeshift": "^0.15.1",
     "knex": "^3.1.0",
-    "pg": "^8.11.3",
+    "pg": "^8.11.5",
     "pg-structure": "^7.15.2",
     "pluralize": "^8.0.0",
     "semver": "^7.5.4",

--- a/packages/migration-utils/package.json
+++ b/packages/migration-utils/package.json
@@ -19,7 +19,7 @@
     "@types/pluralize": "0.0.33",
     "joist-utils": "workspace:*",
     "node-pg-migrate": "^6.2.2",
-    "pg": "^8.11.3",
+    "pg": "^8.11.5",
     "pg-structure": "^7.15.2",
     "pluralize": "^8.0.0"
   },

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -24,7 +24,7 @@
     "joist-utils": "workspace:*",
     "knex": "^3.1.0",
     "object-hash": "^3.0.0",
-    "pg": "^8.11.3",
+    "pg": "^8.11.5",
     "pg-types": "^4.0.2"
   },
   "devDependencies": {

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -85,5 +85,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.151.14"
+  "version": "1.152.3"
 }

--- a/packages/tests/integration/migrations/1580658856631_author.ts
+++ b/packages/tests/integration/migrations/1580658856631_author.ts
@@ -61,10 +61,14 @@ export function up(b: MigrationBuilder): void {
   // Create two subclass tables
   createSubTable(b, "publishers", "small_publishers", {
     city: { type: "text", notNull: true },
+    // For testing columns shared between CTI subtypes
+    shared_column: { type: "text" },
     // Used to test reactive fields that only exist on a subtype
     all_author_names: { type: "text" },
   });
   createSubTable(b, "publishers", "large_publishers", {
+    // For testing columns shared between CTI subtypes
+    shared_column: { type: "text" },
     country: "text",
   });
 

--- a/packages/tests/integration/schema/.history.json
+++ b/packages/tests/integration/schema/.history.json
@@ -141,6 +141,7 @@
     "longitude",
     "name",
     "numberOfBookReviews",
+    "sharedColumn",
     "size",
     "tags",
     "tasks",
@@ -315,6 +316,7 @@
     "latitude",
     "longitude",
     "name",
+    "sharedColumn",
     "size",
     "type"
   ],
@@ -355,6 +357,7 @@
     "latitude",
     "longitude",
     "name",
+    "sharedColumn",
     "size",
     "type"
   ],
@@ -412,6 +415,7 @@
     "longitude",
     "name",
     "numberOfBookReviews",
+    "sharedColumn",
     "size",
     "tags",
     "tasks",

--- a/packages/tests/integration/schema/largePublisher.graphql
+++ b/packages/tests/integration/schema/largePublisher.graphql
@@ -23,6 +23,7 @@ type LargePublisher {
   numberOfBookReviews: Int
   tasks: [Task!]!
   deletedAt: DateTime
+  sharedColumn: String
 }
 
 input SaveLargePublisherInput {
@@ -36,6 +37,7 @@ input SaveLargePublisherInput {
   type: PublisherType
   groupId: ID
   deletedAt: DateTime
+  sharedColumn: String
 }
 
 type SaveLargePublisherResult {

--- a/packages/tests/integration/schema/smallPublisher.graphql
+++ b/packages/tests/integration/schema/smallPublisher.graphql
@@ -23,6 +23,7 @@ type SmallPublisher {
   numberOfBookReviews: Int
   tasks: [Task!]!
   deletedAt: DateTime
+  sharedColumn: String
 }
 
 input SaveSmallPublisherInput {
@@ -36,6 +37,7 @@ input SaveSmallPublisherInput {
   type: PublisherType
   groupId: ID
   deletedAt: DateTime
+  sharedColumn: String
 }
 
 type SaveSmallPublisherResult {

--- a/packages/tests/integration/src/EntityManager.find.batch.test.ts
+++ b/packages/tests/integration/src/EntityManager.find.batch.test.ts
@@ -32,6 +32,7 @@ describe("EntityManager.find.batch", () => {
       [
         `WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) )`,
         ` SELECT array_agg(_find.tag) as _tags, p.*, p_s0.*, p_s1.*, p.id as id,`,
+        ` COALESCE(p_s0.shared_column, p_s1.shared_column) as shared_column,`,
         ` CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class`,
         ` FROM publishers as p`,
         ` LEFT OUTER JOIN large_publishers p_s0 ON p.id = p_s0.id`,

--- a/packages/tests/integration/src/EntityManager.lens.test.ts
+++ b/packages/tests/integration/src/EntityManager.lens.test.ts
@@ -198,7 +198,7 @@ describe("EntityManager.lens", () => {
       expect(em.entities.length).toBe(2);
 
       expect(lastQuery()).toMatchInlineSnapshot(
-        `"select "p".*, p_s0.*, p_s1.*, p.id as id, CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class, "i".id as __source_id from publishers as p left outer join large_publishers as p_s0 on p.id = p_s0.id left outer join small_publishers as p_s1 on p.id = p_s1.id inner join authors as a on a.publisher_id = p.id inner join images as i on i.author_id = a.id where a.deleted_at is null and i.id = any($1) order by p.id ASC limit $2"`,
+        `"select "p".*, p_s0.*, p_s1.*, p.id as id, COALESCE(p_s0.shared_column, p_s1.shared_column) as shared_column, CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class, "i".id as __source_id from publishers as p left outer join large_publishers as p_s0 on p.id = p_s0.id left outer join small_publishers as p_s1 on p.id = p_s1.id inner join authors as a on a.publisher_id = p.id inner join images as i on i.author_id = a.id where a.deleted_at is null and i.id = any($1) order by p.id ASC limit $2"`,
       );
     });
 
@@ -217,7 +217,7 @@ describe("EntityManager.lens", () => {
       expect(em.entities.length).toBe(2);
 
       expect(lastQuery()).toMatchInlineSnapshot(
-        `"select "p".*, p_s0.*, p_s1.*, p.id as id, CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class, "b".id as __source_id from publishers as p left outer join large_publishers as p_s0 on p.id = p_s0.id left outer join small_publishers as p_s1 on p.id = p_s1.id inner join authors as a on a.publisher_id = p.id inner join books as b on b.author_id = a.id where a.deleted_at is null and b.deleted_at is null and b.id = any($1) order by p.id ASC limit $2"`,
+        `"select "p".*, p_s0.*, p_s1.*, p.id as id, COALESCE(p_s0.shared_column, p_s1.shared_column) as shared_column, CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class, "b".id as __source_id from publishers as p left outer join large_publishers as p_s0 on p.id = p_s0.id left outer join small_publishers as p_s1 on p.id = p_s1.id inner join authors as a on a.publisher_id = p.id inner join books as b on b.author_id = a.id where a.deleted_at is null and b.deleted_at is null and b.id = any($1) order by p.id ASC limit $2"`,
       );
     });
 

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -816,7 +816,7 @@ describe("EntityManager.queries", () => {
     expect(pubs.length).toEqual(2);
 
     expect(parseFindQuery(pm, where)).toMatchObject({
-      selects: [`p.*`, "p_s0.*", "p_s1.*", `p.id as id`, expect.anything()],
+      selects: [`p.*`, "p_s0.*", "p_s1.*", `p.id as id`, expect.stringContaining("shared_column"), expect.anything()],
       tables: [{ alias: "p", table: "publishers", join: "primary" }, expect.anything(), expect.anything()],
       condition: {
         op: "and",
@@ -839,7 +839,14 @@ describe("EntityManager.queries", () => {
     expect(pubs.length).toEqual(2);
 
     expect(parseFindQuery(pm, where, opts)).toMatchObject({
-      selects: [`p.*`, "p_s0.*", "p_s1.*", `p.id as id`, expect.anything()],
+      selects: [
+        `p.*`,
+        "p_s0.*",
+        "p_s1.*",
+        `p.id as id`,
+        expect.stringContaining("shared_column"),
+        expect.stringContaining("__class"),
+      ],
       tables: [
         { alias: "p", table: "publishers", join: "primary" },
         { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id", distinct: false },
@@ -863,7 +870,15 @@ describe("EntityManager.queries", () => {
     expect(pubs.length).toEqual(2);
 
     expect(parseFindQuery(pm, where, opts)).toMatchObject({
-      selects: [`p.*`, "p_s0.*", "p_s1.*", `p.id as id`, expect.anything()],
+      selects: [
+        `p.*`,
+        "p_s0.*",
+        "p_s1.*",
+        `p.id as id`,
+
+        expect.stringContaining("shared_column"),
+        expect.stringContaining("__class"),
+      ],
       tables: [{ alias: "p", table: "publishers", join: "primary" }, expect.anything(), expect.anything()],
       condition: {
         op: "and",
@@ -889,7 +904,8 @@ describe("EntityManager.queries", () => {
         "p_s0.*",
         "p_s1.*",
         `p.id as id`,
-        "CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class",
+        expect.stringContaining("shared_column"),
+        expect.stringContaining("__class"),
       ],
       tables: [
         { alias: "p", table: "publishers", join: "primary" },
@@ -915,7 +931,14 @@ describe("EntityManager.queries", () => {
     expect(pubs[0].name).toEqual("p1");
 
     expect(parseFindQuery(pm, where, opts)).toMatchObject({
-      selects: [`p.*`, "p_s0.*", "p_s1.*", `p.id as id`, expect.anything()],
+      selects: [
+        `p.*`,
+        "p_s0.*",
+        "p_s1.*",
+        `p.id as id`,
+        expect.stringContaining("shared_column"),
+        expect.stringContaining("__class"),
+      ],
       tables: [
         { alias: "p", table: "publishers", join: "primary" },
         { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id", distinct: false },

--- a/packages/tests/integration/src/EntityManager.test.ts
+++ b/packages/tests/integration/src/EntityManager.test.ts
@@ -1232,6 +1232,7 @@ describe("EntityManager", () => {
       numberOfBookReviews: null,
       group: null,
       hugeNumber: null,
+      sharedColumn: null,
       size: null,
       type: PublisherType.Big,
       createdAt: expect.anything(),

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -55,10 +55,12 @@ export type LargePublisherId = Flavor<string, LargePublisher> & Flavor<string, "
 
 export interface LargePublisherFields extends PublisherFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  sharedColumn: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   country: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
 }
 
 export interface LargePublisherOpts extends PublisherOpts {
+  sharedColumn?: string | null;
   country?: string | null;
   critics?: Critic[];
   users?: User[];
@@ -70,18 +72,21 @@ export interface LargePublisherIdsOpts extends PublisherIdsOpts {
 }
 
 export interface LargePublisherFilter extends PublisherFilter {
+  sharedColumn?: ValueFilter<string, null>;
   country?: ValueFilter<string, null>;
   critics?: EntityFilter<Critic, CriticId, FilterOf<Critic>, null | undefined>;
   users?: EntityFilter<User, UserId, FilterOf<User>, null | undefined>;
 }
 
 export interface LargePublisherGraphQLFilter extends PublisherGraphQLFilter {
+  sharedColumn?: ValueGraphQLFilter<string>;
   country?: ValueGraphQLFilter<string>;
   critics?: EntityGraphQLFilter<Critic, CriticId, GraphQLFilterOf<Critic>, null | undefined>;
   users?: EntityGraphQLFilter<User, UserId, GraphQLFilterOf<User>, null | undefined>;
 }
 
 export interface LargePublisherOrder extends PublisherOrder {
+  sharedColumn?: OrderBy;
   country?: OrderBy;
 }
 
@@ -120,6 +125,14 @@ export abstract class LargePublisherCodegen extends Publisher implements Entity 
 
   get idTaggedMaybe(): TaggedId | undefined {
     return getField(this, "id");
+  }
+
+  get sharedColumn(): string | undefined {
+    return getField(this, "sharedColumn");
+  }
+
+  set sharedColumn(sharedColumn: string | undefined) {
+    setField(this, "sharedColumn", cleanStringValue(sharedColumn));
   }
 
   get country(): string | undefined {

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -55,11 +55,13 @@ export type SmallPublisherId = Flavor<string, SmallPublisher> & Flavor<string, "
 export interface SmallPublisherFields extends PublisherFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };
   city: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
+  sharedColumn: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   allAuthorNames: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: true };
 }
 
 export interface SmallPublisherOpts extends PublisherOpts {
   city: string;
+  sharedColumn?: string | null;
   users?: User[];
 }
 
@@ -69,18 +71,21 @@ export interface SmallPublisherIdsOpts extends PublisherIdsOpts {
 
 export interface SmallPublisherFilter extends PublisherFilter {
   city?: ValueFilter<string, never>;
+  sharedColumn?: ValueFilter<string, null>;
   allAuthorNames?: ValueFilter<string, null>;
   users?: EntityFilter<User, UserId, FilterOf<User>, null | undefined>;
 }
 
 export interface SmallPublisherGraphQLFilter extends PublisherGraphQLFilter {
   city?: ValueGraphQLFilter<string>;
+  sharedColumn?: ValueGraphQLFilter<string>;
   allAuthorNames?: ValueGraphQLFilter<string>;
   users?: EntityGraphQLFilter<User, UserId, GraphQLFilterOf<User>, null | undefined>;
 }
 
 export interface SmallPublisherOrder extends PublisherOrder {
   city?: OrderBy;
+  sharedColumn?: OrderBy;
   allAuthorNames?: OrderBy;
 }
 
@@ -129,6 +134,14 @@ export abstract class SmallPublisherCodegen extends Publisher implements Entity 
 
   set city(city: string) {
     setField(this, "city", cleanStringValue(city));
+  }
+
+  get sharedColumn(): string | undefined {
+    return getField(this, "sharedColumn");
+  }
+
+  set sharedColumn(sharedColumn: string | undefined) {
+    setField(this, "sharedColumn", cleanStringValue(sharedColumn));
   }
 
   abstract readonly allAuthorNames: ReactiveField<SmallPublisher, string | undefined>;

--- a/packages/tests/integration/src/entities/codegen/metadata.ts
+++ b/packages/tests/integration/src/entities/codegen/metadata.ts
@@ -547,6 +547,7 @@ export const largePublisherMeta: EntityMetadata<LargePublisher> = {
   tableName: "large_publishers",
   fields: {
     "id": { kind: "primaryKey", fieldName: "id", fieldIdName: undefined, required: true, serde: new KeySerde("p", "id", "id", "int"), immutable: true },
+    "sharedColumn": { kind: "primitive", fieldName: "sharedColumn", fieldIdName: undefined, derived: false, required: false, protected: false, type: "string", serde: new PrimitiveSerde("sharedColumn", "shared_column", "text"), immutable: false },
     "country": { kind: "primitive", fieldName: "country", fieldIdName: undefined, derived: false, required: false, protected: false, type: "string", serde: new PrimitiveSerde("country", "country", "text"), immutable: false },
     "critics": { kind: "o2m", fieldName: "critics", fieldIdName: "criticIds", required: false, otherMetadata: () => criticMeta, otherFieldName: "favoriteLargePublisher", serde: undefined, immutable: false },
     "users": { kind: "o2m", fieldName: "users", fieldIdName: "userIds", required: false, otherMetadata: () => userMeta, otherFieldName: "favoritePublisher", serde: undefined, immutable: false },
@@ -696,6 +697,7 @@ export const smallPublisherMeta: EntityMetadata<SmallPublisher> = {
   fields: {
     "id": { kind: "primaryKey", fieldName: "id", fieldIdName: undefined, required: true, serde: new KeySerde("p", "id", "id", "int"), immutable: true },
     "city": { kind: "primitive", fieldName: "city", fieldIdName: undefined, derived: false, required: true, protected: false, type: "string", serde: new PrimitiveSerde("city", "city", "text"), immutable: false },
+    "sharedColumn": { kind: "primitive", fieldName: "sharedColumn", fieldIdName: undefined, derived: false, required: false, protected: false, type: "string", serde: new PrimitiveSerde("sharedColumn", "shared_column", "text"), immutable: false },
     "allAuthorNames": { kind: "primitive", fieldName: "allAuthorNames", fieldIdName: undefined, derived: "async", required: false, protected: false, type: "string", serde: new PrimitiveSerde("allAuthorNames", "all_author_names", "text"), immutable: false },
     "users": { kind: "o2m", fieldName: "users", fieldIdName: "userIds", required: false, otherMetadata: () => userMeta, otherFieldName: "favoritePublisher", serde: undefined, immutable: false },
   },

--- a/packages/tests/integration/src/entities/inserts.ts
+++ b/packages/tests/integration/src/entities/inserts.ts
@@ -127,11 +127,17 @@ export async function insertPublisher(row: {
   size_id?: number;
   group_id?: number;
   city?: string;
+  shared_column?: string;
   updated_at?: Date;
   deleted_at?: Date;
 }) {
-  await testDriver.insert("publishers", row);
-  await testDriver.insert("small_publishers", { id: row.id ?? 1, city: row.city ?? "city" });
+  const { shared_column, ...others } = row;
+  await testDriver.insert("publishers", others);
+  await testDriver.insert("small_publishers", {
+    id: row.id ?? 1,
+    city: row.city ?? "city",
+    shared_column: row.shared_column,
+  });
 }
 
 /** Inserts a large publisher, into `publishers` and `large_publishers`. */
@@ -143,12 +149,13 @@ export async function insertLargePublisher(row: {
   huge_number?: string | number;
   size_id?: number;
   group_id?: number;
+  shared_column?: string;
   country?: string;
   updated_at?: Date;
 }) {
-  const { country = "country", ...others } = row;
+  const { country = "country", shared_column, ...others } = row;
   await testDriver.insert("publishers", others);
-  await testDriver.insert("large_publishers", { id: row.id ?? 1, country });
+  await testDriver.insert("large_publishers", { id: row.id ?? 1, country, shared_column });
 }
 
 export function insertTag(row: { id?: number; name: string }) {

--- a/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
@@ -21,7 +21,7 @@ describe("ReactiveQueryField", () => {
        "BEGIN;",
        "select nextval('publishers_id_seq') from generate_series(1, 1)",
        "INSERT INTO "publishers" ("id", "name", "latitude", "longitude", "huge_number", "number_of_book_reviews", "deleted_at", "created_at", "updated_at", "size_id", "type_id", "group_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
-       "INSERT INTO "large_publishers" ("id", "country") VALUES ($1, $2)",
+       "INSERT INTO "large_publishers" ("id", "shared_column", "country") VALUES ($1, $2, $3)",
        "select distinct count(distinct "br".id) as count from book_reviews as br inner join books as b on br.book_id = b.id inner join authors as a on b.author_id = a.id left outer join publishers as p on a.publisher_id = p.id where b.deleted_at is null and a.deleted_at is null and p.deleted_at is null and p.id = $1 limit $2",
        "COMMIT;",
      ]
@@ -44,7 +44,7 @@ describe("ReactiveQueryField", () => {
        "select nextval('publishers_id_seq') from generate_series(1, 1) UNION ALL select nextval('authors_id_seq') from generate_series(1, 1) UNION ALL select nextval('books_id_seq') from generate_series(1, 2) UNION ALL select nextval('book_reviews_id_seq') from generate_series(1, 2)",
        "BEGIN;",
        "INSERT INTO "publishers" ("id", "name", "latitude", "longitude", "huge_number", "number_of_book_reviews", "deleted_at", "created_at", "updated_at", "size_id", "type_id", "group_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
-       "INSERT INTO "large_publishers" ("id", "country") VALUES ($1, $2)",
+       "INSERT INTO "large_publishers" ("id", "shared_column", "country") VALUES ($1, $2, $3)",
        "INSERT INTO "authors" ("id", "first_name", "last_name", "ssn", "initials", "number_of_books", "book_comments", "is_popular", "age", "graduated", "nick_names", "nick_names_upper", "was_ever_popular", "address", "business_address", "quotes", "number_of_atoms", "deleted_at", "number_of_public_reviews", "numberOfPublicReviews2", "tags_of_all_books", "search", "created_at", "updated_at", "favorite_shape", "range_of_books", "favorite_colors", "mentor_id", "current_draft_book_id", "favorite_book_id", "publisher_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31)",
        "INSERT INTO "books" ("id", "title", "order", "notes", "deleted_at", "created_at", "updated_at", "author_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8),($9, $10, $11, $12, $13, $14, $15, $16)",
        "INSERT INTO "book_reviews" ("id", "rating", "is_public", "is_test", "created_at", "updated_at", "book_id", "critic_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8),($9, $10, $11, $12, $13, $14, $15, $16)",

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.151.14"
+  "version": "1.152.3"
 }

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.151.14"
+  "version": "1.152.3"
 }

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.151.14"
+  "version": "1.152.3"
 }

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.151.14"
+  "version": "1.152.3"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,7 +8,7 @@
     "build"
   ],
   "dependencies": {
-    "pg": "^8.11.3",
+    "pg": "^8.11.5",
     "pg-connection-string": "^2.6.2"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10885,7 +10885,7 @@ __metadata:
     joist-utils: "workspace:*"
     jscodeshift: "npm:^0.15.1"
     knex: "npm:^3.1.0"
-    pg: "npm:^8.11.3"
+    pg: "npm:^8.11.5"
     pg-structure: "npm:^7.15.2"
     pluralize: "npm:^8.0.0"
     prettier: "npm:^3.2.5"
@@ -10957,7 +10957,7 @@ __metadata:
     jest: "npm:30.0.0-alpha.3"
     joist-utils: "workspace:*"
     node-pg-migrate: "npm:^6.2.2"
-    pg: "npm:^8.11.3"
+    pg: "npm:^8.11.5"
     pg-structure: "npm:^7.15.2"
     pluralize: "npm:^8.0.0"
     prettier: "npm:^3.2.5"
@@ -10982,7 +10982,7 @@ __metadata:
     joist-utils: "workspace:*"
     knex: "npm:^3.1.0"
     object-hash: "npm:^3.0.0"
-    pg: "npm:^8.11.3"
+    pg: "npm:^8.11.5"
     pg-types: "npm:^4.0.2"
     prettier: "npm:^3.2.5"
     prettier-plugin-organize-imports: "npm:^3.2.4"
@@ -11187,7 +11187,7 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.10.5"
     jest: "npm:30.0.0-alpha.3"
-    pg: "npm:^8.11.3"
+    pg: "npm:^8.11.5"
     pg-connection-string: "npm:^2.6.2"
     prettier: "npm:^3.2.5"
     prettier-plugin-organize-imports: "npm:^3.2.4"
@@ -14313,6 +14313,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pg-connection-string@npm:^2.6.4":
+  version: 2.6.4
+  resolution: "pg-connection-string@npm:2.6.4"
+  checksum: 10/2c1d2ac1add1f93076f1594d217a0980f79add05dc48de6363e1c550827c78a6ee3e3b5420da9c54858f6b678cdb348aed49732ee68158b6cdb70f1d1c748cf9
+  languageName: node
+  linkType: hard
+
 "pg-int8@npm:1.0.1":
   version: 1.0.1
   resolution: "pg-int8@npm:1.0.1"
@@ -14336,10 +14343,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pg-pool@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "pg-pool@npm:3.6.2"
+  peerDependencies:
+    pg: ">=8.0"
+  checksum: 10/d5ccefb9a4913c737e07106ada841c7d8f2b110b02ef6b4cee198e1e7e758bac43cb3b6df7646e25858b9fe300db00f2f349868296fbd4b3b4c99c15906d1596
+  languageName: node
+  linkType: hard
+
 "pg-protocol@npm:*, pg-protocol@npm:^1.6.0":
   version: 1.6.0
   resolution: "pg-protocol@npm:1.6.0"
   checksum: 10/995864cc2a8517368b84697c753caff769a4db292eda66f96d9eec46e3aa84737cd0b0fe171aca9d7d4b4a4c46bb25bd399713cb1027a5bf8f38adea0b4284f4
+  languageName: node
+  linkType: hard
+
+"pg-protocol@npm:^1.6.1":
+  version: 1.6.1
+  resolution: "pg-protocol@npm:1.6.1"
+  checksum: 10/9af672208adae8214f55f5b4597c4699ab9946205a99863d3e2bb8d024fdab16711457b539bc366cc29040218aa87508cf61294b76d288f48881b973d9117bd6
   languageName: node
   linkType: hard
 
@@ -14388,7 +14411,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg@npm:^8.0.3, pg@npm:^8.11.3":
+"pg@npm:^8.0.3":
   version: 8.11.3
   resolution: "pg@npm:8.11.3"
   dependencies:
@@ -14409,6 +14432,28 @@ __metadata:
     pg-native:
       optional: true
   checksum: 10/f15f29c8e17723ee1da72abdf400cbed2c04602c58c93687f3f0068e71df2a6fb62b9a3543e13da21b10a0494f4c5b4cfc8d6cd8396617b76c4cbfd6ddab17e7
+  languageName: node
+  linkType: hard
+
+"pg@npm:^8.11.5":
+  version: 8.11.5
+  resolution: "pg@npm:8.11.5"
+  dependencies:
+    pg-cloudflare: "npm:^1.1.1"
+    pg-connection-string: "npm:^2.6.4"
+    pg-pool: "npm:^3.6.2"
+    pg-protocol: "npm:^1.6.1"
+    pg-types: "npm:^2.1.0"
+    pgpass: "npm:1.x"
+  peerDependencies:
+    pg-native: ">=3.0.1"
+  dependenciesMeta:
+    pg-cloudflare:
+      optional: true
+  peerDependenciesMeta:
+    pg-native:
+      optional: true
+  checksum: 10/1510bc42943ea1749bfffac3f7ebae52ae638dc798e38786552fc67ffc0b2e4bd54456e7fd5cda7e805f30a0a59126c98e8c59afa88b6952f95411f16a16f709
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
A recent pg bug fix means the last-selected column is what is returned, instead of the last-not-null column which was a pretty convenient "implicit coalesce" that we had been unwittingly relying on.

Fixes #1019.