### PR TITLE
fix: continue instead of return on config warnings

### DIFF
--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -139,7 +139,7 @@ export function warnInvalidConfigEntries(config: Config, db: DbMetadata): void {
     const entities = entitiesByName[entityName];
     if (!entities) {
       console.log(`WARNING: Found config for non-existent entity ${entityName}`);
-      return;
+      continue;
     }
     // We don't have keyBy...
     const [entity] = entities;


### PR DESCRIPTION
Updates `warnInvalidConfigEntries` to move to the next itteration if the entity within the config is not found, instead of returning early. This allows all found issues to be printed in one execution, vs needing to manually fix-run ad nasuem.


edit; thoughts on a --strict flag or something to return a non-zero exit code if any of these warnings are printed? We would find something like this very helpful for CI