### PR TITLE
fix: EntityManager.hydrate should clear dirty fields.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1487,10 +1487,15 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
         getInstanceData(entity).row = row;
         // And then only refresh the data keys that have already been serde-d from rows
         // (this keeps us from deserializing data out of rows that we don't need).
-        const { data } = getInstanceData(entity);
+        const { data, originalData } = getInstanceData(entity);
+        const changedFields = (entity as any).changes.fields;
         for (const fieldName of Object.keys(data)) {
           const serde = getMetadata(entity).allFields[fieldName].serde ?? fail(`Missing serde for ${fieldName}`);
           serde.setOnEntity(data, row);
+          // Make the field look not-dirty
+          if (changedFields.includes(fieldName)) {
+            delete originalData[fieldName];
+          }
         }
       }
       entities[i++] = entity;

--- a/packages/tests/integration/src/EntityManager.test.ts
+++ b/packages/tests/integration/src/EntityManager.test.ts
@@ -702,10 +702,12 @@ describe("EntityManager", () => {
     await insertAuthor({ first_name: "a1" });
     const em = newEntityManager();
     const a1 = await em.load(Author, "1");
-    await knex.update({ first_name: "a1b" }).into("authors");
+    a1.firstName = "a2";
+    expect(a1.changes.firstName.hasChanged).toBe(true);
+    await knex.update({ first_name: "a3" }).into("authors");
     const [a1b] = em.hydrate(Author, await knex.select("*").from("authors"), { overwriteExisting: true });
-    expect(a1b).toStrictEqual(a1);
-    expect(a1b.firstName).toEqual("a1b");
+    expect(a1b.firstName).toEqual("a3");
+    expect(a1.changes.firstName.hasChanged).toBe(false);
   });
 
   it("ignores sets of the same value", async () => {


### PR DESCRIPTION
This is just handling primitives; there is probably more work to be done in realizing that m2o values have changed, and keeping both sides of the newly-updated relation in sync.