### PR TITLE
fix: support single quotes in scanEntityFiles

### DIFF
--- a/packages/codegen/src/scanEntityFiles.ts
+++ b/packages/codegen/src/scanEntityFiles.ts
@@ -4,7 +4,7 @@ import { DbMetadata } from "./EntityDbMetadata";
 import { Config } from "./config";
 
 // Erg, we need a regex in case the fieldName arg is wrapped onto a new line... :-/
-const regex = /config\.setDefault\([\s\n]*"(\w+)"/g;
+const regex = /config\.setDefault\([\s\n]*"(\w+)"|config\.setDefault\([\s\n]*'(\w+)'/g;
 
 /** Scans the entity files themselves for usage hints (like `setDefault` calls) to drive our codegen output. */
 export async function scanEntityFiles(config: Config, dbMeta: DbMetadata): Promise<void> {

--- a/packages/tests/integration/src/entities/Book.ts
+++ b/packages/tests/integration/src/entities/Book.ts
@@ -62,8 +62,13 @@ config.addRule({ author: "numberOfBooks2" }, (b) => {
   b.fullNonReactiveAccess.numberOfBooks2RuleInvoked++;
 });
 
-/** Example of a synchronous default. */
-config.setDefault("notes", (b) => `Notes for ${b.title}`);
+/**
+ * Example of a synchronous default.
+ *
+ * Explicitly using single quotes for scanEntityFiles detection
+ * */
+// prettier-ignore
+config.setDefault('notes', (b) => `Notes for ${b.title}`);
 
 /** Example of an asynchronous default. */
 config.setDefault("order", { author: "books" }, (b) => b.author.get?.books.get.length);


### PR DESCRIPTION
Turns out it was already rewritten to do the inverted regex flow - I was looking at the inital PR which added it, not main.

- Add adds the single quote to the regex. Fixes #1202
- Changes one of the integration entity setDefault calls to use single quotes w/ prettier ignore comment - I assume this should suffice as a decent enough check.