### PR TITLE
feat: index all foreign keys in many to many tables

### DIFF
--- a/packages/migration-utils/src/utils.ts
+++ b/packages/migration-utils/src/utils.ts
@@ -256,6 +256,7 @@ export function createManyToManyTable(
     options,
   );
   b.createIndex(tableName, [column1, column2], { unique: true, ifNotExists: options?.ifNotExists });
+  b.createIndex(tableName, [column2]); // Improves lookup performance when querying just column2
 }
 
 /** Adds columns + auto-indexes any foreign keys. */

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -474,23 +474,23 @@ describe("Author", () => {
     expect(i).toBeDefined();
   });
 
-  it("creates a unique composite index for m2m tasks_to_publishers", async () => {
+  it("creates a unique composite index for m2m authors_to_tags", async () => {
     const pgConfig = newPgConnectionConfig();
     const db = await pgStructure(pgConfig);
-    const t = db.tables.find((t) => t.name === "tasks_to_publishers")!;
-    const i = t.indexes.find((i) => i.name === "tasks_to_publishers_task_id_publisher_id_unique_index")!;
+    const t = db.tables.find((t) => t.name === "authors_to_tags")!;
+    const i = t.indexes.find((i) => i.name === "authors_to_tags_author_id_tag_id_unique_index")!;
     expect(i).toBeDefined();
-    expect(i.columns.map((c) => c.name)).toEqual(["task_id", "publisher_id"]);
+    expect(i.columns.map((c) => c.name)).toEqual(["author_id", "tag_id"]);
     expect(i.isUnique).toEqual(true);
   });
 
   it("creates an index for the second column of an m2m relationship", async () => {
     const pgConfig = newPgConnectionConfig();
     const db = await pgStructure(pgConfig);
-    const t = db.tables.find((t) => t.name === "tasks_to_publishers")!;
-    const i = t.indexes.find((i) => i.name === "tasks_to_publishers_publisher_id_index")!;
+    const t = db.tables.find((t) => t.name === "authors_to_tags")!;
+    const i = t.indexes.find((i) => i.name === "authors_to_tags_tag_id_index")!;
     expect(i).toBeDefined();
-    expect(i.columns.map((c) => c.name)).toEqual(["publisher_id"]);
+    expect(i.columns.map((c) => c.name)).toEqual(["tag_id"]);
   });
 
   describe("isNewEntity", () => {

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -474,6 +474,25 @@ describe("Author", () => {
     expect(i).toBeDefined();
   });
 
+  it("creates a unique composite index for m2m tasks_to_publishers", async () => {
+    const pgConfig = newPgConnectionConfig();
+    const db = await pgStructure(pgConfig);
+    const t = db.tables.find((t) => t.name === "tasks_to_publishers")!;
+    const i = t.indexes.find((i) => i.name === "tasks_to_publishers_task_id_publisher_id_unique_index")!;
+    expect(i).toBeDefined();
+    expect(i.columns.map((c) => c.name)).toEqual(["task_id", "publisher_id"]);
+    expect(i.isUnique).toEqual(true);
+  });
+
+  it("creates an index for the second column of an m2m relationship", async () => {
+    const pgConfig = newPgConnectionConfig();
+    const db = await pgStructure(pgConfig);
+    const t = db.tables.find((t) => t.name === "tasks_to_publishers")!;
+    const i = t.indexes.find((i) => i.name === "tasks_to_publishers_publisher_id_index")!;
+    expect(i).toBeDefined();
+    expect(i.columns.map((c) => c.name)).toEqual(["publisher_id"]);
+  });
+
   describe("isNewEntity", () => {
     it("is false after fetch for existing entities", async () => {
       await insertAuthor({ first_name: "a1" });


### PR DESCRIPTION
This PR adds logic to improve querying many-to-many tables.

Today, when a many-to-many table is created, a composite index is created. This composite index enforces uniqueness between the two columns in the table. This index is also helpful when querying _the first column_ defined in the index. However, queries for just the second column will be inefficient.

Let's look at a concrete example. Imagine you have a many to many table linking tags and authors.

Today, the table would look like this:

```
joist=# \d authors_to_tags;
                                       Table "public.authors_to_tags"
   Column   |           Type           | Collation | Nullable |                   Default
------------+--------------------------+-----------+----------+---------------------------------------------
 id         | integer                  |           | not null | nextval('authors_to_tags_id_seq'::regclass)
 author_id  | integer                  |           | not null |
 tag_id     | integer                  |           | not null |
 created_at | timestamp with time zone |           | not null | now()
Indexes:
    "authors_to_tags_pkey" PRIMARY KEY, btree (id)
    "authors_to_tags_author_id_tag_id_unique_index" UNIQUE, btree (author_id, tag_id)
Foreign-key constraints:
    "authors_to_tags_author_id_fkey" FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
    "authors_to_tags_tag_id_fkey" FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
```

The important part is this index:

> "authors_to_tags_author_id_tag_id_unique_index" UNIQUE, btree (author_id, tag_id)

This index enforces uniqueness and is helpful for filtering by `author_id` OR `author_id` and `tag_id`. However, this index is inefficient when filtering by `tag_id` alone. This is because of how compound indexes work. You can learn more about this [in the docs](https://www.postgresql.org/docs/current/indexes-multicolumn.html):

> A multicolumn B-tree index can be used with query conditions that involve any subset of the index's columns, but the index is most efficient when there are constraints on the leading (leftmost) columns. The exact rule is that equality constraints on leading columns, plus any inequality constraints on the first column that does not have an equality constraint, will be used to limit the portion of the index that is scanned. Constraints on columns to the right of these columns are checked in the index, so they save visits to the table proper, but they do not reduce the portion of the index that has to be scanned. For example, given an index on (a, b, c) and a query condition WHERE a = 5 AND b >= 42 AND c < 77, the index would have to be scanned from the first entry with a = 5 and b = 42 up through the last entry with a = 5. Index entries with c >= 77 would be skipped, but they'd still have to be scanned through. This index could in principle be used for queries that have constraints on b and/or c with no constraint on a — but the entire index would have to be scanned, so in most cases the planner would prefer a sequential table scan over using the index.

Therefore, to improve performance on the "right side" of the queries, this PR also creates a separate index on the second column. Now the same many-to-many table would look like this:

```
joist=# \d authors_to_tags;
                                       Table "public.authors_to_tags"
   Column   |           Type           | Collation | Nullable |                   Default
------------+--------------------------+-----------+----------+---------------------------------------------
 id         | integer                  |           | not null | nextval('authors_to_tags_id_seq'::regclass)
 author_id  | integer                  |           | not null |
 tag_id     | integer                  |           | not null |
 created_at | timestamp with time zone |           | not null | now()
Indexes:
    "authors_to_tags_pkey" PRIMARY KEY, btree (id)
    "authors_to_tags_author_id_tag_id_unique_index" UNIQUE, btree (author_id, tag_id)
    "authors_to_tags_tag_id_index" btree (tag_id)
Foreign-key constraints:
    "authors_to_tags_author_id_fkey" FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
    "authors_to_tags_tag_id_fkey" FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
```

The important / new part being:

> "authors_to_tags_tag_id_index" btree (tag_id)

Now queries that just have a `WHERE tag_id=` statement will use the more efficient index.

Fixes #1195