### PR TITLE
fix: Add STI subtypes as per-type filters.

### DIFF
--- a/packages/codegen/src/inheritance.ts
+++ b/packages/codegen/src/inheritance.ts
@@ -112,6 +112,7 @@ function expandSingleTableInheritance(config: Config, entities: EntityDbMetadata
         entity.manyToManys = entity.manyToManys.filter((f) => !subTypeFieldNames.includes(f.fieldName));
         entity.largeManyToManys = entity.largeManyToManys.filter((f) => !subTypeFieldNames.includes(f.fieldName));
         entity.polymorphics = entity.polymorphics.filter((f) => !subTypeFieldNames.includes(f.fieldName));
+        entity.subTypes.push(subEntity);
 
         entities.push(subEntity);
       }

--- a/packages/tests/esm-misc/joist-config.json
+++ b/packages/tests/esm-misc/joist-config.json
@@ -10,5 +10,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.169.0"
+  "version": "1.170.0"
 }

--- a/packages/tests/immediate-foreign-keys/joist-config.json
+++ b/packages/tests/immediate-foreign-keys/joist-config.json
@@ -16,5 +16,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.169.0"
+  "version": "1.170.0"
 }

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -94,5 +94,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.169.0"
+  "version": "1.170.0"
 }

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -48,6 +48,8 @@ import {
   PublisherSize,
   SmallPublisher,
   Tag,
+  TaskItem,
+  TaskItemFilter,
   User,
   UserFilter,
   newAuthor,
@@ -64,6 +66,7 @@ const pm = getMetadata(Publisher);
 const cm = getMetadata(Comment);
 const um = getMetadata(User);
 const criticMeta = getMetadata(Critic);
+const taskItemMeta = getMetadata(TaskItem);
 const opts = { softDeletes: "include" } as const;
 
 describe("EntityManager.queries", () => {
@@ -2235,6 +2238,25 @@ describe("EntityManager.queries", () => {
         op: "and",
         conditions: [
           { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
+        ],
+      },
+      orderBys: [expect.anything()],
+    });
+  });
+
+  it("can find through m2o with subtype only fields", async () => {
+    const where = { taskTaskNew: { specialNewField: 1 } } satisfies TaskItemFilter;
+    expect(parseFindQuery(taskItemMeta, where, opts)).toMatchObject({
+      selects: [`ti.*`],
+      tables: [
+        { alias: "ti", table: "task_items", join: "primary" },
+        { alias: "t", table: "tasks", join: "outer", col1: "ti.task_id", col2: "t.id" },
+      ],
+      condition: {
+        op: "and",
+        conditions: [
+          { alias: "t", column: "type_id", dbType: "int", cond: { kind: "eq", value: 2 } },
+          { alias: "t", column: "special_new_field", dbType: "int", cond: { kind: "eq", value: 1 } },
         ],
       },
       orderBys: [expect.anything()],

--- a/packages/tests/integration/src/SingleTableInheritance.test.ts
+++ b/packages/tests/integration/src/SingleTableInheritance.test.ts
@@ -1,16 +1,17 @@
 import { getProperties } from "joist-orm";
 import {
-  Task,
-  TaskNew,
-  TaskOld,
-  TaskType,
   newAuthor,
   newTask,
   newTaskItem,
   newTaskNew,
   newTaskOld,
+  Task,
+  TaskItem,
+  TaskNew,
+  TaskOld,
+  TaskType,
 } from "src/entities";
-import { insertTask, select } from "src/entities/inserts";
+import { insertTask, insertTaskItem, select } from "src/entities/inserts";
 import { newEntityManager, queries, resetQueryCount } from "src/testEm";
 
 describe("SingleTableInheritance", () => {
@@ -368,6 +369,15 @@ describe("SingleTableInheritance", () => {
     newTaskNew(em, { deletedAt: new Date(), specialNewAuthor: a });
     await em.flush();
     expect(a.tasks.get).toMatchEntity([]);
+  });
+
+  it("can filter using subtype specific filters", async () => {
+    await insertTask({ type: "NEW", special_new_field: 1 });
+    await insertTask({ type: "OLD", special_old_field: 1 });
+    await insertTaskItem({ task_id: 1 });
+    const em = newEntityManager();
+    const items = await em.find(TaskItem, { taskTaskNew: { specialNewField: 1 } });
+    expect(items).toMatchEntity([{}]);
   });
 
   it("runs reactive validation rules", async () => {

--- a/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
@@ -79,6 +79,8 @@ export interface TaskItemFilter {
   newTask?: EntityFilter<TaskNew, TaskNewId, FilterOf<TaskNew>, null>;
   oldTask?: EntityFilter<TaskOld, TaskOldId, FilterOf<TaskOld>, null>;
   task?: EntityFilter<Task, TaskId, FilterOf<Task>, null>;
+  taskTaskNew?: EntityFilter<TaskNew, TaskNewId, FilterOf<TaskNew>, null>;
+  taskTaskOld?: EntityFilter<TaskOld, TaskOldId, FilterOf<TaskOld>, null>;
 }
 
 export interface TaskItemGraphQLFilter {
@@ -88,6 +90,8 @@ export interface TaskItemGraphQLFilter {
   newTask?: EntityGraphQLFilter<TaskNew, TaskNewId, GraphQLFilterOf<TaskNew>, null>;
   oldTask?: EntityGraphQLFilter<TaskOld, TaskOldId, GraphQLFilterOf<TaskOld>, null>;
   task?: EntityGraphQLFilter<Task, TaskId, GraphQLFilterOf<Task>, null>;
+  taskTaskNew?: EntityGraphQLFilter<TaskNew, TaskNewId, GraphQLFilterOf<TaskNew>, null>;
+  taskTaskOld?: EntityGraphQLFilter<TaskOld, TaskOldId, GraphQLFilterOf<TaskOld>, null>;
 }
 
 export interface TaskItemOrder {

--- a/packages/tests/integration/src/entities/inserts.ts
+++ b/packages/tests/integration/src/entities/inserts.ts
@@ -64,6 +64,11 @@ export function insertTask(row: {
   });
 }
 
+export function insertTaskItem(row: { id?: number; task_id?: number }) {
+  const { ...rest } = row;
+  return testDriver.insert("task_items", { ...rest });
+}
+
 export function insertBook(row: {
   id?: number;
   title: string;

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.169.0"
+  "version": "1.170.0"
 }

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.169.0"
+  "version": "1.170.0"
 }

--- a/packages/tests/temporal/joist-config.json
+++ b/packages/tests/temporal/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "temporal": { "timeZone": "America/Los_Angeles" },
-  "version": "1.169.0"
+  "version": "1.170.0"
 }

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -8,5 +8,5 @@
   },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.169.0"
+  "version": "1.170.0"
 }

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.169.0"
+  "version": "1.170.0"
 }


### PR DESCRIPTION
When we have base types, the normal filter only exposes the fields available on the base type/all subtypes.

However we recently allowed to subtype-specific filtering with a syntax of `<field><subtype>`, typed to the subtype filter, which then allowed using each of the subtype's fields.

We built this for CTI, but STI should have gotten it for free, except that the STI.subtypes field was not getting wired up correctly, and so it just got skipped by accident.