### PR TITLE
feat: Recognize cross-field setDefault dependencies.

### DIFF
--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@types/object-hash": "^3.0.6",
     "ansis": "^3.2.0",
+    "batching-toposort": "^1.2.0",
     "dataloader": "^2.2.2",
     "joist-utils": "workspace:*",
     "knex": "^3.1.0",

--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -6,6 +6,7 @@ import {
   Loaded,
   LoadHint,
   MaybeAbstractEntityConstructor,
+  normalizeHint,
   Reacted,
   ReactiveHint,
   RelationsIn,
@@ -195,12 +196,7 @@ export class ConfigApi<T extends Entity, C> {
     if (fn) {
       // If we're called once by the codegen, and again by the user, override the syncDefault
       delete this.__data.syncDefaults[fieldName];
-      this.__data.asyncDefaults[fieldName] = async (entity: T, ctx: C) => {
-        // Ideally we'd convert this once outside `fn`, but we don't have `metadata` yet
-        const loadHint = convertToLoadHint(getMetadata(entity), hintOrFnOrValue);
-        const loaded = await entity.em.populate(entity, loadHint);
-        return fn(loaded, ctx);
-      };
+      this.__data.asyncDefaults[fieldName] = new AsyncDefault(fieldName, hintOrFnOrValue, fn);
     } else {
       this.__data.syncDefaults[fieldName] = hintOrFnOrValue;
     }
@@ -300,7 +296,11 @@ export class ConfigData<T extends Entity, C> {
   /** Synchronous defaults for this entity type, invoked on `em.create`. */
   syncDefaults: Record<string, ((entity: T) => void) | unknown> = {};
   /** Asynchronous defaults for this entity type, invoked on `em.flush`. */
-  asyncDefaults: Record<string, (entity: T, ctx: C) => MaybePromise<T>> = {};
+  asyncDefaults: Record<string, AsyncDefault<T>> = {};
+  /** Asynchronous defaults organized by dependent-level for parallel loading. */
+  asyncDefaultsByLevel: AsyncDefault<T>[][] = [];
+  /** All fields in order of default dependencies. */
+  fieldsInOrder: string[] = [];
 
   // An array of the reactive rules that depend on this entity
   reactiveRules: ReactiveRule[] = [];
@@ -328,5 +328,31 @@ function getErrorObject(): Error {
     throw Error("");
   } catch (err) {
     return err as Error;
+  }
+}
+
+class AsyncDefault<T extends Entity> {
+  readonly fieldName: string;
+  #fieldHint: ReactiveHint<T>;
+  #loadHint: any;
+  #fn: (entity: any, ctx: any) => any;
+
+  constructor(fieldName: string, fieldHint: ReactiveHint<T>, fn: (entity: T, ctx: any) => any) {
+    this.fieldName = fieldName;
+    this.#fieldHint = fieldHint;
+    this.#fn = fn;
+  }
+
+  /** Return the immediate, sibling fields we depend on. */
+  get dependsOn(): string[] {
+    // i.e. `{ author: { firstName }, title: {}` -> `[author, title]`
+    return Object.keys(normalizeHint(this.#fieldHint));
+  }
+
+  /** For the given `entity`, returns what the default value should be. */
+  getValue(entity: T, ctx: any): Promise<any> {
+    // We can't convert this until now, since it requires the `metadata`
+    this.#loadHint ??= convertToLoadHint(getMetadata(entity), this.#fieldHint);
+    return entity.em.populate(entity, this.#loadHint).then((loaded) => this.#fn(loaded, ctx));
   }
 }

--- a/packages/orm/src/configure.ts
+++ b/packages/orm/src/configure.ts
@@ -11,6 +11,8 @@ import { ReactiveQueryFieldImpl } from "./relations/ReactiveQueryField";
 import { isCannotBeUpdatedRule } from "./rules";
 import { KeySerde } from "./serde";
 import { fail } from "./utils";
+// @ts-ignore
+import batchTopo from "batching-toposort";
 
 const tagToConstructorMap = new Map<string, MaybeAbstractEntityConstructor<any>>();
 const tableToMetaMap = new Map<string, EntityMetadata>();
@@ -25,6 +27,7 @@ export function configureMetadata(metas: EntityMetadata[]): void {
   hookUpBaseTypeAndSubTypes(metas);
   reverseIndexReactivity(metas);
   populatePolyComponentFields(metas);
+  sortDependentFields(metas);
 }
 
 function fireAfterMetadatas(metas: EntityMetadata[]): void {
@@ -76,6 +79,28 @@ function setImmutableFields(metas: EntityMetadata[]): void {
         field.immutable = true;
       }
     });
+  }
+}
+
+// Order fields based on setDefault dependencies
+function sortDependentFields(metas: EntityMetadata[]): void {
+  for (const meta of metas) {
+    // Put every field into the dag of { dependency: dependents[] }
+    const dag: Record<string, string[]> = {};
+    for (const fieldName of Object.keys(meta.allFields)) {
+      dag[fieldName] ??= [];
+      const df = meta.config.__data.asyncDefaults[fieldName];
+      if (df) for (const dep of df.dependsOn) (dag[dep] ??= []).push(fieldName);
+    }
+    // [[a, b], [c, d]]
+    const levels = batchTopo(dag) as string[][];
+    meta.config.__data.asyncDefaultsByLevel = levels
+      .map((level) => {
+        return level.map((fieldName) => meta.config.__data.asyncDefaults[fieldName]).filter((df) => !!df);
+      })
+      .filter((level) => level.length > 0);
+    // [a, b, c, d]
+    meta.config.__data.fieldsInOrder = levels.flat();
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5590,6 +5590,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"batching-toposort@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "batching-toposort@npm:1.2.0"
+  checksum: 10/34f3a1f6b3d3466bb44cf3c71d256f98808fb8826a0deb97051d0b1db58b36d99a8d7468d256e90b7528cb0b3a3b8f96c9e7549f5ba7c03657eddbae4780c362
+  languageName: node
+  linkType: hard
+
 "before-after-hook@npm:^3.0.2":
   version: 3.0.2
   resolution: "before-after-hook@npm:3.0.2"
@@ -10973,6 +10980,7 @@ __metadata:
     "@types/node": "npm:^20.14.9"
     "@types/object-hash": "npm:^3.0.6"
     ansis: "npm:^3.2.0"
+    batching-toposort: "npm:^1.2.0"
     dataloader: "npm:^2.2.2"
     jest: "npm:30.0.0-alpha.5"
     joist-utils: "workspace:*"


### PR DESCRIPTION
We use the field-level hints to async setDefault calls to topo sort them.

Once we know the dependencies, we then call setDefaults in "Waves" i.e. not strictly one-after-the-one, so that we still get parallelism for fields that don't depend on each other.

We could further optimize this to do all hint loads in parallelize, and only actually do the invocations synchronously in order.

Fixes #1160