### PR TITLE
feat: Add EntityManager.mode.

### DIFF
--- a/packages/tests/integration/src/EntityManager.modes.test.ts
+++ b/packages/tests/integration/src/EntityManager.modes.test.ts
@@ -1,0 +1,37 @@
+import { expect } from "@jest/globals";
+import { ReadOnlyError } from "joist-orm";
+import { Author } from "src/entities";
+import { insertAuthor, select } from "src/entities/inserts";
+import { newEntityManager } from "src/testEm";
+
+describe("EntityManager.modes", () => {
+  it("read-only cannot em.flush", async () => {
+    const em = newEntityManager();
+    em.mode = "read-only";
+    await expect(em.flush()).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("read-only cannot mutate entities", async () => {
+    await insertAuthor({ first_name: "a1" });
+    const em = newEntityManager();
+    em.mode = "read-only";
+    const a1 = await em.load(Author, "a:1");
+    expect(() => {
+      a1.firstName = "a2";
+    }).toThrow(ReadOnlyError);
+  });
+
+  it("in-memory writes does not commit", async () => {
+    // Given an author
+    await insertAuthor({ first_name: "a1" });
+    // When we change it
+    const em = newEntityManager();
+    const a1 = await em.load(Author, "a:1");
+    a1.firstName = "a2";
+    em.mode = "in-memory-writes";
+    await em.flush();
+    // Then it didn't actually change
+    const rows = await select("authors");
+    expect(rows).toMatchObject([{ first_name: "a1" }]);
+  });
+});

--- a/packages/tests/integration/src/setupTestEnv.ts
+++ b/packages/tests/integration/src/setupTestEnv.ts
@@ -2,5 +2,7 @@ import { GetEnvVars } from "env-cmd";
 
 export default async function globalSetup() {
   process.env.TZ = "UTC";
+  // process.env.DEBUG = "knex:query,bindings";
+  // process.env.DEBUG = "knex:*";
   Object.entries(await GetEnvVars()).forEach(([key, value]) => (process.env[key] = value));
 }


### PR DESCRIPTION
Allows putting the EM into either read-only (no mutations allowed) or in-memory-writes (mutations allowed but no writes).

The in-memory-writes in particular is useful for building "oracle" functionality where you want to mutate entities to "see what would happen", but ensure the WIP data is never committed to the db, even by an errant, over-eager `em.flush`.