### PR TITLE
fix: Fix regex to have only 1 group.

### DIFF
--- a/packages/codegen/src/scanEntityFiles.ts
+++ b/packages/codegen/src/scanEntityFiles.ts
@@ -4,7 +4,7 @@ import { DbMetadata } from "./EntityDbMetadata";
 import { Config } from "./config";
 
 // Erg, we need a regex in case the fieldName arg is wrapped onto a new line... :-/
-const regex = /config\.setDefault\([\s\n]*"(\w+)"|config\.setDefault\([\s\n]*'(\w+)'/g;
+const regex = /config\.setDefault\([\s\n]*["'](\w+)["']/g;
 
 /** Scans the entity files themselves for usage hints (like `setDefault` calls) to drive our codegen output. */
 export async function scanEntityFiles(config: Config, dbMeta: DbMetadata): Promise<void> {


### PR DESCRIPTION
The two `\w`s was throwing off the code that was later hard-coded to checking only match[1] instead of match[1] or match[2].

Getting back to just one \w lets the match[1] code stay as-is.