### PR TITLE
feat: Add reaction logging

### DIFF
--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -114,6 +114,15 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
     }
   }
 
+  toTaggedString(): string {
+    if (this.idMaybe) {
+      return this.idTagged;
+    }
+    const meta = getMetadata(this);
+    const sameType = this.em.entities.filter((e) => e instanceof meta.cstr);
+    return `${meta.tagName}#${sameType.indexOf(this) + 1}`;
+  }
+
   public get em(): EM {
     return this.__data.em as EM;
   }

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -28,4 +28,11 @@ export interface Entity {
    * name / display name.
    */
   toString(): string;
+  /**
+   * Returns `tag:id`, i.e. `a:1` for persisted entities and `a#1` for new entities.
+   *
+   * This is meant to be used for developer-facing logging and debugging, and not a user-facing
+   * name / display name.
+   */
+  toTaggedString(): string;
 }

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -7,7 +7,7 @@ import { getField, setField } from "./fields";
 import { Entity, Entity as EntityW, IdType, isEntity } from "./Entity";
 import { FlushLock } from "./FlushLock";
 import { JoinRows } from "./JoinRows";
-import { ReactionsManager } from "./ReactionsManager";
+import { ReactionLogger, ReactionsManager } from "./ReactionsManager";
 import { JoinRowTodo, Todo, combineJoinRows, createTodos } from "./Todo";
 import { ReactiveRule, constraintNameToValidationError } from "./config";
 import { createOrUpdatePartial } from "./createOrUpdatePartial";
@@ -1618,6 +1618,12 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
     }
     // For all relations, unhook the entity from the other side
     await Promise.all(relationsToCleanup.map((r) => r.cleanupOnEntityDeleted()));
+  }
+
+  setReactionLogging(logger: ReactionLogger): void;
+  setReactionLogging(enabled: boolean): void;
+  setReactionLogging(arg: boolean | ReactionLogger): void {
+    this.#rm.setLogger(typeof arg === "boolean" ? (arg ? new ReactionLogger() : undefined) : arg);
   }
 }
 

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1105,7 +1105,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
       if (baseMeta.inheritanceType === "sti") {
         setStiDiscriminatorValue(baseMeta, entity);
       }
-      this.#rm.queueAllDownstreamFields(entity);
+      this.#rm.queueAllDownstreamFields(entity, "created");
     }
   }
 
@@ -1125,7 +1125,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
     const alreadyMarked = getInstanceData(entity).markDeleted();
     if (!alreadyMarked) return;
     // Any derived fields that read this entity will need recalc-d
-    this.#rm.queueAllDownstreamFields(entity);
+    this.#rm.queueAllDownstreamFields(entity, "deleted");
     // Synchronously unhook the entity if the relations are loaded
     getCascadeDeleteRelations(entity).forEach((r) => r.maybeCascadeDelete());
     // And queue the cascade deletes

--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -184,12 +184,16 @@ export class ReactionsManager {
             green.bold(`${rf.cstr.name}`) + green(".") + yellow(rf.name),
             gray("to recalc"),
           );
-          logger?.log(
-            "   ", // indent
-            todo.map((e) => e.idMaybe).join(","),
-            "->",
-            relations.map((r) => r.entity.idMaybe).join(","),
-          );
+          if (relations.length > 0) {
+            logger?.log(
+              "   ", // indent
+              gray("["),
+              todo.map((e) => e.toTaggedString()).join(" "),
+              gray("] -> ["),
+              [...new Set(relations)].map((r) => r.entity.toTaggedString()).join(" "),
+              gray("]"),
+            );
+          }
           return relations;
         }),
       );

--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -176,10 +176,19 @@ export class ReactionsManager {
           const from = todo[0].constructor.name;
           logger?.log(
             " ", // indent
-            gray(`Loading (${todo.length})`),
-            green.bold(`${from}s`) + green(`.${rf.path.join(".")}.`) + yellow(rf.name),
-            gray("found for"),
-            green.bold(`${relations.length} ${rf.cstr.name}s`),
+            gray(`Walked`),
+            white(`${todo.length}`),
+            green.bold(`${from}`) + green(`.${rf.path.join(".")}`),
+            gray("paths, found"),
+            white(`${relations.length}`),
+            green.bold(`${rf.cstr.name}`) + green(".") + yellow(rf.name),
+            gray("to recalc"),
+          );
+          logger?.log(
+            "   ", // indent
+            todo.map((e) => e.idMaybe).join(","),
+            "->",
+            relations.map((r) => r.entity.idMaybe).join(","),
           );
           return relations;
         }),

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -27,6 +27,7 @@ export { EntityOrId, HintNode } from "./HintTree";
 export { InstanceData } from "./InstanceData";
 export * from "./QueryBuilder";
 export * from "./QueryParser";
+export { setReactionLogging, setReactionWriter } from "./ReactionsManager";
 export * from "./changes";
 export { ConfigApi, EntityHook } from "./config";
 export { configureMetadata, getConstructorFromTaggedId, maybeGetConstructorFromReference } from "./configure";
@@ -38,25 +39,25 @@ export * from "./json";
 export * from "./keys";
 export { kq, kqDot, kqStar } from "./keywords";
 export {
-  DeepNew,
-  LoadHint,
-  Loadable,
-  Loaded,
-  MarkLoaded,
-  NestedLoadHint,
-  New,
-  RelationsIn,
   assertLoaded,
+  DeepNew,
   ensureLoaded,
   isLoaded,
   isNew,
+  Loadable,
+  Loaded,
+  LoadHint,
+  MarkLoaded,
   maybePopulateThen,
+  NestedLoadHint,
+  New,
+  RelationsIn,
 } from "./loadHints";
 export * from "./loadLens";
 export {
+  defaultValue,
   FactoryEntityOpt,
   FactoryOpts,
-  defaultValue,
   getTestIndex,
   maybeBranchValue,
   maybeNew,
@@ -72,21 +73,21 @@ export { JoinResult, PreloadHydrator, PreloadPlugin } from "./plugins/PreloadPlu
 export { Reactable, Reacted, ReactiveHint, reverseReactiveHint } from "./reactiveHints";
 export * from "./relations";
 export {
-  GenericError,
-  ValidationError,
-  ValidationErrors,
-  ValidationRule,
-  ValidationRuleResult,
   cannotBeUpdated,
+  GenericError,
   maxValueRule,
   minValueRule,
   mustBeSubType,
   newRequiredRule,
   rangeValueRule,
+  ValidationError,
+  ValidationErrors,
+  ValidationRule,
+  ValidationRuleResult,
 } from "./rules";
 export * from "./serde";
 export { asNew, assertNever, cleanStringValue, fail, indexBy } from "./utils";
-export { WithLoaded, ensureWithLoaded, withLoaded } from "./withLoaded";
+export { ensureWithLoaded, WithLoaded, withLoaded } from "./withLoaded";
 
 // https://spin.atomicobject.com/2018/01/15/typescript-flexible-nominal-typing/
 interface Flavoring<FlavorT> {

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -27,7 +27,7 @@ export { EntityOrId, HintNode } from "./HintTree";
 export { InstanceData } from "./InstanceData";
 export * from "./QueryBuilder";
 export * from "./QueryParser";
-export { setReactionLogging, setReactionWriter } from "./ReactionsManager";
+export { ReactionLogger, setReactionLogging } from "./ReactionsManager";
 export * from "./changes";
 export { ConfigApi, EntityHook } from "./config";
 export { configureMetadata, getConstructorFromTaggedId, maybeGetConstructorFromReference } from "./configure";

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -60,6 +60,7 @@ export const testZonedDateTime = testPlainDate?.toZonedDateTime("UTC");
 
 let logger: FactoryLogger | undefined = undefined;
 let writer: WriteFn | undefined = undefined;
+type WriteFn = (line: string) => void;
 
 /**
  * Creates a test instance of `T`.
@@ -775,8 +776,6 @@ class CopyMap extends Map<Function, UseMapValue> {
     return super.set(k, v);
   }
 }
-
-type WriteFn = (line: string) => void;
 
 class FactoryLogger {
   private level = 0;

--- a/packages/orm/src/relations/Relation.ts
+++ b/packages/orm/src/relations/Relation.ts
@@ -16,6 +16,7 @@ export interface Relation<T extends Entity, U extends Entity> {
   [RelationT]: T;
   [RelationU]: U;
   isLoaded: boolean;
+  entity: Entity;
 }
 
 /** Type guard utility for determining if an entity field is a Relation. */

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -5,7 +5,6 @@ import {
   Collection,
   Entity,
   EntityManager,
-  getMetadata,
   isAsyncProperty,
   isCollection,
   isDefined,
@@ -57,13 +56,8 @@ function maybeTestId(maybeEntity: any): any {
 }
 
 /** Returns either the persisted id or `tag#<offset-in-EntityManager>`. */
-function getTestId(em: EntityManager, entity: Entity): string {
-  if (entity.idMaybe) {
-    return entity.idTagged;
-  }
-  const meta = getMetadata(entity);
-  const sameType = em.entities.filter((e) => e instanceof meta.cstr);
-  return `${meta.tagName}#${sameType.indexOf(entity) + 1}`;
+function getTestId(_: EntityManager, entity: Entity): string {
+  return entity.toTaggedString();
 }
 
 /**

--- a/packages/tests/integration/src/relations/ReactiveReference.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveReference.test.ts
@@ -159,8 +159,8 @@ describe("ReactiveReference", () => {
     expect(rows).toMatchObject([{ id: 1, titles_of_favorite_books: "b22" }]);
     expect(reactionOutput).toMatchInlineSnapshot(`
      [
-       "Book:1.title changed, queuing Book:1.author.search↩",
-       "Book:1.title changed, queuing Book:1.favoriteAuthor.publisher.titlesOfFavoriteBooks↩",
+       "b:1.title changed, queuing b:1.author.search↩",
+       "b:1.title changed, queuing b:1.favoriteAuthor.publisher.titlesOfFavoriteBooks↩",
        "Recalculating reactive fields values...↩",
        "  Walked 1 Book.author paths, found 1 Author.search to recalc↩",
        "    [ b:1 ] -> [ a:1 ]↩",

--- a/packages/tests/integration/src/relations/ReactiveReference.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveReference.test.ts
@@ -1,7 +1,7 @@
 import { Author, Book, BookReview, newAuthor } from "@src/entities";
 import { insertAuthor, insertBook, insertBookReview, insertPublisher, select, update } from "@src/entities/inserts";
 import { newEntityManager, queries, resetQueryCount } from "@src/testEm";
-import { setReactionLogging, setReactionWriter } from "joist-orm";
+import { ReactionLogger, setReactionLogging } from "joist-orm";
 import ansiRegex = require("ansi-regex");
 
 let reactionOutput: string[] = [];
@@ -172,16 +172,14 @@ describe("ReactiveReference", () => {
 });
 
 beforeEach(() => {
-  setReactionWriter((line: string) => {
-    reactionOutput.push(line.replace(ansiRegex(), "").replace("\n", "↩"));
-  });
-  setReactionLogging(true);
-});
-
-afterEach(() => {
   reactionOutput = [];
+  setReactionLogging(
+    new ReactionLogger((line: string) => {
+      reactionOutput.push(line.replace(ansiRegex(), "").replace("\n", "↩"));
+    }),
+  );
 });
 
 afterAll(() => {
-  setReactionWriter(undefined);
+  setReactionLogging(false);
 });

--- a/packages/tests/integration/src/relations/ReactiveReference.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveReference.test.ts
@@ -162,8 +162,10 @@ describe("ReactiveReference", () => {
        "Book:1.title changed, queuing Book:1.author.search↩",
        "Book:1.title changed, queuing Book:1.favoriteAuthor.publisher.titlesOfFavoriteBooks↩",
        "Recalculating reactive fields values...↩",
-       "  Loading (1) Books.author.search found for 1 Authors↩",
-       "  Loading (1) Books.favoriteAuthor.publisher.titlesOfFavoriteBooks found for 1 Publishers↩",
+       "  Walked 1 Book.author paths, found 1 Author.search to recalc↩",
+       "    [ b:1 ] -> [ a:1 ]↩",
+       "  Walked 1 Book.favoriteAuthor.publisher paths, found 1 Publisher.titlesOfFavoriteBooks to recalc↩",
+       "    [ b:1 ] -> [ p:1 ]↩",
      ]
     `);
   });


### PR DESCRIPTION
* Enable with `setReactionLogging(true)` for global logging
* Enable with `em.setReactionLogging(true)` for per-EM logging
* Adds `Entity.toTaggedString()` which could be useful elsewhere

![image](https://github.com/joist-orm/joist-orm/assets/6401/7bebd267-0009-44eb-a41d-2a09f3b99b89)

Another example:

![image](https://github.com/joist-orm/joist-orm/assets/6401/f3191fb8-c757-4476-a819-d2e8a759d192)
