### PR TITLE
fix: Allow returning Reacted entities from hasReactiveAsyncProperty.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -223,6 +223,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
       static readonly metadata: ${EntityMetadata}<${entity.type}>;
 
       declare readonly __orm: {
+        entityType: ${entityName};
         filterType: ${entityName}Filter;
         gqlFilterType: ${entityName}GraphQLFilter;
         orderType: ${entityName}Order;
@@ -231,6 +232,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
         optIdsType: ${entityName}IdsOpts;
         factoryOptsType: Parameters<typeof ${factoryMethod}>[1];
       };
+
       ${relations.filter((r) => r.kind === "abstract").map((r) => r.line)}
 
       ${cstr}

--- a/packages/orm/src/reactiveHints.ts
+++ b/packages/orm/src/reactiveHints.ts
@@ -113,7 +113,16 @@ export type Reacted<T extends Entity, H> = Entity & {
   fullNonReactiveAccess: Loaded<T, H>;
   /** Allow detecting if a reactive change is due to nuances like `hasUpdated` or `hasChanged`. */
   changes: Changes<T, keyof (FieldsOf<T> & RelationsOf<T>), keyof NormalizeHint<H>>;
+  /** Allow returning reacted entities from `hasReactiveAsyncProperties`. */
+  readonly __orm: { entityType: T };
 } & MaybeTransientFields<T>;
+
+/** Allow returning reacted entities from `hasReactiveAsyncProperties`. */
+export type MaybeReactedEntity<V> = V extends (infer T extends Entity) | undefined
+  ? { __orm: { entityType: T } } | undefined
+  : V extends Entity
+    ? { __orm: { entityType: V } }
+    : V;
 
 /**
  * A reactive hint that only allows fields immediately on the entity, i.e. no nested hints.

--- a/packages/orm/src/relations/hasAsyncProperty.ts
+++ b/packages/orm/src/relations/hasAsyncProperty.ts
@@ -2,7 +2,7 @@ import { currentlyInstantiatingEntity } from "../BaseEntity";
 import { Entity } from "../Entity";
 import { getMetadata } from "../EntityMetadata";
 import { LoadHint, Loaded } from "../loadHints";
-import { Reacted, ReactiveHint, convertToLoadHint } from "../reactiveHints";
+import { MaybeReactedEntity, Reacted, ReactiveHint, convertToLoadHint } from "../reactiveHints";
 import { tryResolve } from "../utils";
 
 export const AsyncPropertyT = Symbol();
@@ -44,7 +44,7 @@ export function hasAsyncProperty<T extends Entity, const H extends LoadHint<T>, 
  */
 export function hasReactiveAsyncProperty<T extends Entity, const H extends ReactiveHint<T>, V>(
   reactiveHint: H,
-  fn: (entity: Reacted<T, H>) => V,
+  fn: (entity: Reacted<T, H>) => MaybeReactedEntity<V>,
 ): AsyncProperty<T, V> {
   const entity = currentlyInstantiatingEntity as T;
   return new AsyncPropertyImpl(entity, reactiveHint as any, fn as any, { isReactive: true });

--- a/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
@@ -100,6 +100,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   static readonly metadata: EntityMetadata<Author>;
 
   declare readonly __orm: {
+    entityType: Author;
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;

--- a/packages/tests/esm-misc/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/BookCodegen.ts
@@ -91,6 +91,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   static readonly metadata: EntityMetadata<Book>;
 
   declare readonly __orm: {
+    entityType: Book;
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
@@ -87,6 +87,7 @@ export abstract class T1AuthorCodegen extends BaseEntity<EntityManager, number> 
   static readonly metadata: EntityMetadata<T1Author>;
 
   declare readonly __orm: {
+    entityType: T1Author;
     filterType: T1AuthorFilter;
     gqlFilterType: T1AuthorGraphQLFilter;
     orderType: T1AuthorOrder;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T1BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T1BookCodegen.ts
@@ -91,6 +91,7 @@ export abstract class T1BookCodegen extends BaseEntity<EntityManager, number> im
   static readonly metadata: EntityMetadata<T1Book>;
 
   declare readonly __orm: {
+    entityType: T1Book;
     filterType: T1BookFilter;
     gqlFilterType: T1BookGraphQLFilter;
     orderType: T1BookOrder;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
@@ -96,6 +96,7 @@ export abstract class T2AuthorCodegen extends BaseEntity<EntityManager, number> 
   static readonly metadata: EntityMetadata<T2Author>;
 
   declare readonly __orm: {
+    entityType: T2Author;
     filterType: T2AuthorFilter;
     gqlFilterType: T2AuthorGraphQLFilter;
     orderType: T2AuthorOrder;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
@@ -97,6 +97,7 @@ export abstract class T2BookCodegen extends BaseEntity<EntityManager, number> im
   static readonly metadata: EntityMetadata<T2Book>;
 
   declare readonly __orm: {
+    entityType: T2Book;
     filterType: T2BookFilter;
     gqlFilterType: T2BookGraphQLFilter;
     orderType: T2BookOrder;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
@@ -97,6 +97,7 @@ export abstract class T3AuthorCodegen extends BaseEntity<EntityManager, number> 
   static readonly metadata: EntityMetadata<T3Author>;
 
   declare readonly __orm: {
+    entityType: T3Author;
     filterType: T3AuthorFilter;
     gqlFilterType: T3AuthorGraphQLFilter;
     orderType: T3AuthorOrder;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
@@ -97,6 +97,7 @@ export abstract class T3BookCodegen extends BaseEntity<EntityManager, number> im
   static readonly metadata: EntityMetadata<T3Book>;
 
   declare readonly __orm: {
+    entityType: T3Book;
     filterType: T3BookFilter;
     gqlFilterType: T3BookGraphQLFilter;
     orderType: T3BookOrder;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
@@ -97,6 +97,7 @@ export abstract class T4AuthorCodegen extends BaseEntity<EntityManager, number> 
   static readonly metadata: EntityMetadata<T4Author>;
 
   declare readonly __orm: {
+    entityType: T4Author;
     filterType: T4AuthorFilter;
     gqlFilterType: T4AuthorGraphQLFilter;
     orderType: T4AuthorOrder;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
@@ -97,6 +97,7 @@ export abstract class T4BookCodegen extends BaseEntity<EntityManager, number> im
   static readonly metadata: EntityMetadata<T4Book>;
 
   declare readonly __orm: {
+    entityType: T4Book;
     filterType: T4BookFilter;
     gqlFilterType: T4BookGraphQLFilter;
     orderType: T4BookOrder;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
@@ -87,6 +87,7 @@ export abstract class T5AuthorCodegen extends BaseEntity<EntityManager, number> 
   static readonly metadata: EntityMetadata<T5Author>;
 
   declare readonly __orm: {
+    entityType: T5Author;
     filterType: T5AuthorFilter;
     gqlFilterType: T5AuthorGraphQLFilter;
     orderType: T5AuthorOrder;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
@@ -100,6 +100,7 @@ export abstract class T5BookCodegen extends BaseEntity<EntityManager, number> im
   static readonly metadata: EntityMetadata<T5Book>;
 
   declare readonly __orm: {
+    entityType: T5Book;
     filterType: T5BookFilter;
     gqlFilterType: T5BookGraphQLFilter;
     orderType: T5BookOrder;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookReviewCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookReviewCodegen.ts
@@ -90,6 +90,7 @@ export abstract class T5BookReviewCodegen extends BaseEntity<EntityManager, numb
   static readonly metadata: EntityMetadata<T5BookReview>;
 
   declare readonly __orm: {
+    entityType: T5BookReview;
     filterType: T5BookReviewFilter;
     gqlFilterType: T5BookReviewGraphQLFilter;
     orderType: T5BookReviewOrder;

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -233,9 +233,9 @@ export class Author extends AuthorCodegen {
         return undefined;
       }
       const ratings = books.flatMap((b) => b.reviews.get).map((r) => r.rating);
-      if (ratings.length === 0) return books[0].fullNonReactiveAccess;
+      if (ratings.length === 0) return books[0];
       const bestRating = Math.max(...ratings);
-      return books.find((b) => b.reviews.get.some((r) => r.rating === bestRating)) as Book | undefined;
+      return books.find((b) => b.reviews.get.some((r) => r.rating === bestRating));
     },
   );
 
@@ -244,7 +244,7 @@ export class Author extends AuthorCodegen {
     authorMeta,
     "rootMentor",
     "mentorsRecursive",
-    (a) => a.mentorsRecursive.get[a.mentorsRecursive.get.length - 1]?.fullNonReactiveAccess,
+    (a) => a.mentorsRecursive.get[a.mentorsRecursive.get.length - 1],
   );
 
   /** Example of an async property that can be loaded via a populate hint. */
@@ -256,8 +256,7 @@ export class Author extends AuthorCodegen {
   /** Example of an async property that returns an entity. */
   readonly latestComment2: AsyncProperty<Author, Comment | undefined> = hasReactiveAsyncProperty(
     { publisher: "comments", comments: {} },
-    (author) =>
-      author.publisher.get?.comments.get[0].fullNonReactiveAccess ?? author.comments.get[0].fullNonReactiveAccess,
+    (author) => author.publisher.get?.comments.get[0] ?? author.comments.get[0],
   );
 
   /** Example of an async property that has a conflicting/overlapping reactive hint with ^. */

--- a/packages/tests/integration/src/entities/Critic.ts
+++ b/packages/tests/integration/src/entities/Critic.ts
@@ -1,6 +1,13 @@
-import { CriticCodegen, criticConfig as config } from "./entities";
+import { AsyncProperty, hasReactiveAsyncProperty } from "joist-orm";
+import { criticConfig as config, CriticCodegen, PublisherGroup } from "./entities";
 
-export class Critic extends CriticCodegen {}
+export class Critic extends CriticCodegen {
+  // For testing returning Reacted<...> from hasReactiveAsyncProperty
+  readonly filteredGroup: AsyncProperty<Critic, PublisherGroup | undefined> = hasReactiveAsyncProperty(
+    "group",
+    (c) => c.group.get,
+  );
+}
 
 /** For testing walking through subtype relations. */
 config.addRule({ favoriteLargePublisher: "images" }, () => {});

--- a/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
@@ -77,6 +77,7 @@ export abstract class AdminUserCodegen extends User implements Entity {
   static readonly metadata: EntityMetadata<AdminUser>;
 
   declare readonly __orm: {
+    entityType: AdminUser;
     filterType: AdminUserFilter;
     gqlFilterType: AdminUserGraphQLFilter;
     orderType: AdminUserOrder;

--- a/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
@@ -336,6 +336,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   static readonly metadata: EntityMetadata<Author>;
 
   declare readonly __orm: {
+    entityType: Author;
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;

--- a/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
@@ -100,6 +100,7 @@ export abstract class AuthorScheduleCodegen extends BaseEntity<EntityManager, st
   static readonly metadata: EntityMetadata<AuthorSchedule>;
 
   declare readonly __orm: {
+    entityType: AuthorSchedule;
     filterType: AuthorScheduleFilter;
     gqlFilterType: AuthorScheduleGraphQLFilter;
     orderType: AuthorScheduleOrder;

--- a/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
@@ -141,6 +141,7 @@ export abstract class AuthorStatCodegen extends BaseEntity<EntityManager, string
   static readonly metadata: EntityMetadata<AuthorStat>;
 
   declare readonly __orm: {
+    entityType: AuthorStat;
     filterType: AuthorStatFilter;
     gqlFilterType: AuthorStatGraphQLFilter;
     orderType: AuthorStatOrder;

--- a/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
@@ -132,6 +132,7 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, strin
   static readonly metadata: EntityMetadata<BookAdvance>;
 
   declare readonly __orm: {
+    entityType: BookAdvance;
     filterType: BookAdvanceFilter;
     gqlFilterType: BookAdvanceGraphQLFilter;
     orderType: BookAdvanceOrder;

--- a/packages/tests/integration/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookCodegen.ts
@@ -197,6 +197,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   static readonly metadata: EntityMetadata<Book>;
 
   declare readonly __orm: {
+    entityType: Book;
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;

--- a/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
@@ -141,6 +141,7 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string
   static readonly metadata: EntityMetadata<BookReview>;
 
   declare readonly __orm: {
+    entityType: BookReview;
     filterType: BookReviewFilter;
     gqlFilterType: BookReviewGraphQLFilter;
     orderType: BookReviewOrder;

--- a/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
@@ -96,6 +96,7 @@ export abstract class ChildCodegen extends BaseEntity<EntityManager, string> imp
   static readonly metadata: EntityMetadata<Child>;
 
   declare readonly __orm: {
+    entityType: Child;
     filterType: ChildFilter;
     gqlFilterType: ChildGraphQLFilter;
     orderType: ChildOrder;

--- a/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
@@ -120,6 +120,7 @@ export abstract class ChildGroupCodegen extends BaseEntity<EntityManager, string
   static readonly metadata: EntityMetadata<ChildGroup>;
 
   declare readonly __orm: {
+    entityType: ChildGroup;
     filterType: ChildGroupFilter;
     gqlFilterType: ChildGroupGraphQLFilter;
     orderType: ChildGroupOrder;

--- a/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
@@ -111,6 +111,7 @@ export abstract class ChildItemCodegen extends BaseEntity<EntityManager, string>
   static readonly metadata: EntityMetadata<ChildItem>;
 
   declare readonly __orm: {
+    entityType: ChildItem;
     filterType: ChildItemFilter;
     gqlFilterType: ChildItemGraphQLFilter;
     orderType: ChildItemOrder;

--- a/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
@@ -160,6 +160,7 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> i
   static readonly metadata: EntityMetadata<Comment>;
 
   declare readonly __orm: {
+    entityType: Comment;
     filterType: CommentFilter;
     gqlFilterType: CommentGraphQLFilter;
     orderType: CommentOrder;

--- a/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
@@ -128,6 +128,7 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> im
   static readonly metadata: EntityMetadata<Critic>;
 
   declare readonly __orm: {
+    entityType: Critic;
     filterType: CriticFilter;
     gqlFilterType: CriticGraphQLFilter;
     orderType: CriticOrder;

--- a/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
@@ -101,6 +101,7 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager, stri
   static readonly metadata: EntityMetadata<CriticColumn>;
 
   declare readonly __orm: {
+    entityType: CriticColumn;
     filterType: CriticColumnFilter;
     gqlFilterType: CriticColumnGraphQLFilter;
     orderType: CriticColumnOrder;

--- a/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
@@ -147,6 +147,7 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> imp
   static readonly metadata: EntityMetadata<Image>;
 
   declare readonly __orm: {
+    entityType: Image;
     filterType: ImageFilter;
     gqlFilterType: ImageGraphQLFilter;
     orderType: ImageOrder;

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -99,6 +99,7 @@ export abstract class LargePublisherCodegen extends Publisher implements Entity 
   static readonly metadata: EntityMetadata<LargePublisher>;
 
   declare readonly __orm: {
+    entityType: LargePublisher;
     filterType: LargePublisherFilter;
     gqlFilterType: LargePublisherGraphQLFilter;
     orderType: LargePublisherOrder;

--- a/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
@@ -103,6 +103,7 @@ export abstract class ParentGroupCodegen extends BaseEntity<EntityManager, strin
   static readonly metadata: EntityMetadata<ParentGroup>;
 
   declare readonly __orm: {
+    entityType: ParentGroup;
     filterType: ParentGroupFilter;
     gqlFilterType: ParentGroupGraphQLFilter;
     orderType: ParentGroupOrder;

--- a/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
@@ -109,6 +109,7 @@ export abstract class ParentItemCodegen extends BaseEntity<EntityManager, string
   static readonly metadata: EntityMetadata<ParentItem>;
 
   declare readonly __orm: {
+    entityType: ParentItem;
     filterType: ParentItemFilter;
     gqlFilterType: ParentItemGraphQLFilter;
     orderType: ParentItemOrder;

--- a/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
@@ -198,6 +198,7 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
   static readonly metadata: EntityMetadata<Publisher>;
 
   declare readonly __orm: {
+    entityType: Publisher;
     filterType: PublisherFilter;
     gqlFilterType: PublisherGraphQLFilter;
     orderType: PublisherOrder;

--- a/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
@@ -106,6 +106,7 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
   static readonly metadata: EntityMetadata<PublisherGroup>;
 
   declare readonly __orm: {
+    entityType: PublisherGroup;
     filterType: PublisherGroupFilter;
     gqlFilterType: PublisherGroupGraphQLFilter;
     orderType: PublisherGroupOrder;

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -100,6 +100,7 @@ export abstract class SmallPublisherCodegen extends Publisher implements Entity 
   static readonly metadata: EntityMetadata<SmallPublisher>;
 
   declare readonly __orm: {
+    entityType: SmallPublisher;
     filterType: SmallPublisherFilter;
     gqlFilterType: SmallPublisherGraphQLFilter;
     orderType: SmallPublisherOrder;

--- a/packages/tests/integration/src/entities/codegen/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TagCodegen.ts
@@ -125,6 +125,7 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> imple
   static readonly metadata: EntityMetadata<Tag>;
 
   declare readonly __orm: {
+    entityType: Tag;
     filterType: TagFilter;
     gqlFilterType: TagGraphQLFilter;
     orderType: TagOrder;

--- a/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
@@ -122,6 +122,7 @@ export abstract class TaskCodegen extends BaseEntity<EntityManager, string> impl
   static readonly metadata: EntityMetadata<Task>;
 
   declare readonly __orm: {
+    entityType: Task;
     filterType: TaskFilter;
     gqlFilterType: TaskGraphQLFilter;
     orderType: TaskOrder;

--- a/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
@@ -119,6 +119,7 @@ export abstract class TaskItemCodegen extends BaseEntity<EntityManager, string> 
   static readonly metadata: EntityMetadata<TaskItem>;
 
   declare readonly __orm: {
+    entityType: TaskItem;
     filterType: TaskItemFilter;
     gqlFilterType: TaskItemGraphQLFilter;
     orderType: TaskItemOrder;

--- a/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
@@ -98,6 +98,7 @@ export abstract class TaskNewCodegen extends Task implements Entity {
   static readonly metadata: EntityMetadata<TaskNew>;
 
   declare readonly __orm: {
+    entityType: TaskNew;
     filterType: TaskNewFilter;
     gqlFilterType: TaskNewGraphQLFilter;
     orderType: TaskNewOrder;

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -121,6 +121,7 @@ export abstract class TaskOldCodegen extends Task implements Entity {
   static readonly metadata: EntityMetadata<TaskOld>;
 
   declare readonly __orm: {
+    entityType: TaskOld;
     filterType: TaskOldFilter;
     gqlFilterType: TaskOldGraphQLFilter;
     orderType: TaskOldOrder;

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -199,6 +199,7 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> impl
   static readonly metadata: EntityMetadata<User>;
 
   declare readonly __orm: {
+    entityType: User;
     filterType: UserFilter;
     gqlFilterType: UserGraphQLFilter;
     orderType: UserOrder;

--- a/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
@@ -93,6 +93,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, number> im
   static readonly metadata: EntityMetadata<Author>;
 
   declare readonly __orm: {
+    entityType: Author;
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;

--- a/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
@@ -101,6 +101,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, number> impl
   static readonly metadata: EntityMetadata<Book>;
 
   declare readonly __orm: {
+    entityType: Book;
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;

--- a/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
@@ -103,6 +103,7 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager, string> im
   static readonly metadata: EntityMetadata<Artist>;
 
   declare readonly __orm: {
+    entityType: Artist;
     filterType: ArtistFilter;
     gqlFilterType: ArtistGraphQLFilter;
     orderType: ArtistOrder;

--- a/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
@@ -100,6 +100,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   static readonly metadata: EntityMetadata<Author>;
 
   declare readonly __orm: {
+    entityType: Author;
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;

--- a/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
@@ -91,6 +91,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   static readonly metadata: EntityMetadata<Book>;
 
   declare readonly __orm: {
+    entityType: Book;
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;

--- a/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
@@ -68,6 +68,7 @@ export abstract class DatabaseOwnerCodegen extends BaseEntity<EntityManager, str
   static readonly metadata: EntityMetadata<DatabaseOwner>;
 
   declare readonly __orm: {
+    entityType: DatabaseOwner;
     filterType: DatabaseOwnerFilter;
     gqlFilterType: DatabaseOwnerGraphQLFilter;
     orderType: DatabaseOwnerOrder;

--- a/packages/tests/schema-misc/src/entities/codegen/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/PaintingCodegen.ts
@@ -101,6 +101,7 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager, string> 
   static readonly metadata: EntityMetadata<Painting>;
 
   declare readonly __orm: {
+    entityType: Painting;
     filterType: PaintingFilter;
     gqlFilterType: PaintingGraphQLFilter;
     orderType: PaintingOrder;

--- a/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
@@ -100,6 +100,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   static readonly metadata: EntityMetadata<Author>;
 
   declare readonly __orm: {
+    entityType: Author;
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;

--- a/packages/tests/temporal/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/temporal/src/entities/codegen/BookCodegen.ts
@@ -108,6 +108,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   static readonly metadata: EntityMetadata<Book>;
 
   declare readonly __orm: {
+    entityType: Book;
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;

--- a/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
@@ -109,6 +109,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   static readonly metadata: EntityMetadata<Author>;
 
   declare readonly __orm: {
+    entityType: Author;
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;

--- a/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
@@ -110,6 +110,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   static readonly metadata: EntityMetadata<Book>;
 
   declare readonly __orm: {
+    entityType: Book;
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;

--- a/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
@@ -104,6 +104,7 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> i
   static readonly metadata: EntityMetadata<Comment>;
 
   declare readonly __orm: {
+    entityType: Comment;
     filterType: CommentFilter;
     gqlFilterType: CommentGraphQLFilter;
     orderType: CommentOrder;

--- a/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
@@ -93,6 +93,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   static readonly metadata: EntityMetadata<Author>;
 
   declare readonly __orm: {
+    entityType: Author;
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;

--- a/packages/tests/uuid-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/BookCodegen.ts
@@ -110,6 +110,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   static readonly metadata: EntityMetadata<Book>;
 
   declare readonly __orm: {
+    entityType: Book;
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;


### PR DESCRIPTION
Previously the return values of `hasReactiveReference`s and `hasReactiveAsyncProperties` that return entities, i.e. the `Reacted<Author>` type, was expected to be "the full Author", which of course it's not, given that Reacted are subviews of the full type.

This PR adjusts the return type of hasReactiveAsyncProperty to, if either an entity or optional entity (i.e. `entity | undefined`) is returned, we'll accept the reacted subtype.

We piggyback on the existing `__orm` type hint field, albeit we didn't have the entityType itself in the type before, so we codegen that out now.