### PR TITLE
fix: Fix lens finds going through overwriteExisting path.

### DIFF
--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -58,7 +58,7 @@ export function findDataLoader<T extends Entity>(
         const preloadHydrator = preloader && hint && preloader.addPreloading(em, meta, buildHintTree(hint), query);
         const rows = await em.driver.executeFind(em, query, opts);
         ensureUnderLimit(em, rows);
-        const entities = em.hydrate(type, rows, { overwriteExisting: false });
+        const entities = em.hydrate(type, rows);
         preloadHydrator?.(rows, entities);
         return [entities];
       }
@@ -124,7 +124,7 @@ export function findDataLoader<T extends Entity>(
       const rows = await em.driver.executeQuery(em, cleanSql(sql), bindings);
       ensureUnderLimit(em, rows);
 
-      const entities = em.hydrate(type, rows, { overwriteExisting: false });
+      const entities = em.hydrate(type, rows);
       preloadJoins?.forEach((j) => j.hydrator(rows, entities));
 
       // Make an empty array for each batched query, per the dataloader contract

--- a/packages/orm/src/dataloaders/oneToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyDataLoader.ts
@@ -52,7 +52,7 @@ export function oneToManyDataLoader<T extends Entity, U extends Entity>(
 
     const rows = await em.driver.executeFind(em, query, {});
 
-    const entities = em.hydrate(meta.cstr, rows, { overwriteExisting: false });
+    const entities = em.hydrate(meta.cstr, rows);
     // .filter((e) => !e.isDeletedEntity);
 
     const entitiesById = groupBy(entities, (entity) => {

--- a/packages/orm/src/dataloaders/oneToManyFindDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyFindDataLoader.ts
@@ -66,8 +66,8 @@ export function oneToManyFindDataLoader<T extends Entity, U extends Entity>(
     // maybeAddNotSoftDeleted(conditions, meta, alias, "include");
 
     const rows = await em.driver.executeFind(em, query, {});
+    em.hydrate(collection.otherMeta.cstr, rows);
 
-    const entities = em.hydrate(collection.otherMeta.cstr, rows, { overwriteExisting: false });
     // Decode `id=b:1,author_id=a:1`
     return keys.map((k) => {
       const [otherKey, parentKey] = k.split(",");

--- a/packages/orm/src/dataloaders/oneToOneDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToOneDataLoader.ts
@@ -51,8 +51,7 @@ export function oneToOneDataLoader<T extends Entity, U extends Entity>(
     addTablePerClassJoinsAndClassTag(query, otherMeta, alias, true);
 
     const rows = await em.driver.executeFind(em, query, {});
-
-    const entities = em.hydrate(otherMeta.cstr, rows, { overwriteExisting: false });
+    const entities = em.hydrate(otherMeta.cstr, rows);
 
     const entitiesByOtherId = groupBy(entities, (entity) => {
       // TODO If this came from the UoW, it may not be an id? I.e. pre-insert.

--- a/packages/tests/integration/src/EntityManager.test.ts
+++ b/packages/tests/integration/src/EntityManager.test.ts
@@ -703,7 +703,7 @@ describe("EntityManager", () => {
     const em = newEntityManager();
     const a1 = await em.load(Author, "1");
     await knex.update({ first_name: "a1b" }).into("authors");
-    const [a1b] = em.hydrate(Author, await knex.select("*").from("authors"));
+    const [a1b] = em.hydrate(Author, await knex.select("*").from("authors"), { overwriteExisting: true });
     expect(a1b).toStrictEqual(a1);
     expect(a1b.firstName).toEqual("a1b");
   });


### PR DESCRIPTION
The `EM.hydrate` method is a somewhat private-ish method for loading an entity from a row result set.

It has conditional behavior on what to do if, when hydrating a row, that row has already been loaded into an in-memory entity.

The safest option is to ignore the new hydrate, because it might right over WIP changes in the current EM/entity.

However, the prior default was `overwriteExisting: true`, and then we just put `overwriteExisting: false` in a bunch of places. Which was fine, except we forgot one, in the lensDataLoader.

This surfaced as a bug in production not because of the incorrect overwriteExisting behavior, but because it highlighted that the overwriteExisting behavior was really pretty slow, because it had not been optimized to use the lazy row/data serde hand-off.

This PR flips the default of hydrate to `overwriteExisting: false`, which technically fixes the perf bug by skipping any hydrate logic for rows that are already loaded, but we do go ahead and optimize the `overwriteExisting: true` codepath as well.