### PR TITLE
fix: Update setDefault to allow returning a Reacted entity.

### DIFF
--- a/packages/tests/integration/src/entities/Book.ts
+++ b/packages/tests/integration/src/entities/Book.ts
@@ -49,10 +49,21 @@ config.setDefault("notes", (b) => `Notes for ${b.title}`);
 config.setDefault("order", { author: "books" }, (b) => b.author.get?.books.get.length);
 
 /** Example of an asynchronous default that returns an entity. */
-config.setDefault("author", "title", async (b, { em }) => {
-  // See if we have an author with the same name as the book title
-  return em.findOne(Author, { lastName: b.title });
-});
+config.setDefault(
+  "author",
+  {
+    // Elaborate hint to test returning a Reacted<Author>
+    tags: { publishers: "authors" },
+    title: {},
+  },
+  async (b, { em }) => {
+    // Test returning a Reacted<Author> can pass type check
+    const maybeAuthor = b.tags.get[0]?.publishers.get[0]?.authors.get[0];
+    if (maybeAuthor) return maybeAuthor;
+    // See if we have an author with the same name as the book title
+    return em.findOne(Author, { lastName: b.title });
+  },
+);
 
 config.cascadeDelete("reviews");
 


### PR DESCRIPTION
Somewhat optimistically, the setDefault lambda uses ReactiveHints so that maybe we can do cross-default field precedence detection someday.

Which is cool, but it means the lambdas return Reacted<...> instead of the pure entity, so add a fix + coverage for that behavior.

Fixes #1018.