### PR TITLE
fix: Fix synchronous defaults on m2o fields.

### DIFF
--- a/packages/orm/src/defaults.ts
+++ b/packages/orm/src/defaults.ts
@@ -14,6 +14,7 @@ export function hasDefaultValue(meta: EntityMetadata, fieldName: string): boolea
 export function setSyncDefaults(entity: Entity): void {
   getBaseAndSelfMetas(getMetadata(entity)).forEach((m) => {
     for (const [field, maybeFn] of Object.entries(m.config.__data.syncDefaults)) {
+      const value = (entity as any)[field];
       // Use allFields in case a subtype sets a default for one of its base fields
       if (m.allFields[field].kind === "primitive" && (m.allFields[field] as PrimitiveField)["derived"] === "async") {
         // If this is a ReactiveQueryField, we want to push in a default, but setOpts is called
@@ -21,8 +22,10 @@ export function setSyncDefaults(entity: Entity): void {
         // not have been initialized yet (i.e. `entity[field]` will be undefined and not yet an
         // `instanceof ReactiveQueryField`). Thankfully we can just use setField.
         setField(entity, field, maybeFn);
-      } else if ((entity as any)[field] === undefined) {
+      } else if (value === undefined) {
         (entity as any)[field] = maybeFn instanceof Function ? maybeFn(entity) : maybeFn;
+      } else if (isLoadedReference(value) && !value.isSet) {
+        value.set(maybeFn instanceof Function ? maybeFn(entity) : maybeFn);
       }
     }
   });

--- a/packages/orm/src/defaults.ts
+++ b/packages/orm/src/defaults.ts
@@ -25,6 +25,9 @@ export function setSyncDefaults(entity: Entity): void {
       } else if (value === undefined) {
         (entity as any)[field] = maybeFn instanceof Function ? maybeFn(entity) : maybeFn;
       } else if (isLoadedReference(value) && !value.isSet) {
+        // A sync default usually would never be for a reference, because reference defaults usually
+        // require a field hint (so would be async) to get "the other entity". However, something like:
+        // `config.setDefault("original", (self) => self);` is technically valid.
         value.set(maybeFn instanceof Function ? maybeFn(entity) : maybeFn);
       }
     }


### PR DESCRIPTION
I.e.

```
config.setDefault("original", b => b);
```