### PR TITLE
fix: Allow ReactiveReferences to be accessed when already loaded.

### DIFF
--- a/packages/orm/src/relations/ReactiveReference.ts
+++ b/packages/orm/src/relations/ReactiveReference.ts
@@ -140,6 +140,9 @@ export class ReactiveReferenceImpl<
   private doGet(opts?: { withDeleted?: boolean }): U | N {
     const { fn } = this;
     ensureNotDeleted(this.entity, "pending");
+    // Call isLoaded to probe the load hint, and get `_isLoaded` set, but still have
+    // our `if` check the raw `_isLoaded` to know if we should eval-latest or return `loaded`.
+    this.isLoaded;
     // We assume `isLoaded` has been called coming into this to manage
     if (this._isLoaded === "full") {
       const newValue = this.filterDeleted(fn(this.entity as Reacted<T, H>), opts);
@@ -150,6 +153,10 @@ export class ReactiveReferenceImpl<
       if (!getEmInternalApi(this.entity.em).isValidating) {
         this.setImpl(newValue);
       }
+      // ...should we store the `newValue` as `loaded`? It seems like a good idea, just in
+      // case our graph mutates & we become "not fully loaded" some time later, but going
+      // to leave this out for now, until we have a need/test case covering the behavior.
+      // this.loaded = newValue;
       return this.maybeFindEntity();
     } else if (this._isLoaded) {
       return this.loaded as U | N;

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -212,7 +212,9 @@ export class Author extends AuthorCodegen {
       if (books.length === 0) {
         return undefined;
       }
-      const bestRating = Math.max(...books.flatMap((b) => b.reviews.get).map((r) => r.rating));
+      const ratings = books.flatMap((b) => b.reviews.get).map((r) => r.rating);
+      if (ratings.length === 0) return books[0].fullNonReactiveAccess;
+      const bestRating = Math.max(...ratings);
       return books.find((b) => b.reviews.get.some((r) => r.rating === bestRating)) as Book | undefined;
     },
   );


### PR DESCRIPTION
I.e. on factories that are DeepNew.

---

**Stack**:
- #1129
- #1132
- #1131
- #1128 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*