### PR TITLE
fix: Missing kqDot within distinct/orderBy

### DIFF
--- a/packages/orm/src/drivers/buildKnexQuery.ts
+++ b/packages/orm/src/drivers/buildKnexQuery.ts
@@ -69,7 +69,7 @@ export function buildKnexQuery(
     parsed.orderBys.forEach(({ alias, column, order }) => {
       // If we're doing "select distinct" for o2m joins, then all order bys must be selects
       if (needsDistinct) {
-        query.select(`${alias}.${column}`);
+        query.select(knex.raw(kqDot(alias, column)));
       }
       query.orderBy(knex.raw(kqDot(alias, column)) as any, order);
     });

--- a/packages/orm/src/drivers/buildRawQuery.ts
+++ b/packages/orm/src/drivers/buildRawQuery.ts
@@ -38,7 +38,7 @@ export function buildRawQuery(
   // If we're doing "select distinct" for o2m joins, then all order bys must be selects
   if (needsDistinct && parsed.orderBys.length > 0) {
     for (const { alias, column } of parsed.orderBys) {
-      sql += `, ${alias}.${column}`;
+      sql += `, ${kqDot(alias, column)}`;
     }
   }
 

--- a/packages/tests/integration/src/QueryParser.quotes.test.ts
+++ b/packages/tests/integration/src/QueryParser.quotes.test.ts
@@ -13,7 +13,7 @@ describe("QueryParser", () => {
   it("quotes with abbreviation", () => {
     expect(generateSql(parseFindQuery(bm, { author: { firstName: "jeff", schedules: { id: 4 } } }))).toEqual(
       [
-        'select distinct b.*, "b"."title", "b"."id"',
+        'select distinct b.*, b.title, b.id',
         " from books as b",
         " inner join authors as a on b.author_id = a.id",
         ' left outer join author_schedules as "as" on a.id = "as".author_id',


### PR DESCRIPTION
After renaming a entity to something abreviated to a psql keyword, I hit the following;

```
SELECT DISTINCT "to".*, to.id FROM tender_offer AS "to" LEFT OUTER JOIN other_table AS ot ON "to".id = ot.some_id WHERE ot.other_id = $1 ORDER BY "to".id ASC LIMIT $2 - syntax error at or near "to""
```

Notice the second `to` being unquoted within the select. I suspect this is due to the locations identified within the PR not using kqDot.