### PR TITLE
feat: Add a seed function

### DIFF
--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -2,6 +2,7 @@ import { MatchedEntity } from "./toMatchEntity";
 export { Context } from "./context";
 export { ContextFn, makeRun, makeRunEach, newContext, run, runEach } from "./run";
 export { toMatchEntity } from "./toMatchEntity";
+export { seed } from "./seed";
 
 declare global {
   namespace jest {

--- a/packages/test-utils/src/run.ts
+++ b/packages/test-utils/src/run.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import { Entity, EntityManager, isEntity } from "joist-orm";
 import { fail } from "joist-utils";
 import { Context } from "./context";

--- a/packages/test-utils/src/run.ts
+++ b/packages/test-utils/src/run.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { Entity, EntityManager, isEntity } from "joist-orm";
 import { fail } from "joist-utils";
 import { Context } from "./context";

--- a/packages/test-utils/src/seed.ts
+++ b/packages/test-utils/src/seed.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { EntityManager, newPgConnectionConfig, PostgresDriver } from "joist-orm";
 import { knex as createKnex } from "knex";
 

--- a/packages/test-utils/src/seed.ts
+++ b/packages/test-utils/src/seed.ts
@@ -1,0 +1,30 @@
+import { EntityManager, newPgConnectionConfig, PostgresDriver } from "joist-orm";
+import { knex as createKnex } from "knex";
+
+export function seed<E extends EntityManager = EntityManager>(fn: (em: E) => Promise<void>): void {
+  const env = process.env.NODE_ENV;
+  if (env !== "local" && env !== "test") {
+    throw new Error("seed will only run with NODE_ENV=local or NODE_ENV=test because it resets the database");
+  }
+
+  const knex = createKnex({ client: "pg", connection: newPgConnectionConfig() });
+
+  async function seed() {
+    await knex.select(knex.raw("flush_database()"));
+    const driver = new PostgresDriver(knex);
+    const em = new EntityManager({}, { driver }) as E;
+    await fn(em);
+    await em.flush();
+  }
+
+  seed()
+    .then(async () => {
+      console.log("Seeded!");
+      await knex.destroy();
+    })
+    .catch(async (err) => {
+      console.error(err);
+      await knex.destroy();
+      process.exit(1);
+    });
+}

--- a/packages/test-utils/src/seed.ts
+++ b/packages/test-utils/src/seed.ts
@@ -1,12 +1,29 @@
 import { EntityManager, newPgConnectionConfig, PostgresDriver } from "joist-orm";
 import { knex as createKnex } from "knex";
 
+/**
+ * Allows easily seeding your local database with test data from the factories.
+ *
+ * This will delete all data in the database, so is restricted to only `local` and
+ * `test` `NODE_ENV`s.
+ *
+ * We currently make a lot of assumptions:
+ *
+ * - That the project is using knex (all Joist projects do atm)
+ * - That the project is using postgres (all Joist projects do atm)
+ * - That the project does not have a context, or at least does not require a context to seed
+ *
+ * If any of these assumptions are not true, you can copy this code into your project.
+ */
 export function seed<E extends EntityManager = EntityManager>(fn: (em: E) => Promise<void>): void {
   const env = process.env.NODE_ENV;
   if (env !== "local" && env !== "test") {
     throw new Error("seed will only run with NODE_ENV=local or NODE_ENV=test because it resets the database");
   }
 
+  // We make a lot of assumptions about the project is surely using
+  // knex & postgres, but at some point these will be configurable...
+  // Maybe we can detect it in the `DATABASE_URL` or what not.
   const knex = createKnex({ client: "pg", connection: newPgConnectionConfig() });
 
   async function seed() {

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -16,7 +16,9 @@ import {
 } from "joist-orm";
 import { isPlainObject } from "joist-utils";
 
-const { matchers } = (globalThis as any)[Symbol.for("$$jest-matchers-object")];
+// This might be undefined if running outside of jest
+const jestMatchers = (globalThis as any)[Symbol.for("$$jest-matchers-object")];
+const matchers = jestMatchers?.matchers;
 
 /**
  * Provides convenient `toMatchObject`-style matching for Joist entities.


### PR DESCRIPTION
Historically I've not found seed functions useful, b/c I like to just run test suites to generate my boundary conditions, but :shrug: they are a thing.