### PR TITLE
fix: additional missing type imports

### DIFF
--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -823,7 +823,7 @@ function zodSchemaType(s: string): Code {
 }
 
 function userFieldTypeType(s: string): Import {
-  return Import.from(s);
+  return Import.from(`t:${s}`);
 }
 
 function serdeType(s: string): Import {

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -401,11 +401,11 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
   const baseEntity = dbMeta.entities.find((e) => e.name === meta.baseClassName);
   const subEntities = dbMeta.entities.filter((e) => e.baseClassName === meta.name);
   const base = baseEntity?.entity.type ?? code`${BaseEntity}<${EntityManager}, ${idType}>`;
-  const maybeBaseFields = baseEntity ? code`extends ${imp(baseEntity.name + "Fields@./entities.ts")}` : "";
+  const maybeBaseFields = baseEntity ? code`extends ${imp('t:' + baseEntity.name + "Fields@./entities.ts")}` : "";
   const maybeBaseOpts = baseEntity ? code`extends ${baseEntity.entity.optsType}` : "";
-  const maybeBaseIdOpts = baseEntity ? code`extends ${imp(baseEntity.name + "IdsOpts@./entities.ts")}` : "";
-  const maybeBaseFilter = baseEntity ? code`extends ${imp(baseEntity.name + "Filter@./entities.ts")}` : "";
-  const maybeBaseGqlFilter = baseEntity ? code`extends ${imp(baseEntity.name + "GraphQLFilter@./entities.ts")}` : "";
+  const maybeBaseIdOpts = baseEntity ? code`extends ${imp('t:' + baseEntity.name + "IdsOpts@./entities.ts")}` : "";
+  const maybeBaseFilter = baseEntity ? code`extends ${imp('t:' + baseEntity.name + "Filter@./entities.ts")}` : "";
+  const maybeBaseGqlFilter = baseEntity ? code`extends ${imp('t:' + baseEntity.name + "GraphQLFilter@./entities.ts")}` : "";
   const maybeBaseOrder = baseEntity ? code`extends ${baseEntity.entity.orderType}` : "";
   const maybeBaseId = baseEntity ? code` & Flavor<${idType}, "${baseEntity.name}">` : "";
   const maybePreventBaseTypeInstantiation = meta.abstract

--- a/packages/tests/esm-misc/joist-config.json
+++ b/packages/tests/esm-misc/joist-config.json
@@ -10,5 +10,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.154.0"
+  "version": "1.155.1"
 }

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -90,5 +90,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.154.0"
+  "version": "1.155.1"
 }

--- a/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
@@ -26,18 +26,8 @@ import type {
   ValueGraphQLFilter,
 } from "joist-orm";
 import type { Context } from "src/context";
-import {
-  AdminUser,
-  adminUserMeta,
-  EntityManager,
-  newAdminUser,
-  User,
-  UserFields,
-  UserFilter,
-  UserGraphQLFilter,
-  UserIdsOpts,
-} from "../entities";
-import type { Entity, UserOpts, UserOrder } from "../entities";
+import { AdminUser, adminUserMeta, EntityManager, newAdminUser, User } from "../entities";
+import type { Entity, UserFields, UserFilter, UserGraphQLFilter, UserIdsOpts, UserOpts, UserOrder } from "../entities";
 
 export type AdminUserId = Flavor<string, AdminUser> & Flavor<string, "User">;
 

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -40,14 +40,20 @@ import {
   largePublisherMeta,
   newLargePublisher,
   Publisher,
+  User,
+  userMeta,
+} from "../entities";
+import type {
+  CriticId,
+  Entity,
   PublisherFields,
   PublisherFilter,
   PublisherGraphQLFilter,
   PublisherIdsOpts,
-  User,
-  userMeta,
+  PublisherOpts,
+  PublisherOrder,
+  UserId,
 } from "../entities";
-import type { CriticId, Entity, PublisherOpts, PublisherOrder, UserId } from "../entities";
 
 export type LargePublisherId = Flavor<string, LargePublisher> & Flavor<string, "Publisher">;
 

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -38,16 +38,21 @@ import {
   EntityManager,
   newSmallPublisher,
   Publisher,
-  PublisherFields,
-  PublisherFilter,
-  PublisherGraphQLFilter,
-  PublisherIdsOpts,
   SmallPublisher,
   smallPublisherMeta,
   User,
   userMeta,
 } from "../entities";
-import type { Entity, PublisherOpts, PublisherOrder, UserId } from "../entities";
+import type {
+  Entity,
+  PublisherFields,
+  PublisherFilter,
+  PublisherGraphQLFilter,
+  PublisherIdsOpts,
+  PublisherOpts,
+  PublisherOrder,
+  UserId,
+} from "../entities";
 
 export type SmallPublisherId = Flavor<string, SmallPublisher> & Flavor<string, "Publisher">;
 

--- a/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
@@ -39,16 +39,23 @@ import {
   EntityManager,
   newTaskNew,
   Task,
-  TaskFields,
-  TaskFilter,
-  TaskGraphQLFilter,
-  TaskIdsOpts,
   TaskItem,
   taskItemMeta,
   TaskNew,
   taskNewMeta,
 } from "../entities";
-import type { AuthorId, AuthorOrder, Entity, TaskItemId, TaskOpts, TaskOrder } from "../entities";
+import type {
+  AuthorId,
+  AuthorOrder,
+  Entity,
+  TaskFields,
+  TaskFilter,
+  TaskGraphQLFilter,
+  TaskIdsOpts,
+  TaskItemId,
+  TaskOpts,
+  TaskOrder,
+} from "../entities";
 
 export type TaskNewId = Flavor<string, TaskNew> & Flavor<string, "Task">;
 

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -44,16 +44,23 @@ import {
   Publisher,
   publisherMeta,
   Task,
-  TaskFields,
-  TaskFilter,
-  TaskGraphQLFilter,
-  TaskIdsOpts,
   TaskItem,
   taskItemMeta,
   TaskOld,
   taskOldMeta,
 } from "../entities";
-import type { CommentId, Entity, PublisherId, TaskItemId, TaskOpts, TaskOrder } from "../entities";
+import type {
+  CommentId,
+  Entity,
+  PublisherId,
+  TaskFields,
+  TaskFilter,
+  TaskGraphQLFilter,
+  TaskIdsOpts,
+  TaskItemId,
+  TaskOpts,
+  TaskOrder,
+} from "../entities";
 
 export type TaskOldId = Flavor<string, TaskOld> & Flavor<string, "Task">;
 

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -43,7 +43,7 @@ import type {
   ValueGraphQLFilter,
 } from "joist-orm";
 import type { Context } from "src/context";
-import { IpAddress, PasswordValue } from "src/entities/types";
+import type { IpAddress, PasswordValue } from "src/entities/types";
 import {
   AdminUser,
   Author,

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.154.0"
+  "version": "1.155.1"
 }

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.154.0"
+  "version": "1.155.1"
 }

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.154.0"
+  "version": "1.155.1"
 }

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.154.0"
+  "version": "1.155.1"
 }


### PR DESCRIPTION
When I have more time I'll look in to expanding out the esm test dir to catch these;

This PR follows up on #1029 with some rarer usages I missed but hit when running in our app.

These are namely:
- user defined types in FieldConfig
- subtype 'extends' - such as `interface SmallPublisherFields extends from PublisherFields`

I've validated these changes our our app through a patch, but we're not using all functionality of joist, so no promises this is everything. We're using zod, types and CTI though, so decent coverage.

Sorry for the hotfix!