### PR TITLE
fix: Remove id from allowed factory params.

### DIFF
--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -7,7 +7,6 @@ import {
   IdOf,
   MaybeAbstractEntityConstructor,
   OptsOf,
-  isId,
 } from "./EntityManager";
 import {
   EntityMetadata,
@@ -249,9 +248,6 @@ function resolveFactoryOpt<T extends Entity>(
   // const otherFieldName = field.kind === "poly" ? field.components[0].otherFieldName : field.otherFieldName;
   if (isEntity(opt)) {
     return opt as T;
-  } else if (isId(opt)) {
-    // Try finding the entity in the UoW, otherwise fallback on just setting it as the id (which we support that now)
-    return (em.entities.find((e) => e.idTaggedMaybe === opt || getTestId(em, e) === opt) as T) || opt;
   } else if (opt && !isPlainObject(opt) && !(opt instanceof MaybeNew)) {
     // If opt isn't a POJO, assume this is a completely-custom factory
     return meta.factory(em, opt);
@@ -567,10 +563,7 @@ type DefinedOr<T> = T | undefined | null;
 type DeepPartialOpts<T extends Entity> = AllowRelationsOrPartials<OptsOf<T>>;
 
 /** What a factory can accept for a given entity. */
-export type FactoryEntityOpt<T extends Entity> =
-  | T
-  | IdOf<T>
-  | (ActualFactoryOpts<T> & { useFactoryDefaults?: boolean | "none" });
+export type FactoryEntityOpt<T extends Entity> = T | (ActualFactoryOpts<T> & { useFactoryDefaults?: boolean | "none" });
 
 type AllowRelationsOrPartials<T> = {
   [P in keyof T]?: T[P] extends DefinedOr<infer U>

--- a/packages/tests/integration/src/EntityManager.factories.test.ts
+++ b/packages/tests/integration/src/EntityManager.factories.test.ts
@@ -40,7 +40,7 @@ describe("EntityManager.factories", () => {
     expect(em.numberOfEntities).toEqual(1);
   });
 
-  it("can create a child and a required parent implicity", async () => {
+  it("can create a child and a required parent implicitly", async () => {
     const em = newEntityManager();
     // Given we make a book with no existing/passed authors
     const b1 = newBook(em);
@@ -253,18 +253,12 @@ describe("EntityManager.factories", () => {
     newBook(em, { tags: [new Date()] });
   });
 
-  it("can use tagged ids as shortcuts", async () => {
+  it("can no longer use tagged ids as shortcuts", async () => {
     const em = newEntityManager();
     const a1 = newAuthor(em);
+    // @ts-expect-error
     const b1 = newBook(em, { author: "a:1" });
     expect(b1.author.get).toEqual(a1);
-  });
-
-  it("can use tagged ids as shortcuts in list", async () => {
-    const em = newEntityManager();
-    const a1 = newAuthor(em);
-    const p1 = newPublisher(em, { authors: ["a:1"] });
-    expect(p1.authors.get).toEqual([a1]);
   });
 
   it("can omit default values for non-required primitive fields", async () => {


### PR DESCRIPTION
This seems cute at the time, but in practice we basically never use it, and always use variables or hashes.

And keeping it in throws off intellisense b/c doing things like `author: { ... }` within the `...` you'll be prompted for string-ish methods, like if you had wanted to pass a param that structurally matches string.

So net/net better DX is to only see the entities fields and not the misc string methods in the autocomplete list.