### PR TITLE
feat: optional field & code on ValidationError

### DIFF
--- a/packages/orm/src/rules.ts
+++ b/packages/orm/src/rules.ts
@@ -11,7 +11,13 @@ import { MaybePromise, groupBy, maybePromiseThen } from "./utils";
  *
  * Consumers can extend `GenericError` to add fields relevant for their application.
  */
-export type ValidationRuleResult<E extends GenericError> = string | string[] | E | E[] | {field: string, msg: string } | undefined;
+export type ValidationRuleResult<E extends GenericError> =
+  | string
+  | string[]
+  | E
+  | E[]
+  | { field: string; msg: string }
+  | undefined;
 
 /** An entity validation rule. */
 export type ValidationRule<T extends Entity> = (entity: T) => MaybePromise<ValidationRuleResult<any>>;
@@ -34,7 +40,7 @@ export type AsyncDerivedFieldInternal<T extends Entity> = {
 export type GenericError = { message: string };
 
 /** An extension to GenericError which associates the error to a specific entity */
-export type ValidationError = { entity: Entity, field?: string } & GenericError;
+export type ValidationError = { entity: Entity; field?: string, code?: string } & GenericError;
 
 export class ValidationErrors extends Error {
   public errors: Array<GenericError | ValidationError>;
@@ -57,7 +63,8 @@ export class ValidationErrors extends Error {
  */
 export function newRequiredRule<T extends Entity>(key: keyof FieldsOf<T> & string): ValidationRule<T> {
   // Use getField so that we peer through relations
-  return (entity) => (getField(entity, key) === undefined ? { field: key, code: 'required', message: `${key} is required` }: undefined);
+  return (entity) =>
+    getField(entity, key) === undefined ? { field: key, code: "required", message: `${key} is required` } : undefined;
 }
 
 /**
@@ -75,7 +82,7 @@ export function cannotBeUpdated<T extends Entity, K extends keyof Changes<T> & s
     if ((entity as any as EntityChanges<T>).changes[field].hasUpdated) {
       return maybePromiseThen(unless ? unless(entity) : false, (result) => {
         if (!result) {
-          return {field, code: 'not-updatable', message: `${field} cannot be updated` };
+          return { field, code: "not-updatable", message: `${field} cannot be updated` };
         }
         return undefined;
       });
@@ -139,12 +146,12 @@ export function minValueRule<T extends Entity, K extends keyof T & string>(
 
     // Show an error when the value type is not a number
     if (typeof value !== "number") {
-      return { field, code: 'expect-number', message: `${field} must be a number` };
+      return { field, code: "expect-number", message: `${field} must be a number` };
     }
 
     // Show an error when the value is smaller than the minimum value
     if (value < minValue) {
-      return { field, code: 'expect-number-lt-min', message: `${field} must be greater than or equal to ${minValue}` };
+      return { field, code: "expect-number-lt-min", message: `${field} must be greater than or equal to ${minValue}` };
     }
 
     return;
@@ -179,7 +186,7 @@ export function maxValueRule<T extends Entity, K extends keyof T & string>(
 
     // Show an error when the value is smaller than the minimum value
     if (value > maxValue) {
-      return { field, code: 'expect-number-gt-max', message: `${field} must be smaller than or equal to ${maxValue}` };
+      return { field, code: "expect-number-gt-max", message: `${field} must be smaller than or equal to ${maxValue}` };
     }
 
     return;

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -58,6 +58,17 @@ describe("Author", () => {
     );
   });
 
+  it("can return field & code from validation errors", async () => {
+    expect.assertions(1);
+    const em = newEntityManager();
+    new Author(em, { firstName: 'foo', lastName: "NotAllowedLastName" });
+    try {
+      await em.flush()
+    } catch(err: any) {
+      expect(err.errors[0]).toMatchObject({ field: "lastName", code: 'invalid-name' })
+    }
+  });
+
   it("can have async validation rules", async () => {
     const em = newEntityManager();
     const a1 = new Author(em, { firstName: "a1" });

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -309,7 +309,7 @@ config.addRule((a) => {
 
 config.addRule((a) => {
   if (a.lastName === "NotAllowedLastName") {
-    return "lastName is invalid";
+    return { field: "lastName", code: "invalid-name", message: "lastName is invalid" };
   }
 });
 


### PR DESCRIPTION
This riffs off of #345.

I've assume the intent here is to allow rules to return this infomation vs _automagically_ determining the field.

I've verged slightly from the ideas within the issue, by introducing a second new property, `code?: string`. This avoids the overloading of `message` as a user-readable and-also programatic value.

I thought this was important as already we have rules such as min/max number where the message can encode more infomation. You would then be left with a decision of either making it static and easy to find or dynamic and hard.