### PR TITLE
fix: Sync derived fields on STI types

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1934,15 +1934,16 @@ function recalcSynchronousDerivedFields(todos: Record<string, Todo>) {
     [...new Set(entities.map(getMetadata))].map((m) => {
       return [
         m,
-        Object.values(m.fields)
-          .filter((f) => f.kind === "primitive" && f.derived === "sync")
+        Object.values(m.allFields)
+          .filter((f) => (f.kind === "primitive" || f.kind === "enum") && f.derived === "sync")
           .map((f) => f.fieldName),
       ];
     }),
   );
+  if (entities.some((e) => getMetadata(e).type === "TaskNew")) console.log([...derivedFieldsByMeta.entries()]);
 
   for (const entity of entities) {
-    const derivedFields = getBaseAndSelfMetas(getMetadata(entity)).flatMap((m) => derivedFieldsByMeta.get(m) || []);
+    const derivedFields = derivedFieldsByMeta.get(getMetadata(entity)) || [];
     derivedFields.forEach((fieldName) => {
       // setField will intelligently mark/not mark the field as dirty.
       setField(entity, fieldName as any, (entity as any)[fieldName]);

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1940,7 +1940,6 @@ function recalcSynchronousDerivedFields(todos: Record<string, Todo>) {
       ];
     }),
   );
-  if (entities.some((e) => getMetadata(e).type === "TaskNew")) console.log([...derivedFieldsByMeta.entries()]);
 
   for (const entity of entities) {
     const derivedFields = derivedFieldsByMeta.get(getMetadata(entity)) || [];

--- a/packages/tests/integration/src/SingleTableInheritance.test.ts
+++ b/packages/tests/integration/src/SingleTableInheritance.test.ts
@@ -375,8 +375,8 @@ describe("SingleTableInheritance", () => {
 
   it("setDefaults work as expected for subtypes", async () => {
     const em = newEntityManager();
-    const ot = newTaskOld(em, {});
-    const nt = newTaskNew(em, {});
+    const ot = em.create(TaskOld, { specialOldField: 1 });
+    const nt = em.create(TaskNew, {});
     await em.flush();
     // Then TaskOld runs its defaults
     expect(ot).toMatchEntity({
@@ -394,8 +394,8 @@ describe("SingleTableInheritance", () => {
 
   it("derived fields work as expected", async () => {
     const em = newEntityManager();
-    const ot = newTaskOld(em, {});
-    const nt = newTaskNew(em, {});
+    const ot = em.create(TaskOld, { specialOldField: 1 });
+    const nt = em.create(TaskNew, {});
     await em.flush();
     // Then TaskOld runs its defaults
     expect(ot).toMatchEntity({


### PR DESCRIPTION
I've yet to be able to reproduce why this was failing in graphql-service, but working in joist. However, these changes do get it working in graphql-service.