### PR TITLE
feat: index suffix _idx -> _index

### DIFF
--- a/docs/docs/advanced/full-text-search.md
+++ b/docs/docs/advanced/full-text-search.md
@@ -21,7 +21,7 @@ import { addColumns } from "joist-migration-utils";
 import { MigrationBuilder } from "node-pg-migrate";
 
 export async function up(b: MigrationBuilder): Promise<void> {
-  addColumns(b, "books", { search: { type: "text" }});
+  addColumns(b, "books", { search: { type: "text" } });
 
   // Then create a "generated" column, allowing postgres to handle the `to_tsvector` word stemming.
   b.sql(`
@@ -29,7 +29,7 @@ export async function up(b: MigrationBuilder): Promise<void> {
     ADD COLUMN ts_search tsvector
     GENERATED ALWAYS AS (to_tsvector('english', coalesce(search, ''))) STORED;
 
-    CREATE INDEX ts_search_idx ON books USING GIN (ts_search);
+    CREATE INDEX ts_search_index ON books USING GIN (ts_search);
   `);
 }
 ```
@@ -81,7 +81,7 @@ readonly search: ReactiveField<Book, string> = hasReactiveField(
 // Use the buildQuery method to create a base query to build off of
 const query = buildQuery(knex, Book, {});
 
-// Use knex raw methods to craft the search query against the `ts_search` generated column 
+// Use knex raw methods to craft the search query against the `ts_search` generated column
 // and (optionally) sort by the rank
 void query
   .whereRaw(`ts_search @@ plainto_tsquery('english', '${searchTerm}')`)

--- a/docs/docs/modeling/enum-tables.md
+++ b/docs/docs/modeling/enum-tables.md
@@ -60,7 +60,7 @@ And then other domain entities use foreign keys to point back to valid values:
  updated_at         | timestamp with time zone | not null |
 Indexes:
     "authors_pkey" PRIMARY KEY, btree (id)
-    "authors_favorite_color_id_idx" btree (size_id)
+    "authors_favorite_color_id_index" btree (size_id)
 Foreign-key constraints:
     "authors_favorite_color_id_fkey" FOREIGN KEY
        (favorite_color_id) REFERENCES color(id)

--- a/packages/migration-utils/src/utils.ts
+++ b/packages/migration-utils/src/utils.ts
@@ -21,7 +21,7 @@ export function createEntityTable(b: MigrationBuilder, tableName: string, column
   // another table, assume we'll be doing a lot of lookups on this column and should fk it.
   Object.entries(columns).forEach(([name, def]) => {
     if (typeof def === "object" && def.references) {
-      b.sql(`CREATE INDEX ${tableName}_${name}_idx ON ${tableName} USING btree (${name})`);
+      b.addIndex(tableName, [name], { method: "btree" });
     }
   });
 
@@ -55,7 +55,7 @@ export function createSubTable(
   // another table, assume we'll be doing a lot of lookups on this column and should fk it.
   Object.entries(columns).forEach(([name, def]) => {
     if (typeof def === "object" && def.references) {
-      b.sql(`CREATE INDEX ${subTableName}_${name}_idx ON ${subTableName} USING btree (${name})`);
+      b.addIndex(subTableName, [name], { method: "btree" });
     }
   });
 }
@@ -264,7 +264,7 @@ export function addColumns(b: MigrationBuilder, tableName: string, columns: Colu
   b.addColumns(tableName, columns);
   Object.entries(columns).forEach(([name, def]) => {
     if (typeof def === "object" && def.references) {
-      b.sql(`CREATE INDEX ${tableName}_${name}_idx ON ${tableName} USING btree (${name})`);
+      b.addIndex(tableName, [name], { method: "btree" });
     }
   });
 }

--- a/packages/tests/integration/migrations/1580658856631_author.ts
+++ b/packages/tests/integration/migrations/1580658856631_author.ts
@@ -153,7 +153,7 @@ export function up(b: MigrationBuilder): void {
   b.sql(`
     ALTER TABLE authors ADD COLUMN ts_search tsvector
     GENERATED ALWAYS AS (to_tsvector('english', coalesce(search, ''))) STORED;
-    CREATE INDEX authors_ts_search_idx ON authors USING GIN (ts_search);
+    CREATE INDEX authors_ts_search_index ON authors USING GIN (ts_search);
   `);
 
   // A publisher can only have one author named `Jim`, but still have other authors

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -470,7 +470,7 @@ describe("Author", () => {
     const pgConfig = newPgConnectionConfig();
     const db = await pgStructure(pgConfig);
     const t = db.tables.find((t) => t.name === "authors")!;
-    const i = t.indexes.find((i) => i.name === "authors_publisher_id_idx")!;
+    const i = t.indexes.find((i) => i.name === "authors_publisher_id_index")!;
     expect(i).toBeDefined();
   });
 

--- a/packages/tests/number-ids/migrations/1580658856631_author.ts
+++ b/packages/tests/number-ids/migrations/1580658856631_author.ts
@@ -16,5 +16,5 @@ export function up(b: MigrationBuilder): void {
     created_at: { type: "timestamptz", notNull: true },
     updated_at: { type: "timestamptz", notNull: true },
   });
-  b.sql(`CREATE INDEX books_author_id_idx ON books USING btree (author_id)`);
+  b.addIndex("books", ["author_id"], { method: "btree" });
 }

--- a/packages/tests/untagged-ids/migrations/1580658856631_author.ts
+++ b/packages/tests/untagged-ids/migrations/1580658856631_author.ts
@@ -16,7 +16,7 @@ export function up(b: MigrationBuilder): void {
     created_at: { type: "timestamptz", notNull: true },
     updated_at: { type: "timestamptz", notNull: true },
   });
-  b.sql(`CREATE INDEX books_author_id_idx ON books USING btree (author_id)`);
+  b.createIndex("books", ["author_id"], { method: "btree" });
 
   b.createTable("comments", {
     id: { type: "uuid", primaryKey: true },
@@ -26,6 +26,6 @@ export function up(b: MigrationBuilder): void {
     created_at: { type: "timestamptz", notNull: true },
     updated_at: { type: "timestamptz", notNull: true },
   });
-  b.sql(`CREATE INDEX comments_author_id_idx ON comments USING btree (parent_author_id)`);
-  b.sql(`CREATE INDEX comments_book_id_idx ON comments USING btree (parent_book_id)`);
+  b.addIndex("comments", ["parent_author_id"], { method: "btree" });
+  b.addIndex("comments", ["parent_book_id"], { method: "btree" });
 }

--- a/packages/tests/uuid-ids/migrations/1580658856631_author.ts
+++ b/packages/tests/uuid-ids/migrations/1580658856631_author.ts
@@ -29,5 +29,5 @@ export function up(b: MigrationBuilder): void {
     created_at: { type: "timestamptz", notNull: true },
     updated_at: { type: "timestamptz", notNull: true },
   });
-  b.sql(`CREATE INDEX books_author_id_idx ON books USING btree (author_id)`);
+  b.addIndex("books", ["author_id"], { method: "btree" });
 }


### PR DESCRIPTION
I noticed that when you use `.addIndex` you get indexes that end with `_index`. In joist, we'd sometimes use `.addIndex`, but sometimes we'd use `b.sql` and specify `_idx` for indexes.

This PR updates all uses of `b.sql` for creating indexes to use `b.addIndex` for consistency.

NOTE: I don't feel super-strongly about this. If you don't want to make this change, no problem at all 😄 