### PR TITLE
feat: Support filtering by poly components

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -802,8 +802,14 @@ function generateFilterFields(meta: EntityDbMetadata): Code[] {
   const m2m = meta.manyToManys.map(({ fieldName, otherEntity }) => {
     return code`${fieldName}?: ${EntityFilter}<${otherEntity.type}, ${otherEntity.idType}, ${FilterOf}<${otherEntity.type}>, null | undefined>;`;
   });
-  const polys = meta.polymorphics.map(({ fieldName, fieldType }) => {
-    return code`${fieldName}?: ${EntityFilter}<${fieldType}, ${IdOf}<${fieldType}>, never, null | undefined>;`;
+  const polys = meta.polymorphics.flatMap(({ fieldName, fieldType, components, notNull }) => {
+    return [
+      code`${fieldName}?: ${EntityFilter}<${fieldType}, ${IdOf}<${fieldType}>, never, ${nullOrNever(notNull)}>;`,
+      ...components.map((comp) => {
+        const { type } = comp.otherEntity;
+        return code`${fieldName}${type}?: ${EntityFilter}<${type}, ${IdOf}<${type}>, ${FilterOf}<${type}>, null>;`;
+      }),
+    ];
   });
   return [...maybeId, ...primitives, ...enums, ...pgEnums, ...m2o, ...o2o, ...o2m, ...m2m, ...polys];
 }
@@ -838,8 +844,14 @@ function generateGraphQLFilterFields(meta: EntityDbMetadata): Code[] {
   const m2m = meta.manyToManys.map(({ fieldName, otherEntity }) => {
     return code`${fieldName}?: ${EntityGraphQLFilter}<${otherEntity.type}, ${otherEntity.idType}, ${GraphQLFilterOf}<${otherEntity.type}>, null | undefined>;`;
   });
-  const polys = meta.polymorphics.map(({ fieldName, fieldType }) => {
-    return code`${fieldName}?: ${EntityGraphQLFilter}<${fieldType}, ${IdOf}<${fieldType}>, never, null | undefined>;`;
+  const polys = meta.polymorphics.flatMap(({ fieldName, fieldType, components, notNull }) => {
+    return [
+      code`${fieldName}?: ${EntityGraphQLFilter}<${fieldType}, ${IdOf}<${fieldType}>, never, ${nullOrNever(notNull)}>;`,
+      ...components.map((comp) => {
+        const { type } = comp.otherEntity;
+        return code`${fieldName}${type}?: ${EntityGraphQLFilter}<${type}, ${IdOf}<${type}>, ${FilterOf}<${type}>, null>;`;
+      }),
+    ];
   });
   return [...maybeId, ...primitives, ...enums, ...pgEnums, ...m2o, ...o2o, ...o2m, ...m2m, ...polys];
 }

--- a/packages/orm/src/EntityMetadata.ts
+++ b/packages/orm/src/EntityMetadata.ts
@@ -45,6 +45,8 @@ export interface EntityMetadata<T extends Entity = any> {
   tagName: string;
   fields: Record<string, Field>;
   allFields: Record<string, Field & { aliasSuffix: string }>;
+  /** Usually polys are in `allFields`, but we pull the components out for comp-specific finds, like `parentBook`. */
+  polyComponentFields?: Record<string, Field & { aliasSuffix: string }>;
   config: ConfigApi<any, any>;
   orderBy: string | undefined;
   timestampFields: TimestampFields;

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -179,7 +179,10 @@ export function parseFindQuery(
       Object.keys(ef.subFilter).forEach((key) => {
         // Skip the `{ as: ... }` alias binding
         if (key === "as") return;
-        const field = meta.allFields[key] ?? fail(`Field '${key}' not found on ${meta.tableName}`);
+        const field =
+          meta.allFields[key] ??
+          meta.polyComponentFields?.[key] ??
+          fail(`Field '${key}' not found on ${meta.tableName}`);
         const fa = `${alias}${field.aliasSuffix}`;
         if (field.kind === "primitive" || field.kind === "primaryKey" || field.kind === "enum") {
           const column = field.serde.columns[0];

--- a/packages/orm/src/configure.ts
+++ b/packages/orm/src/configure.ts
@@ -1,6 +1,6 @@
 import { Entity } from "./Entity";
 import { MaybeAbstractEntityConstructor, TaggedId } from "./EntityManager";
-import { EntityMetadata, getMetadata } from "./EntityMetadata";
+import { EntityMetadata, ManyToOneField, getMetadata } from "./EntityMetadata";
 import { setBooted } from "./config";
 import { hasDefaultValue } from "./defaults";
 import { getFakeInstance } from "./getProperties";
@@ -10,6 +10,7 @@ import { ReactiveReferenceImpl, Reference } from "./relations";
 import { ReactiveFieldImpl } from "./relations/ReactiveField";
 import { ReactiveQueryFieldImpl } from "./relations/ReactiveQueryField";
 import { isCannotBeUpdatedRule } from "./rules";
+import { KeySerde } from "./serde";
 import { fail } from "./utils";
 
 const tagToConstructorMap = new Map<string, MaybeAbstractEntityConstructor<any>>();
@@ -25,6 +26,7 @@ export function configureMetadata(metas: EntityMetadata[]): void {
   setImmutableFields(metas);
   hookUpBaseTypeAndSubTypes(metas);
   reverseIndexReactivity(metas);
+  populatePolyComponentFields(metas);
 }
 
 function fireAfterMetadatas(metas: EntityMetadata[]): void {
@@ -180,6 +182,42 @@ function ensureDefaultsSet(metas: EntityMetadata[]): void {
         throw new Error(
           `Field ${meta.type}.${field.fieldName} is configured with hasConfigDefault=true in joist-config but is missing a config.setDefault`,
         );
+      }
+    }
+  }
+}
+
+/**
+ * In addition to the canonical `meta.allFields`, we populate a `meta.polyComponentFields` to
+ * disaggregates the poly's components into individual fields so that `em.find` / `parseFindQuery`
+ * can support component-specific find queries.
+ */
+function populatePolyComponentFields(metas: EntityMetadata[]): void {
+  for (const meta of metas) {
+    for (const [key, field] of Object.entries(meta.allFields)) {
+      if (field.kind === "poly") {
+        meta.polyComponentFields = {};
+        for (const comp of field.components) {
+          const fieldName = `${key}${comp.otherMetadata().type}`;
+          // Synthesize a m2o component that won't be used for any actual read/write serde,
+          // but just to help `parseFindQuery` build `WHERE` clauses.
+          meta.polyComponentFields[fieldName] = {
+            kind: "m2o",
+            fieldName,
+            fieldIdName: `${fieldName}Id`,
+            required: false,
+            immutable: false,
+            derived: false,
+            serde: new KeySerde(
+              comp.otherMetadata().tagName,
+              fieldName,
+              comp.columnName,
+              field.serde.columns[0].dbType as any,
+            ),
+            ...comp,
+            aliasSuffix: field.aliasSuffix,
+          } satisfies ManyToOneField & { aliasSuffix: string };
+        }
       }
     }
   }

--- a/packages/tests/esm-misc/joist-config.json
+++ b/packages/tests/esm-misc/joist-config.json
@@ -10,5 +10,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.165.0"
+  "version": "1.165.2"
 }

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -94,5 +94,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.165.0"
+  "version": "1.165.2"
 }

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -1787,6 +1787,30 @@ describe("EntityManager.queries", () => {
     });
   });
 
+  it("can find through a polymorphic component by id", async () => {
+    await insertAuthor({ first_name: "a" });
+    await insertBook({ title: "t", author_id: 1 });
+    await insertComment({ text: "t1", parent_book_id: 1 });
+    await insertComment({ text: "t2" });
+
+    const em = newEntityManager();
+    const where = { parentBook: { title: "t" } } satisfies CommentFilter;
+    const comments = await em.find(Comment, where);
+    const [comment] = comments;
+    expect(comments.length).toEqual(1);
+    expect(comment.text).toEqual("t1");
+
+    expect(parseFindQuery(cm, where)).toMatchObject({
+      selects: [`c.*`],
+      tables: [{ alias: "c", table: "comments", join: "primary" }],
+      condition: {
+        op: "and",
+        conditions: [{ alias: "c", column: "parent_book_id", dbType: "int", cond: { kind: "eq", value: 1 } }],
+      },
+      orderBys: [expect.anything()],
+    });
+  });
+
   it("can find through a polymorphic reference by entity", async () => {
     await insertAuthor({ first_name: "a" });
     await insertBook({ title: "t", author_id: 1 });
@@ -1813,29 +1837,25 @@ describe("EntityManager.queries", () => {
   });
 
   it("can find through a null polymorphic reference", async () => {
-    await insertAuthor({ first_name: "a" });
-    await insertBook({ title: "t", author_id: 1 });
-    await insertComment({ text: "t1", parent_book_id: 1 });
-    await insertComment({ text: "t2" });
+    await insertPublisher({ name: "p1" });
+    await insertUser({ name: "u1", favorite_publisher_small_id: 1 });
+    await insertUser({ name: "u2" });
 
     const em = newEntityManager();
-    const where = { parent: null } satisfies CommentFilter;
-    const comments = await em.find(Comment, where);
-    const [comment] = comments;
-    expect(comments.length).toEqual(1);
-    expect(comment.text).toEqual("t2");
+    const where = { favoritePublisher: null } satisfies UserFilter;
+    const users = await em.find(User, where);
+    const [user] = users;
+    expect(users.length).toEqual(1);
+    expect(user.name).toEqual("u2");
 
-    expect(parseFindQuery(cm, where)).toMatchObject({
-      selects: [`c.*`],
-      tables: [{ alias: "c", table: "comments", join: "primary" }],
+    expect(parseFindQuery(um, where)).toMatchObject({
+      selects: [`u.*`, `u_s0.*`, `u.id as id`, expect.stringContaining("CASE")],
+      tables: [{ alias: "u", table: "users", join: "primary" }, { alias: "u_s0" }],
       condition: {
         op: "and",
         conditions: [
-          { alias: "c", column: "parent_author_id", dbType: "int", cond: { kind: "is-null" } },
-          { alias: "c", column: "parent_book_id", dbType: "int", cond: { kind: "is-null" } },
-          { alias: "c", column: "parent_book_review_id", dbType: "int", cond: { kind: "is-null" } },
-          { alias: "c", column: "parent_publisher_id", dbType: "int", cond: { kind: "is-null" } },
-          { alias: "c", column: "parent_task_id", dbType: "int", cond: { kind: "is-null" } },
+          { alias: "u", column: "favorite_publisher_large_id", dbType: "int", cond: { kind: "is-null" } },
+          { alias: "u", column: "favorite_publisher_small_id", dbType: "int", cond: { kind: "is-null" } },
         ],
       },
       orderBys: [expect.anything()],

--- a/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
@@ -9,7 +9,7 @@ import {
   hasOne,
   hasOneToOne,
   isLoaded,
-  loadLens, New,
+  loadLens,
   newChangesProxy,
   newRequiredRule,
   setField,

--- a/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
@@ -100,7 +100,12 @@ export interface CommentFilter {
   updatedAt?: ValueFilter<Date, never>;
   user?: EntityFilter<User, UserId, FilterOf<User>, null>;
   likedByUsers?: EntityFilter<User, UserId, FilterOf<User>, null | undefined>;
-  parent?: EntityFilter<CommentParent, IdOf<CommentParent>, never, null | undefined>;
+  parent?: EntityFilter<CommentParent, IdOf<CommentParent>, never, never>;
+  parentAuthor?: EntityFilter<Author, IdOf<Author>, FilterOf<Author>, null>;
+  parentBook?: EntityFilter<Book, IdOf<Book>, FilterOf<Book>, null>;
+  parentBookReview?: EntityFilter<BookReview, IdOf<BookReview>, FilterOf<BookReview>, null>;
+  parentPublisher?: EntityFilter<Publisher, IdOf<Publisher>, FilterOf<Publisher>, null>;
+  parentTaskOld?: EntityFilter<TaskOld, IdOf<TaskOld>, FilterOf<TaskOld>, null>;
 }
 
 export interface CommentGraphQLFilter {
@@ -111,7 +116,12 @@ export interface CommentGraphQLFilter {
   updatedAt?: ValueGraphQLFilter<Date>;
   user?: EntityGraphQLFilter<User, UserId, GraphQLFilterOf<User>, null>;
   likedByUsers?: EntityGraphQLFilter<User, UserId, GraphQLFilterOf<User>, null | undefined>;
-  parent?: EntityGraphQLFilter<CommentParent, IdOf<CommentParent>, never, null | undefined>;
+  parent?: EntityGraphQLFilter<CommentParent, IdOf<CommentParent>, never, never>;
+  parentAuthor?: EntityGraphQLFilter<Author, IdOf<Author>, FilterOf<Author>, null>;
+  parentBook?: EntityGraphQLFilter<Book, IdOf<Book>, FilterOf<Book>, null>;
+  parentBookReview?: EntityGraphQLFilter<BookReview, IdOf<BookReview>, FilterOf<BookReview>, null>;
+  parentPublisher?: EntityGraphQLFilter<Publisher, IdOf<Publisher>, FilterOf<Publisher>, null>;
+  parentTaskOld?: EntityGraphQLFilter<TaskOld, IdOf<TaskOld>, FilterOf<TaskOld>, null>;
 }
 
 export interface CommentOrder {

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -119,7 +119,9 @@ export interface UserFilter {
   authorManyToOne?: EntityFilter<Author, AuthorId, FilterOf<Author>, null>;
   createdComments?: EntityFilter<Comment, CommentId, FilterOf<Comment>, null | undefined>;
   likedComments?: EntityFilter<Comment, CommentId, FilterOf<Comment>, null | undefined>;
-  favoritePublisher?: EntityFilter<UserFavoritePublisher, IdOf<UserFavoritePublisher>, never, null | undefined>;
+  favoritePublisher?: EntityFilter<UserFavoritePublisher, IdOf<UserFavoritePublisher>, never, null>;
+  favoritePublisherLargePublisher?: EntityFilter<LargePublisher, IdOf<LargePublisher>, FilterOf<LargePublisher>, null>;
+  favoritePublisherSmallPublisher?: EntityFilter<SmallPublisher, IdOf<SmallPublisher>, FilterOf<SmallPublisher>, null>;
 }
 
 export interface UserGraphQLFilter {
@@ -135,7 +137,19 @@ export interface UserGraphQLFilter {
   authorManyToOne?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>, null>;
   createdComments?: EntityGraphQLFilter<Comment, CommentId, GraphQLFilterOf<Comment>, null | undefined>;
   likedComments?: EntityGraphQLFilter<Comment, CommentId, GraphQLFilterOf<Comment>, null | undefined>;
-  favoritePublisher?: EntityGraphQLFilter<UserFavoritePublisher, IdOf<UserFavoritePublisher>, never, null | undefined>;
+  favoritePublisher?: EntityGraphQLFilter<UserFavoritePublisher, IdOf<UserFavoritePublisher>, never, null>;
+  favoritePublisherLargePublisher?: EntityGraphQLFilter<
+    LargePublisher,
+    IdOf<LargePublisher>,
+    FilterOf<LargePublisher>,
+    null
+  >;
+  favoritePublisherSmallPublisher?: EntityGraphQLFilter<
+    SmallPublisher,
+    IdOf<SmallPublisher>,
+    FilterOf<SmallPublisher>,
+    null
+  >;
 }
 
 export interface UserOrder {

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.165.0"
+  "version": "1.165.2"
 }

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.165.0"
+  "version": "1.165.2"
 }

--- a/packages/tests/temporal/joist-config.json
+++ b/packages/tests/temporal/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "temporal": { "timeZone": "America/Los_Angeles" },
-  "version": "1.165.0"
+  "version": "1.165.2"
 }

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.165.0"
+  "version": "1.165.2"
 }

--- a/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
@@ -20,6 +20,7 @@ import type {
   EntityFilter,
   EntityGraphQLFilter,
   EntityMetadata,
+  FilterOf,
   Flavor,
   IdOf,
   JsonPayload,
@@ -72,7 +73,9 @@ export interface CommentFilter {
   text?: ValueFilter<string, never>;
   createdAt?: ValueFilter<Date, never>;
   updatedAt?: ValueFilter<Date, never>;
-  parent?: EntityFilter<CommentParent, IdOf<CommentParent>, never, null | undefined>;
+  parent?: EntityFilter<CommentParent, IdOf<CommentParent>, never, never>;
+  parentAuthor?: EntityFilter<Author, IdOf<Author>, FilterOf<Author>, null>;
+  parentBook?: EntityFilter<Book, IdOf<Book>, FilterOf<Book>, null>;
 }
 
 export interface CommentGraphQLFilter {
@@ -80,7 +83,9 @@ export interface CommentGraphQLFilter {
   text?: ValueGraphQLFilter<string>;
   createdAt?: ValueGraphQLFilter<Date>;
   updatedAt?: ValueGraphQLFilter<Date>;
-  parent?: EntityGraphQLFilter<CommentParent, IdOf<CommentParent>, never, null | undefined>;
+  parent?: EntityGraphQLFilter<CommentParent, IdOf<CommentParent>, never, never>;
+  parentAuthor?: EntityGraphQLFilter<Author, IdOf<Author>, FilterOf<Author>, null>;
+  parentBook?: EntityGraphQLFilter<Book, IdOf<Book>, FilterOf<Book>, null>;
 }
 
 export interface CommentOrder {

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.165.0"
+  "version": "1.165.2"
 }


### PR DESCRIPTION
Previously filters on poly fields could not see below the immediate poly id value.

This was because each poly component has fundamentally different types.

This PR adds support by just exposing each poly component as a dedicated key in the filter, i.e.:

```ts
em.find(Comment, { parentBook: { title: "b1" } });
```

Where `Comment.parent` is a poly of `Author | Book`, and previously we could only filter on `parent: ...basic condition on the id...`.
