### PR TITLE
fix(fields.ts): fail not defined

### DIFF
--- a/packages/orm/src/fields.ts
+++ b/packages/orm/src/fields.ts
@@ -3,7 +3,7 @@ import { Entity, isEntity } from "./Entity";
 import { getEmInternalApi } from "./EntityManager";
 import { getMetadata } from "./EntityMetadata";
 import { ensureNotDeleted, maybeResolveReferenceToId } from "./index";
-import { maybeRequireTemporal } from "./utils";
+import { fail, maybeRequireTemporal } from "./utils";
 
 /**
  * Returns the current value of `fieldName`, this is an internal method that should


### PR DESCRIPTION
Line 21 is throwing this error:

```sh
    ReferenceError: fail is not defined
```

Instead of the correct `Missing serde for myFieldName` error.

It looks like an import was added last week for `import { maybeRequireTemporal } from "./utils";` where there didn't used to be any imports from `./utils`, so maybe it used to be getting this for free or from the environment somehow?