### PR TITLE
fix: Fix m2m deletes when RQFs are updated.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1307,7 +1307,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
               for (const e of entitiesToFlush) allFlushedEntities.add(e);
               // Recreate `entityTodos` against the only-the-just-changed entities
               entityTodos = createTodos(entitiesToFlush);
-              // ...what about joinRowTodos?...
+              joinRowTodos = combineJoinRows(this.#joinRows);
               await runValidation(entityTodos, joinRowTodos);
               this.#rm.throwIfAnySuppressedTypeErrors();
             } else {

--- a/packages/orm/src/JoinRows.ts
+++ b/packages/orm/src/JoinRows.ts
@@ -25,6 +25,7 @@ export class JoinRows {
     const existing = this.rows.find((r) => r[columnName] === e1 && r[otherColumnName] === e2);
     if (existing) {
       existing.deleted = false;
+      existing.op = JoinRowOperation.Pending;
     } else {
       const joinRow: JoinRow = {
         id: undefined,
@@ -55,6 +56,7 @@ export class JoinRows {
       } else {
         existing.deleted = true;
       }
+      existing.op = JoinRowOperation.Pending;
     } else {
       // Use -1 to force the sortJoinRows to notice us as dirty ("delete: true but id is set")
       this.rows.push({ id: -1, [columnName]: e1, [otherColumnName]: e2, deleted: true, op: JoinRowOperation.Pending });
@@ -133,8 +135,8 @@ export class JoinRows {
 
   /** Scans our `rows` for newly-added/newly-deleted rows that need `INSERT`s/`UPDATE`s. */
   toTodo(): JoinRowTodo | undefined {
-    const newRows = this.rows.filter((r) => r.id === undefined && r.deleted !== true);
-    const deletedRows = this.rows.filter((r) => r.id !== undefined && r.deleted === true);
+    const newRows = this.rows.filter((r) => r.id === undefined && r.deleted !== true && r.op === "pending");
+    const deletedRows = this.rows.filter((r) => r.id !== undefined && r.deleted === true && r.op === "pending");
     if (newRows.length === 0 && deletedRows.length === 0) {
       return undefined;
     }


### PR DESCRIPTION
When RQFs are being updated, the `em.flush` goes through multiple cycles of "flush work so far", "recalc RQF from SQL query", "re-flush anything newly changed", etc.

This iterative loop requires finer-grained tracking that our user-facing isDirtyEntity, which we'd generally already solved by via additional "flushed vs. pending" tracking.

This flushed/pending tracking was only 80% in place for m2m rows, so this PR adds the last 20%, specifically:

* Each RQF loop recalcs the latest joinRowTodos
* Calculating the joinRowTodos only looks at 'pending' m2m operations
* We fix a few bugs where internal m2m row state wasn't flipping back to pending.