### PR TITLE
fix: directly import entities from metadata.ts, support top level await

### DIFF
--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -45,6 +45,8 @@ export type Entity = {
   name: string;
   /** The symbol pointing to the entity itself. */
   type: Import;
+  /** The symbol pointing to the entity itself, directly rather than via entities.ts */
+  typeForMetadataFile: Import;
   /** The name of the entity's runtime metadata const. */
   metaName: string;
   /** The symbol pointing to the entity's runtime metadata const. */
@@ -774,6 +776,7 @@ export function makeEntity(entityName: string): Entity {
   return {
     name: entityName,
     type: entityType(entityName),
+    typeForMetadataFile: entityTypeForMetadataFile(entityName),
     metaName: metaName(entityName),
     metaType: metaType(entityName),
     idType: imp(`t:${entityName}Id@./entities.ts`, { definedIn: `./codegen/${entityName}Codegen.ts` }),
@@ -793,6 +796,10 @@ function metaType(entityName: string): Import {
 
 function entityType(entityName: string): Import {
   return imp(`${entityName}@./entities.ts`);
+}
+
+function entityTypeForMetadataFile(entityName: string): Import {
+  return imp(`${entityName}@./${entityName}.ts`);
 }
 
 function mapType(tableName: string, columnName: string, dbColumnType: DatabaseColumnType): PrimitiveTypescriptType {

--- a/packages/codegen/src/generateMetadataFile.ts
+++ b/packages/codegen/src/generateMetadataFile.ts
@@ -43,7 +43,7 @@ export function generateMetadataFile(config: Config, dbMeta: DbMetadata, meta: E
 
   return code`
     export const ${entity.metaName}: ${EntityMetadata}<${entity.name}> = {
-      cstr: ${entity.type},
+      cstr: ${entity.typeForMetadataFile},
       type: "${entity.name}",
       baseType: ${maybeBaseType}, ${maybeInheritanceType} ${maybeStiColumn} ${maybeStiValue}
       idType: "${config.idType ?? "tagged-string"}",

--- a/packages/tests/esm-misc/joist-config.json
+++ b/packages/tests/esm-misc/joist-config.json
@@ -10,5 +10,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.155.1"
+  "version": "1.155.2"
 }

--- a/packages/tests/esm-misc/src/entities/codegen/metadata.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/metadata.ts
@@ -1,7 +1,9 @@
 import { configureMetadata, EntityManager as EntityManager1, KeySerde, PrimitiveSerde } from "joist-orm";
 import type { Entity as Entity2, EntityMetadata } from "joist-orm";
 import type { Context } from "../../context.js";
-import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "../entities.js";
+import { Author } from "../Author.js";
+import { Book } from "../Book.js";
+import { authorConfig, bookConfig, newAuthor, newBook } from "../entities.js";
 
 export class EntityManager extends EntityManager1<Context, Entity> {}
 

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -90,5 +90,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.155.1"
+  "version": "1.155.2"
 }

--- a/packages/tests/integration/src/entities/codegen/metadata.ts
+++ b/packages/tests/integration/src/entities/codegen/metadata.ts
@@ -2,40 +2,51 @@ import { BigIntSerde, configureMetadata, CustomSerdeAdapter, DecimalToNumberSerd
 import type { Entity as Entity2, EntityMetadata } from "joist-orm";
 import type { Context } from "src/context";
 import { address, AddressSchema, PasswordValueSerde, quotes } from "src/entities/types";
+import { AdminUser } from "../AdminUser";
+import { Author } from "../Author";
+import { AuthorSchedule } from "../AuthorSchedule";
+import { AuthorStat } from "../AuthorStat";
+import { Book } from "../Book";
+import { BookAdvance } from "../BookAdvance";
+import { BookReview } from "../BookReview";
+import { Child } from "../Child";
+import { ChildGroup } from "../ChildGroup";
+import { ChildItem } from "../ChildItem";
+import { Comment } from "../Comment";
+import { Critic } from "../Critic";
+import { CriticColumn } from "../CriticColumn";
+import { Image } from "../Image";
+import { LargePublisher } from "../LargePublisher";
+import { ParentGroup } from "../ParentGroup";
+import { ParentItem } from "../ParentItem";
+import { Publisher } from "../Publisher";
+import { PublisherGroup } from "../PublisherGroup";
+import { SmallPublisher } from "../SmallPublisher";
+import { Tag } from "../Tag";
+import { Task } from "../Task";
+import { TaskItem } from "../TaskItem";
+import { TaskNew } from "../TaskNew";
+import { TaskOld } from "../TaskOld";
+import { User } from "../User";
 import {
-  AdminUser,
   adminUserConfig,
   AdvanceStatuses,
-  Author,
   authorConfig,
-  AuthorSchedule,
   authorScheduleConfig,
-  AuthorStat,
   authorStatConfig,
-  Book,
-  BookAdvance,
   bookAdvanceConfig,
   bookConfig,
   BookRanges,
-  BookReview,
   bookReviewConfig,
-  Child,
   childConfig,
-  ChildGroup,
   childGroupConfig,
-  ChildItem,
   childItemConfig,
   Colors,
-  Comment,
   commentConfig,
-  Critic,
-  CriticColumn,
   criticColumnConfig,
   criticConfig,
-  Image,
   imageConfig,
   ImageTypes,
-  LargePublisher,
   largePublisherConfig,
   newAdminUser,
   newAuthor,
@@ -63,30 +74,19 @@ import {
   newTaskNew,
   newTaskOld,
   newUser,
-  ParentGroup,
   parentGroupConfig,
-  ParentItem,
   parentItemConfig,
-  Publisher,
   publisherConfig,
-  PublisherGroup,
   publisherGroupConfig,
   PublisherSizes,
   PublisherTypes,
-  SmallPublisher,
   smallPublisherConfig,
-  Tag,
   tagConfig,
-  Task,
   taskConfig,
-  TaskItem,
   taskItemConfig,
-  TaskNew,
   taskNewConfig,
-  TaskOld,
   taskOldConfig,
   TaskTypes,
-  User,
   userConfig,
 } from "../entities";
 

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.155.1"
+  "version": "1.155.2"
 }

--- a/packages/tests/number-ids/src/entities/codegen/metadata.ts
+++ b/packages/tests/number-ids/src/entities/codegen/metadata.ts
@@ -1,7 +1,9 @@
 import { configureMetadata, EntityManager as EntityManager1, KeySerde, PrimitiveSerde } from "joist-orm";
 import type { Entity as Entity2, EntityMetadata } from "joist-orm";
 import type { Context } from "src/context";
-import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "../entities";
+import { Author } from "../Author";
+import { Book } from "../Book";
+import { authorConfig, bookConfig, newAuthor, newBook } from "../entities";
 
 export class EntityManager extends EntityManager1<Context, Entity> {}
 

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.155.1"
+  "version": "1.155.2"
 }

--- a/packages/tests/schema-misc/src/entities/codegen/metadata.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/metadata.ts
@@ -1,7 +1,12 @@
 import { configureMetadata, EntityManager as EntityManager1, KeySerde, PrimitiveSerde } from "joist-orm";
 import type { Entity as Entity2, EntityMetadata } from "joist-orm";
 import type { Context } from "src/context";
-import { Artist, artistConfig, Author, authorConfig, Book, bookConfig, DatabaseOwner, databaseOwnerConfig, newArtist, newAuthor, newBook, newDatabaseOwner, newPainting, Painting, paintingConfig } from "../entities";
+import { Artist } from "../Artist";
+import { Author } from "../Author";
+import { Book } from "../Book";
+import { DatabaseOwner } from "../DatabaseOwner";
+import { Painting } from "../Painting";
+import { artistConfig, authorConfig, bookConfig, databaseOwnerConfig, newArtist, newAuthor, newBook, newDatabaseOwner, newPainting, paintingConfig } from "../entities";
 
 export class EntityManager extends EntityManager1<Context, Entity> {}
 

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.155.1"
+  "version": "1.155.2"
 }

--- a/packages/tests/untagged-ids/src/entities/codegen/metadata.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/metadata.ts
@@ -1,7 +1,10 @@
 import { configureMetadata, EntityManager as EntityManager1, KeySerde, PolymorphicKeySerde, PrimitiveSerde } from "joist-orm";
 import type { Entity as Entity2, EntityMetadata } from "joist-orm";
 import type { Context } from "src/context";
-import { Author, authorConfig, Book, bookConfig, Comment, commentConfig, newAuthor, newBook, newComment } from "../entities";
+import { Author } from "../Author";
+import { Book } from "../Book";
+import { Comment } from "../Comment";
+import { authorConfig, bookConfig, commentConfig, newAuthor, newBook, newComment } from "../entities";
 
 export class EntityManager extends EntityManager1<Context, Entity> {}
 

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.155.1"
+  "version": "1.155.2"
 }

--- a/packages/tests/uuid-ids/src/entities/codegen/metadata.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/metadata.ts
@@ -1,7 +1,9 @@
 import { configureMetadata, EntityManager as EntityManager1, EnumFieldSerde, KeySerde, PrimitiveSerde } from "joist-orm";
 import type { Entity as Entity2, EntityMetadata } from "joist-orm";
 import type { Context } from "src/context";
-import { Author, authorConfig, Book, bookConfig, BookStatuses, newAuthor, newBook } from "../entities";
+import { Author } from "../Author";
+import { Book } from "../Book";
+import { authorConfig, bookConfig, BookStatuses, newAuthor, newBook } from "../entities";
 
 export class EntityManager extends EntityManager1<Context, Entity> {}
 


### PR DESCRIPTION
Bit of trial and error here but looks as if I've figured out a fix for #1031 but lmk if I'm missing something big here!

1. This directly imports entities (their codefile directly rather than via entities.ts) within metadata.ts
2. This does not touch imports to entities elsewhere (such as in *Codegen.ts file, which does trigger circ issues)
3. This is enabled by default, but happy to update this PR to gate this under the esm option
4. Currently not tested as top level await is esm only so perhaps need to expand the esm dir in the future
  - Applied this patch in our app and we're running once again, tests passing


There's codegen consequences of this but I haven't committed them until feedback and thoughts on 3.