### PR TITLE
feat: Support multiple separate order bys.

### DIFF
--- a/packages/orm/src/EntityFilter.ts
+++ b/packages/orm/src/EntityFilter.ts
@@ -7,7 +7,7 @@ import { ColumnCondition, RawCondition } from "./QueryParser";
 export type FilterAndSettings<T extends Entity> = {
   where: FilterWithAlias<T>;
   conditions?: ExpressionFilter;
-  orderBy?: OrderOf<T>;
+  orderBy?: OrderOf<T> | OrderOf<T>[];
   limit?: number;
   offset?: number;
   softDeletes?: "exclude" | "include";

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -88,7 +88,7 @@ export interface EntityConstructor<T> {
 /** Options for the auto-batchable `em.find` queries, i.e. limit & offset aren't allowed. */
 export interface FindFilterOptions<T extends Entity> {
   conditions?: ExpressionFilter;
-  orderBy?: OrderOf<T>;
+  orderBy?: OrderOf<T> | OrderOf<T>[];
   softDeletes?: "include" | "exclude";
 }
 

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -377,13 +377,10 @@ export function parseFindQuery(
     }
   }
 
-  function addOrderBy(meta: EntityMetadata, alias: string, orderBy: any): void {
-    // Assume only one key
+  function addOrderBy(meta: EntityMetadata, alias: string, orderBy: Record<string, any>): void {
     const entries = Object.entries(orderBy);
-    if (entries.length === 0) {
-      return;
-    }
-    Object.entries(orderBy).forEach(([key, value]) => {
+    if (entries.length === 0) return;
+    for (const [key, value] of entries) {
       const field = meta.allFields[key] ?? fail(`${key} not found on ${meta.tableName}`);
       if (field.kind === "primitive" || field.kind === "primaryKey" || field.kind === "enum") {
         const column = field.serde.columns[0];
@@ -415,7 +412,7 @@ export function parseFindQuery(
       } else {
         throw new Error(`Unsupported field ${key}`);
       }
-    });
+    }
   }
 
   // always add the main table
@@ -443,7 +440,11 @@ export function parseFindQuery(
   }
 
   if (orderBy) {
-    addOrderBy(meta, alias, orderBy);
+    if (Array.isArray(orderBy)) {
+      for (const ob of orderBy) addOrderBy(meta, alias, ob);
+    } else {
+      addOrderBy(meta, alias, orderBy);
+    }
   }
   maybeAddOrderBy(query, meta, alias);
 


### PR DESCRIPTION
Previously Joist supported multiple order bys, but only if they were embedded within a single object literal.

This works but is overly implicit (relying on key/insertion order) vs. just taking an actual list of order bys.

Fixes #1074