### PR TITLE
feat: Optionally allow unsaved entities to be returned from a resolver

### DIFF
--- a/packages/test-utils/src/run.ts
+++ b/packages/test-utils/src/run.ts
@@ -1,4 +1,4 @@
-import { Entity, EntityManager, isEntity } from "joist-orm";
+import { Entity, EntityManager, isDefined, isEntity } from "joist-orm";
 import { fail } from "joist-utils";
 import { Context } from "./context";
 
@@ -6,11 +6,16 @@ type MaybePromise<T> = T | Promise<T>;
 
 export type ContextFn<C> = (ctx: C) => MaybePromise<C>;
 
+type RunOptions = {
+  expectUnsavedEntities?: boolean;
+};
+
 /** Runs the `fn` in a dedicated / non-test Unit of Work . */
 export async function run<C extends Context, T>(
   ctx: C,
   fn: (ctx: C) => MaybePromise<T>,
   contextFn: ContextFn<C> = newContext,
+  opts?: RunOptions,
 ): Promise<T> {
   const { em } = ctx;
   // Ensure any test data we've setup is flushed
@@ -18,14 +23,14 @@ export async function run<C extends Context, T>(
   const result = await fn(await contextFn(ctx));
   // We expect `fn` (i.e. a resolver) to do its own UoW management, so don't flush.
   await em.refresh({ deepLoad: true });
-  return mapResultToOriginalEm(em, result);
+  return mapResultToOriginalEm(em, result, opts);
 }
 
 /** Creates a `run` with a custom `newContext` method. */
 export function makeRun<C extends Context>(
   contextFn: ContextFn<C>,
-): <T>(ctx: C, fn: (ctx: C) => MaybePromise<T>) => Promise<T> {
-  return (ctx, fn) => run(ctx, fn, contextFn);
+): <T>(ctx: C, fn: (ctx: C) => MaybePromise<T>, opts?: RunOptions) => Promise<T> {
+  return (ctx, fn, opts) => run(ctx, fn, contextFn, opts);
 }
 
 /** Runs the `fn` in a dedicated / non-test Unit of Work for each value in `values */
@@ -72,24 +77,31 @@ function gatherEntities(result: any): Entity[] {
   }
 }
 
-async function mapResultToOriginalEm<R>(em: EntityManager, result: R): Promise<R> {
+async function mapResultToOriginalEm<R>(em: EntityManager, result: R, opts?: RunOptions): Promise<R> {
   const newEmEntities = gatherEntities(result);
   // load any entities that don't exist in the original em
   await Promise.all(
     newEmEntities
-      .filter(
-        (e) =>
-          !em.findExistingInstance(
-            e.idTaggedMaybe ?? fail("Joist 'run' returned an unsaved entity; are you missing an em.flush?"),
-          ),
-      )
+      .filter((e) => {
+        if (e.idTaggedMaybe === undefined) {
+          if (opts?.expectUnsavedEntities === true) return false;
+          fail("Joist 'run' returned an unsaved entity; are you missing an em.flush?");
+        }
+        return !em.findExistingInstance(e.idTaggedMaybe);
+      })
       .map((e) => em.load(e.idTagged)),
   );
   // generate a cache of id -> entity in original em
-  const cache = Object.fromEntries(newEmEntities.map((e) => [e.id, em.findExistingInstance(e.idTagged) as Entity]));
+  const cache = Object.fromEntries(
+    newEmEntities
+      // Exclude entities which have not been flushed, so that they don't fail the lookup
+      .filter((e) => isDefined(e.idTaggedMaybe))
+      .map((e) => [e.id, em.findExistingInstance(e.idTagged) as Entity]),
+  );
   function doMap(value: any): any {
     if (isEntity(value)) {
-      return cache[value.id];
+      // If the value has no ID, simply return it as is
+      return value.idMaybe ? cache[value.id] : value;
     } else if (Array.isArray(value)) {
       return value.map(doMap) as any;
     } else if (typeof value === "object" && value?.constructor === Object) {


### PR DESCRIPTION
For some circumstances, like a mutation which supports a `dryRun` option, it would be nice if resolvers could return unsaved entities, without the test helpers failing.

This PR introduces an optional flag to `run` methods to facilitate this.