### PR TITLE
fix: Fix lens over unloaded AsyncProperties.

### DIFF
--- a/packages/orm/src/loadLens.ts
+++ b/packages/orm/src/loadLens.ts
@@ -1,6 +1,7 @@
 import { Entity, isEntity } from "./Entity";
 import { EntityMetadata, Field, getMetadata } from "./EntityMetadata";
 import { lensDataLoader } from "./dataloaders/lensDataLoader";
+import { isAsyncProperty } from "./relations";
 import { AbstractRelationImpl } from "./relations/AbstractRelationImpl";
 
 /** Generically matches on a Reference/Collection's load method. */
@@ -225,7 +226,10 @@ export function isLensLoaded<T, U, V>(start: T | T[], fn: (lens: Lens<T>) => Len
 
 function isNotLoaded(object: any, path: string): boolean {
   const value = object && object[path];
-  return value instanceof AbstractRelationImpl && !value.isLoaded;
+  if (value instanceof AbstractRelationImpl || isAsyncProperty(value)) {
+    return !value.isLoaded;
+  }
+  return false;
 }
 
 function maybeGet(object: any, path: string): unknown {

--- a/packages/orm/src/relations/AbstractPropertyImpl.ts
+++ b/packages/orm/src/relations/AbstractPropertyImpl.ts
@@ -9,4 +9,6 @@ export abstract class AbstractPropertyImpl<T> {
   get entity(): T {
     return this.#entity;
   }
+
+  abstract get isLoaded(): boolean;
 }

--- a/packages/tests/integration/src/EntityManager.lens.test.ts
+++ b/packages/tests/integration/src/EntityManager.lens.test.ts
@@ -163,6 +163,13 @@ describe("EntityManager.lens", () => {
     expect(p1Id).toEqual("p:1");
   });
 
+  it("can populate properties", async () => {
+    await insertAuthor({ first_name: "a1" });
+    const em = newEntityManager();
+    const a1 = await em.load(Author, "1");
+    await a1.load((a) => a.latestComments);
+  });
+
   describe("sql", () => {
     it("loads a subset via o2o", async () => {
       await insertAuthor({ first_name: "a1" });


### PR DESCRIPTION
The recent optimization of `isLensLoaded` moved from:

* Just try and call `.get` and see if an exception is thrown

To:

* Probe the path and look for explicitly not-loaded relations/properties

But I forgot to check for `AsyncProperty`s in the probe.