### PR TITLE
fix: Fix id alias columns typed as numbers.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -467,7 +467,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
     ${generatePolymorphicTypes(meta)}
     
     export interface ${entityName}Fields ${maybeBaseFields} {
-      ${generateFieldsType(config, meta)}
+      ${generateFieldsType(config, meta, idType)}
     }
 
     export interface ${entityName}Opts ${maybeBaseOpts} {
@@ -715,8 +715,8 @@ function generateOptsFields(config: Config, meta: EntityDbMetadata): Code[] {
 }
 
 // Make our fields type
-function generateFieldsType(config: Config, meta: EntityDbMetadata): Code[] {
-  const id = code`id: { kind: "primitive"; type: ${meta.primaryKey.fieldType}; unique: ${true}; nullable: never };`;
+function generateFieldsType(config: Config, meta: EntityDbMetadata, idType: "string" | "number"): Code[] {
+  const id = code`id: { kind: "primitive"; type: ${idType}; unique: ${true}; nullable: never };`;
   const primitives = meta.primitives.map((field) => {
     const { fieldName, fieldType, notNull, unique, derived } = field;
     return code`${fieldName}: { kind: "primitive"; type: ${fieldType}; unique: ${unique}; nullable: ${undefinedOrNever(

--- a/packages/orm/src/Aliases.ts
+++ b/packages/orm/src/Aliases.ts
@@ -27,13 +27,15 @@ export function aliases<T extends readonly MaybeAbstractEntityConstructor<any>[]
 }
 
 export type Alias<T extends Entity> = {
-  [P in keyof FieldsOf<T>]: FieldsOf<T>[P] extends { kind: "primitive" | "enum"; type: infer V; nullable: infer N }
-    ? PrimitiveAlias<V, N extends undefined ? null : never>
-    : FieldsOf<T>[P] extends { kind: "m2o"; type: infer U }
-      ? EntityAlias<U>
-      : FieldsOf<T>[P] extends { kind: "poly"; type: infer U extends Entity }
-        ? PolyReferenceAlias<U>
-        : never;
+  [P in keyof FieldsOf<T>]: P extends "id"
+    ? EntityAlias<T>
+    : FieldsOf<T>[P] extends { kind: "primitive" | "enum"; type: infer V; nullable: infer N }
+      ? PrimitiveAlias<V, N extends undefined ? null : never>
+      : FieldsOf<T>[P] extends { kind: "m2o"; type: infer U }
+        ? EntityAlias<U>
+        : FieldsOf<T>[P] extends { kind: "poly"; type: infer U extends Entity }
+          ? PolyReferenceAlias<U>
+          : never;
 };
 
 export interface PrimitiveAlias<V, N extends null | never> {

--- a/packages/tests/esm-misc/joist-config.json
+++ b/packages/tests/esm-misc/joist-config.json
@@ -10,5 +10,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.163.1"
+  "version": "1.163.6"
 }

--- a/packages/tests/esm-misc/joist-config.json
+++ b/packages/tests/esm-misc/joist-config.json
@@ -10,5 +10,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.163.6"
+  "version": "1.163.7"
 }

--- a/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
@@ -44,7 +44,7 @@ import type { BookId, Entity } from "../entities.js";
 export type AuthorId = Flavor<string, Author>;
 
 export interface AuthorFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   firstName: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   lastName: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   delete: { kind: "primitive"; type: boolean; unique: false; nullable: undefined; derived: false };

--- a/packages/tests/esm-misc/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/BookCodegen.ts
@@ -42,7 +42,7 @@ import type { AuthorId, AuthorOrder, Entity } from "../entities.js";
 export type BookId = Flavor<string, Book>;
 
 export interface BookFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   title: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   author: { kind: "m2o"; type: Author; nullable: never; derived: false };
 }

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -94,5 +94,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.163.6"
+  "version": "1.163.7"
 }

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -94,5 +94,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.163.1"
+  "version": "1.163.6"
 }

--- a/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
@@ -35,7 +35,7 @@ import type { Entity, UserFields, UserFilter, UserGraphQLFilter, UserIdsOpts, Us
 export type AdminUserId = Flavor<string, AdminUser> & Flavor<string, "User">;
 
 export interface AdminUserFields extends UserFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   role: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
 }
 

--- a/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
@@ -92,7 +92,7 @@ import type {
 export type AuthorId = Flavor<string, Author>;
 
 export interface AuthorFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   firstName: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   lastName: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   ssn: { kind: "primitive"; type: string; unique: true; nullable: undefined; derived: false };

--- a/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
@@ -42,7 +42,7 @@ import type { AuthorId, AuthorOrder, Entity } from "../entities";
 export type AuthorScheduleId = Flavor<string, AuthorSchedule>;
 
 export interface AuthorScheduleFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   overview: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
@@ -36,7 +36,7 @@ import type { Entity } from "../entities";
 export type AuthorStatId = Flavor<string, AuthorStat>;
 
 export interface AuthorStatFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   smallint: { kind: "primitive"; type: number; unique: false; nullable: never; derived: false };
   integer: { kind: "primitive"; type: number; unique: false; nullable: never; derived: false };
   nullableInteger: { kind: "primitive"; type: number; unique: false; nullable: undefined; derived: false };

--- a/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
@@ -53,7 +53,7 @@ import type { BookId, BookOrder, Entity, PublisherId, PublisherOrder } from "../
 export type BookAdvanceId = Flavor<string, BookAdvance>;
 
 export interface BookAdvanceFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   status: { kind: "enum"; type: AdvanceStatus; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookCodegen.ts
@@ -73,7 +73,7 @@ import type {
 export type BookId = Flavor<string, Book>;
 
 export interface BookFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   title: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   order: { kind: "primitive"; type: number; unique: false; nullable: never; derived: false };
   notes: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };

--- a/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
@@ -61,7 +61,7 @@ import type { BookId, BookOrder, CommentId, CriticId, CriticOrder, Entity, TagId
 export type BookReviewId = Flavor<string, BookReview>;
 
 export interface BookReviewFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   rating: { kind: "primitive"; type: number; unique: false; nullable: never; derived: false };
   isPublic: { kind: "primitive"; type: boolean; unique: false; nullable: never; derived: true };
   isTest: { kind: "primitive"; type: boolean; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
@@ -42,7 +42,7 @@ import type { ChildGroupId, Entity } from "../entities";
 export type ChildId = Flavor<string, Child>;
 
 export interface ChildFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
@@ -55,7 +55,7 @@ import type { ChildId, ChildItemId, ChildOrder, Entity, ParentGroupId, ParentGro
 export type ChildGroupId = Flavor<string, ChildGroup>;
 
 export interface ChildGroupFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
@@ -51,7 +51,7 @@ import type { ChildGroupId, ChildGroupOrder, Entity, ParentItemId, ParentItemOrd
 export type ChildItemId = Flavor<string, ChildItem>;
 
 export interface ChildItemFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
@@ -70,7 +70,7 @@ export function isCommentParent(maybeEntity: unknown): maybeEntity is CommentPar
 }
 
 export interface CommentFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   parentTags: { kind: "primitive"; type: string; unique: false; nullable: never; derived: true };
   text: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
@@ -67,7 +67,7 @@ import type {
 export type CriticId = Flavor<string, Critic>;
 
 export interface CriticFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
@@ -42,7 +42,7 @@ import type { CriticId, CriticOrder, Entity } from "../entities";
 export type CriticColumnId = Flavor<string, CriticColumn>;
 
 export interface CriticColumnFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
@@ -56,7 +56,7 @@ import type { AuthorId, AuthorOrder, BookId, BookOrder, Entity, PublisherId, Pub
 export type ImageId = Flavor<string, Image>;
 
 export interface ImageFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   fileName: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -60,7 +60,7 @@ import type {
 export type LargePublisherId = Flavor<string, LargePublisher> & Flavor<string, "Publisher">;
 
 export interface LargePublisherFields extends PublisherFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   sharedColumn: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   country: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
 }

--- a/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
@@ -51,7 +51,7 @@ import type { ChildGroupId, Entity, ParentItemId } from "../entities";
 export type ParentGroupId = Flavor<string, ParentGroup>;
 
 export interface ParentGroupFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
@@ -53,7 +53,7 @@ import type { ChildItemId, Entity, ParentGroupId, ParentGroupOrder } from "../en
 export type ParentItemId = Flavor<string, ParentItem>;
 
 export interface ParentItemFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
@@ -85,7 +85,7 @@ import type {
 export type PublisherId = Flavor<string, Publisher>;
 
 export interface PublisherFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   latitude: { kind: "primitive"; type: number; unique: false; nullable: undefined; derived: false };
   longitude: { kind: "primitive"; type: number; unique: false; nullable: undefined; derived: false };

--- a/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
@@ -54,7 +54,7 @@ import type { Entity, PublisherId } from "../entities";
 export type PublisherGroupId = Flavor<string, PublisherGroup>;
 
 export interface PublisherGroupFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   numberOfBookReviews: { kind: "primitive"; type: number; unique: false; nullable: never; derived: true };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -59,7 +59,7 @@ import type {
 export type SmallPublisherId = Flavor<string, SmallPublisher> & Flavor<string, "Publisher">;
 
 export interface SmallPublisherFields extends PublisherFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   city: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   sharedColumn: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   allAuthorNames: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: true };

--- a/packages/tests/integration/src/entities/codegen/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TagCodegen.ts
@@ -57,7 +57,7 @@ import type { AuthorId, BookId, BookReviewId, Entity, PublisherId, TaskId } from
 export type TagId = Flavor<string, Tag>;
 
 export interface TagFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
@@ -59,7 +59,7 @@ import type { Entity, TagId, TaskItemId } from "../entities";
 export type TaskId = Flavor<string, Task>;
 
 export interface TaskFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   durationInDays: { kind: "primitive"; type: number; unique: false; nullable: never; derived: false };
   deletedAt: { kind: "primitive"; type: Date; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
@@ -52,7 +52,7 @@ import type { Entity, TaskId, TaskNewId, TaskNewOrder, TaskOldId, TaskOldOrder, 
 export type TaskItemId = Flavor<string, TaskItem>;
 
 export interface TaskItemFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   newTask: { kind: "m2o"; type: TaskNew; nullable: undefined; derived: false };

--- a/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
@@ -62,7 +62,7 @@ import type {
 export type TaskNewId = Flavor<string, TaskNew> & Flavor<string, "Task">;
 
 export interface TaskNewFields extends TaskFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   specialNewField: { kind: "primitive"; type: number; unique: false; nullable: undefined; derived: false };
   specialNewAuthor: { kind: "m2o"; type: Author; nullable: undefined; derived: false };
 }

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -67,7 +67,7 @@ import type {
 export type TaskOldId = Flavor<string, TaskOld> & Flavor<string, "Task">;
 
 export interface TaskOldFields extends TaskFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   specialOldField: { kind: "primitive"; type: number; unique: false; nullable: never; derived: false };
   parentOldTask: { kind: "m2o"; type: TaskOld; nullable: undefined; derived: false };
 }

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -73,7 +73,7 @@ export function isUserFavoritePublisher(maybeEntity: unknown): maybeEntity is Us
 }
 
 export interface UserFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   email: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   ipAddress: { kind: "primitive"; type: IpAddress; unique: false; nullable: undefined; derived: false };

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.163.1"
+  "version": "1.163.6"
 }

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.163.6"
+  "version": "1.163.7"
 }

--- a/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
@@ -42,7 +42,7 @@ import type { AuthorId, AuthorOrder, Entity } from "../entities";
 export type BookId = Flavor<number, Book>;
 
 export interface BookFields {
-  id: { kind: "primitive"; type: bigint; unique: true; nullable: never };
+  id: { kind: "primitive"; type: number; unique: true; nullable: never };
   title: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.163.6"
+  "version": "1.163.7"
 }

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.163.1"
+  "version": "1.163.6"
 }

--- a/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
@@ -44,7 +44,7 @@ import type { BookId, Entity } from "../entities";
 export type AuthorId = Flavor<string, Author>;
 
 export interface AuthorFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   firstName: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   lastName: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   delete: { kind: "primitive"; type: boolean; unique: false; nullable: undefined; derived: false };

--- a/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
@@ -42,7 +42,7 @@ import type { AuthorId, AuthorOrder, Entity } from "../entities";
 export type BookId = Flavor<string, Book>;
 
 export interface BookFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   title: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   author: { kind: "m2o"; type: Author; nullable: never; derived: false };
 }

--- a/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
@@ -36,7 +36,7 @@ import type { Entity } from "../entities";
 export type DatabaseOwnerId = Flavor<string, DatabaseOwner>;
 
 export interface DatabaseOwnerFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   name: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
 }
 

--- a/packages/tests/temporal/joist-config.json
+++ b/packages/tests/temporal/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "temporal": { "timeZone": "America/Los_Angeles" },
-  "version": "1.163.1"
+  "version": "1.163.6"
 }

--- a/packages/tests/temporal/joist-config.json
+++ b/packages/tests/temporal/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "temporal": { "timeZone": "America/Los_Angeles" },
-  "version": "1.163.6"
+  "version": "1.163.7"
 }

--- a/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
@@ -43,7 +43,7 @@ import type { BookId, Entity } from "../entities";
 export type AuthorId = Flavor<string, Author>;
 
 export interface AuthorFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   firstName: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   lastName: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   birthday: { kind: "primitive"; type: Temporal.PlainDate; unique: false; nullable: never; derived: false };

--- a/packages/tests/temporal/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/temporal/src/entities/codegen/BookCodegen.ts
@@ -43,7 +43,7 @@ import type { AuthorId, AuthorOrder, Entity } from "../entities";
 export type BookId = Flavor<string, Book>;
 
 export interface BookFields {
-  id: { kind: "primitive"; type: number; unique: true; nullable: never };
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
   title: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   publishedAt: { kind: "primitive"; type: Temporal.ZonedDateTime; unique: false; nullable: never; derived: false };
   createdAt: { kind: "primitive"; type: Temporal.ZonedDateTime; unique: false; nullable: never; derived: true };

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.163.1"
+  "version": "1.163.6"
 }

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.163.6"
+  "version": "1.163.7"
 }

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.163.6"
+  "version": "1.163.7"
 }

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.163.1"
+  "version": "1.163.6"
 }


### PR DESCRIPTION
Previously the `id` column for like:

```
const a = alias(Author);
em.find(..., where: { a.id... });
```

The `id` column was typed as `number`, like the underlying database, instead of string to match our tagged ids.

This was because of a mistake in the entity codegen generation of the `Fields` interface, just using the wrong `idType`.
