### PR TITLE
feat: Add loading info to ReactionLogger output.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -228,7 +228,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
   #dataloaders: Record<string, LoaderCache> = {};
   readonly #joinRows: Record<string, JoinRows> = {};
   /** Stores any `source -> downstream` reactions to recalc during `em.flush`. */
-  readonly #rm = new ReactionsManager();
+  readonly #rm = new ReactionsManager(this);
   /** Ensures our `em.flush` method is not interrupted. */
   readonly #fl = new FlushLock();
   readonly #hooks: Record<EntityManagerHook, HookFn[]> = { beforeTransaction: [], afterTransaction: [] };

--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -2,7 +2,7 @@ import ansis from "ansis";
 import { Entity } from "./Entity";
 import { EntityMetadata, getBaseAndSelfMetas, getMetadata } from "./EntityMetadata";
 import { ReactiveField } from "./config";
-import { NoIdError } from "./index";
+import { EntityManager, NoIdError } from "./index";
 import { followReverseHint } from "./reactiveHints";
 import { Relation } from "./relations";
 import { AbstractPropertyImpl } from "./relations/AbstractPropertyImpl";
@@ -40,6 +40,11 @@ export class ReactionsManager {
   private relationsPendingAssignedIds: Set<Relation<any, any>> = new Set();
   private needsRecalc = { populate: false, query: false };
   private logger: ReactionLogger | undefined = globalLogger;
+  private em: EntityManager;
+
+  constructor(em: EntityManager) {
+    this.em = em;
+  }
 
   /**
    * Queue all downstream reactive fields that depend on `fieldName` as a source field.
@@ -138,7 +143,7 @@ export class ReactionsManager {
     // Map our parameter `kind` value (which is a nicer name) to the shorter ADT kind
     const k = kind === "reactiveFields" ? "populate" : "query";
     if (this.needsRecalc[k]) {
-      this.logger?.logStartingRecalc(kind);
+      this.logger?.logStartingRecalc(this.em, kind);
     }
 
     let loops = 0;
@@ -171,13 +176,13 @@ export class ReactionsManager {
       // Multiple reactions could have pointed back to the same reactive field, so
       // dedupe the found relations before calling .load.
       const unique = [...new Set(relations.flat())];
-      this.logger?.logLoading(unique);
+      this.logger?.logLoading(this.em, unique);
       // Use allSettled so that we can watch for derived values that want to use the entity'd id,
       // i.e. they can fail, but we'll queue them from later.
       const startTime = this.logger?.now() ?? 0;
       const results = await Promise.allSettled(unique.map((r: any) => r.load()));
       const endTime = this.logger?.now() ?? 0;
-      this.logger?.logLoadingTime(endTime - startTime);
+      this.logger?.logLoadingTime(this.em, endTime - startTime);
       const failures: any[] = [];
       results.forEach((result, i) => {
         if (result.status === "rejected") {
@@ -273,8 +278,11 @@ export class ReactionLogger {
     );
   }
 
-  logStartingRecalc(kind: "reactiveFields" | "reactiveQueries"): void {
-    this.log(white.bold(`Recalculating reactive ${kind === "reactiveQueries" ? "queries" : "fields"} values...`));
+  logStartingRecalc(em: EntityManager, kind: "reactiveFields" | "reactiveQueries"): void {
+    this.log(
+      white.bold(`Recalculating reactive ${kind === "reactiveQueries" ? "queries" : "fields"} values...`),
+      this.entityCount(em),
+    );
   }
 
   logWalked(todo: Entity[], rf: ReactiveField, relations: Relation<any, any>[]): void {
@@ -302,8 +310,8 @@ export class ReactionLogger {
     }
   }
 
-  logLoading(relations: any[]): void {
-    this.log(" ", gray("Loading"), String(relations.length), gray("relations..."));
+  logLoading(em: EntityManager, relations: any[]): void {
+    this.log(" ", gray("Loading"), String(relations.length), gray("relations..."), this.entityCount(em));
     // Group by the relation name
     [...groupBy(relations, (r) => `${r.entity.constructor.name}.${r.fieldName}`).entries()].forEach(([, relations]) => {
       const r = relations[0];
@@ -317,8 +325,12 @@ export class ReactionLogger {
     });
   }
 
-  logLoadingTime(millis: number): void {
-    this.log("   ", gray("took"), String(Math.floor(millis)), gray("millis"));
+  logLoadingTime(em: EntityManager, millis: number): void {
+    this.log("   ", gray("took"), String(Math.floor(millis)), gray("millis"), this.entityCount(em));
+  }
+
+  private entityCount(em: EntityManager): string {
+    return gray("(em.entities=") + em.entities.length + gray(")");
   }
 
   private log(...line: string[]): void {

--- a/packages/tests/integration/src/relations/ReactiveReference.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveReference.test.ts
@@ -166,6 +166,10 @@ describe("ReactiveReference", () => {
        "    [ b:1 ] -> [ a:1 ]↩",
        "  Walked 1 Book.favoriteAuthor.publisher paths, found 1 Publisher.titlesOfFavoriteBooks to recalc↩",
        "    [ b:1 ] -> [ p:1 ]↩",
+       "  Loading 2 relations...↩",
+       "    Author.search -> [ a:1 ]↩",
+       "    SmallPublisher.titlesOfFavoriteBooks -> [ p:1 ]↩",
+       "    took 0 millis↩",
      ]
     `);
   });
@@ -174,9 +178,17 @@ describe("ReactiveReference", () => {
 beforeEach(() => {
   reactionOutput = [];
   setReactionLogging(
-    new ReactionLogger((line: string) => {
-      reactionOutput.push(line.replace(ansiRegex(), "").replace("\n", "↩"));
-    }),
+    new (class extends ReactionLogger {
+      constructor() {
+        super((line: string) => {
+          reactionOutput.push(line.replace(ansiRegex(), "").replace("\n", "↩"));
+        });
+      }
+      // Ensure deterministic output
+      now() {
+        return 0;
+      }
+    })(),
   );
 });
 

--- a/packages/tests/integration/src/relations/ReactiveReference.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveReference.test.ts
@@ -161,15 +161,15 @@ describe("ReactiveReference", () => {
      [
        "b:1.title changed, queuing b:1.author.search↩",
        "b:1.title changed, queuing b:1.favoriteAuthor.publisher.titlesOfFavoriteBooks↩",
-       "Recalculating reactive fields values...↩",
+       "Recalculating reactive fields values... (1 EM entities)↩",
        "  Walked 1 Book.author paths, found 1 Author.search to recalc↩",
        "    [ b:1 ] -> [ a:1 ]↩",
        "  Walked 1 Book.favoriteAuthor.publisher paths, found 1 Publisher.titlesOfFavoriteBooks to recalc↩",
        "    [ b:1 ] -> [ p:1 ]↩",
-       "  Loading 2 relations...↩",
+       "  Loading 2 relations... (3 EM entities)↩",
        "    Author.search -> [ a:1 ]↩",
        "    SmallPublisher.titlesOfFavoriteBooks -> [ p:1 ]↩",
-       "    took 0 millis↩",
+       "    took 0 millis (3 EM entities)↩",
      ]
     `);
   });

--- a/packages/tests/integration/src/relations/ReactiveReference.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveReference.test.ts
@@ -161,15 +161,15 @@ describe("ReactiveReference", () => {
      [
        "b:1.title changed, queuing b:1.author.search↩",
        "b:1.title changed, queuing b:1.favoriteAuthor.publisher.titlesOfFavoriteBooks↩",
-       "Recalculating reactive fields values... (1 EM entities)↩",
+       "Recalculating reactive fields values... (em.entities=1)↩",
        "  Walked 1 Book.author paths, found 1 Author.search to recalc↩",
        "    [ b:1 ] -> [ a:1 ]↩",
        "  Walked 1 Book.favoriteAuthor.publisher paths, found 1 Publisher.titlesOfFavoriteBooks to recalc↩",
        "    [ b:1 ] -> [ p:1 ]↩",
-       "  Loading 2 relations... (3 EM entities)↩",
+       "  Loading 2 relations... (em.entities=3)↩",
        "    Author.search -> [ a:1 ]↩",
        "    SmallPublisher.titlesOfFavoriteBooks -> [ p:1 ]↩",
-       "    took 0 millis (3 EM entities)↩",
+       "    took 0 millis (em.entities=3)↩",
      ]
     `);
   });


### PR DESCRIPTION
We already logged the "changed --> downstream" walking, now also log what explicitly we're loading + how long it takes:

![image](https://github.com/user-attachments/assets/c2cb9852-79c2-4bd0-a31d-aa882831cf06)

