### PR TITLE
fix: Don't double-tap the deferred on subtypes.

### DIFF
--- a/packages/orm/src/configure.ts
+++ b/packages/orm/src/configure.ts
@@ -111,10 +111,6 @@ function hookUpBaseTypeAndSubTypes(metas: EntityMetadata[]): void {
         // We use `b0` because that is what addTablePerClassJoinsAndClassTag uses to join in the base table
         m.allFields[name] = { ...field, aliasSuffix: b.inheritanceType === "cti" ? "_b0" : "" };
       });
-      // Push our parent's defaults into us
-      Object.entries(b.config.__data.asyncDefaults).forEach(([name, df]) => {
-        m.config.__data.asyncDefaults[name] = df;
-      });
     }
   }
 }

--- a/packages/tests/integration/src/EntityManager.defaults.test.ts
+++ b/packages/tests/integration/src/EntityManager.defaults.test.ts
@@ -7,6 +7,7 @@ const { getDefaultDependencies } = testing;
 
 // We don't have tests for:
 // - default-defined-on-base pushing into child
+// - default-defined-on-base that inserts both a base and a child (and doesn't double tap the Deferred.resolve)
 // - default-defined-on-sub
 
 describe("EntityManager.defaults", () => {


### PR DESCRIPTION
If a single `em.flush` had both a `BaseTodo` and a `SubTodo`s, where `BaseTodo.createdBy` was set once on all `BaseTodo`s, and again for all `SubTodo`s, we'd call `.resolve()` twice on the `createdBy` deferred.