### PR TITLE
fix: Prune undefined order bys.

### DIFF
--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -391,6 +391,7 @@ export function parseFindQuery(
     const entries = Object.entries(orderBy);
     if (entries.length === 0) return;
     for (const [key, value] of entries) {
+      if (!value) continue; // prune undefined
       const field = meta.allFields[key] ?? fail(`${key} not found on ${meta.tableName}`);
       if (field.kind === "primitive" || field.kind === "primaryKey" || field.kind === "enum") {
         const column = field.serde.columns[0];

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -1463,6 +1463,24 @@ describe("EntityManager.queries", () => {
     });
   });
 
+  it("can prune order by undefined", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2" });
+
+    const em = newEntityManager();
+    const orderBy = { firstName: undefined } satisfies AuthorOrder;
+    const authors = await em.find(Author, {}, { orderBy });
+    expect(authors.length).toEqual(2);
+    expect(authors[0].firstName).toEqual("a1");
+    expect(authors[1].firstName).toEqual("a2");
+
+    expect(parseFindQuery(am, {}, { ...opts, orderBy })).toEqual({
+      selects: [`a.*`],
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
+      orderBys: [{ alias: "a", column: "id", order: "ASC" }],
+    });
+  });
+
   it("can order by multiple m2os", async () => {
     await insertPublisher({ id: 1, name: "p1" });
     await insertPublisher({ id: 2, name: "p2" });


### PR DESCRIPTION
Previously Knex was helping out and defaulting these to ASC.