### PR TITLE
fix: Fix reacting to subtype-only relations.

### DIFF
--- a/packages/orm/src/reactiveHints.ts
+++ b/packages/orm/src/reactiveHints.ts
@@ -192,7 +192,7 @@ export function reverseReactiveHint<T extends Entity>(
         case "o2o": {
           const isOtherReadOnly = field.otherMetadata().allFields[field.otherFieldName].immutable;
           const otherFieldName =
-            field.otherMetadata().allFields[field.otherFieldName].kind === "poly"
+            field.otherMetadata().allFields[field.otherFieldName].kind === "poly" || meta.baseType
               ? `${field.otherFieldName}@${meta.type}`
               : field.otherFieldName;
           // This is not a field, but we want our reverse side to be reactive, so pass reactForOtherSide

--- a/packages/tests/integration/src/EntityManager.reactiveRules.test.tsx
+++ b/packages/tests/integration/src/EntityManager.reactiveRules.test.tsx
@@ -239,7 +239,13 @@ describe("EntityManager.reactiveRules", () => {
         fn,
       },
       // SmallPublisher's "cannot have >5 authors" rule
-      { cstr: "SmallPublisher", name: sm(/Publisher.ts:\d+/), fields: ["publisher"], path: ["publisher"], fn },
+      {
+        cstr: "SmallPublisher",
+        name: sm(/Publisher.ts:\d+/),
+        fields: ["publisher"],
+        path: ["publisher@SmallPublisher"],
+        fn,
+      },
     ]);
 
     expect(getReactiveRules(Book)).toMatchObject([


### PR DESCRIPTION
If we saw a hint like:

* child (no subtypes) -> parent (that is a subtype) -> something else

When we would reverse it, and try to go:

* something else -> parent (that is a different subtype) -> children

The `parent[children]` would blow up, b/c that o2m may not exist.

This is very similar to conditionally walking through polys, so we reuse the same `parent@Subtype` to infra to stop the walking before trying to access `parent[children]`.