### PR TITLE
fix: Call hookUpBaseTypeAndSubTypes before fireAfterMetadatas

### DIFF
--- a/packages/orm/src/configure.ts
+++ b/packages/orm/src/configure.ts
@@ -18,11 +18,11 @@ const typeToMetaMap = new Map<string, EntityMetadata>();
 
 /** Performs our boot-time initialization, i.e. hooking up reactivity. */
 export function configureMetadata(metas: EntityMetadata[]): void {
+  hookUpBaseTypeAndSubTypes(metas);
   fireAfterMetadatas(metas);
   setBooted();
   populateConstructorMaps(metas);
   setImmutableFields(metas);
-  hookUpBaseTypeAndSubTypes(metas);
   reverseIndexReactivity(metas);
   populatePolyComponentFields(metas);
 }

--- a/packages/orm/src/configure.ts
+++ b/packages/orm/src/configure.ts
@@ -18,13 +18,13 @@ const typeToMetaMap = new Map<string, EntityMetadata>();
 
 /** Performs our boot-time initialization, i.e. hooking up reactivity. */
 export function configureMetadata(metas: EntityMetadata[]): void {
-  hookUpBaseTypeAndSubTypes(metas);
-  fireAfterMetadatas(metas);
   setBooted();
   populateConstructorMaps(metas);
   setImmutableFields(metas);
+  hookUpBaseTypeAndSubTypes(metas);
   reverseIndexReactivity(metas);
   populatePolyComponentFields(metas);
+  fireAfterMetadatas(metas);
 }
 
 function fireAfterMetadatas(metas: EntityMetadata[]): void {

--- a/packages/tests/integration/src/Inheritance.test.ts
+++ b/packages/tests/integration/src/Inheritance.test.ts
@@ -397,4 +397,8 @@ describe("Inheritance", () => {
       `"SELECT p.*, p_s0.*, p_s1.*, p.id as id, COALESCE(p_s0.shared_column, p_s1.shared_column) as shared_column, CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class FROM publishers AS p LEFT OUTER JOIN large_publishers AS p_s0 ON p.id = p_s0.id LEFT OUTER JOIN small_publishers AS p_s1 ON p.id = p_s1.id WHERE p.deleted_at IS NULL ORDER BY p.id ASC LIMIT $1"`,
     );
   });
+
+  it("can access sub type metadata in afterMetadata", async () => {
+    expect(Publisher.afterMetadataHasSubTypes).toBe(true);
+  });
 });

--- a/packages/tests/integration/src/Inheritance.test.ts
+++ b/packages/tests/integration/src/Inheritance.test.ts
@@ -398,6 +398,10 @@ describe("Inheritance", () => {
     );
   });
 
+  it("can access base type metadata in afterMetadata", async () => {
+    expect(SmallPublisher.afterMetadataHasBaseTypes).toBe(true);
+  });
+
   it("can access sub type metadata in afterMetadata", async () => {
     expect(Publisher.afterMetadataHasSubTypes).toBe(true);
   });

--- a/packages/tests/integration/src/entities/Publisher.ts
+++ b/packages/tests/integration/src/entities/Publisher.ts
@@ -29,6 +29,8 @@ export abstract class Publisher extends PublisherCodegen {
     changedInBeforeCommit: [] as string[],
   };
 
+  static afterMetadataHasSubTypes = false;
+
   /** Example of a reactive query. */
   readonly numberOfBookReviews: ReactiveField<Publisher, number> = hasReactiveQueryField(
     "numberOfBookReviews",
@@ -95,6 +97,10 @@ export abstract class Publisher extends PublisherCodegen {
   /** For testing reacting to poly CommentParent properties. */
   readonly commentParentInfo: AsyncProperty<Publisher, string> = hasReactiveAsyncProperty([], () => ``);
 }
+
+config.afterMetadata((meta) => {
+  Publisher.afterMetadataHasSubTypes = meta.subTypes.length > 0;
+});
 
 /** Test the types for an enum default value (even though it is already matched by the db defaultValues). */
 config.setDefault("type", () => PublisherType.Big);

--- a/packages/tests/integration/src/entities/SmallPublisher.ts
+++ b/packages/tests/integration/src/entities/SmallPublisher.ts
@@ -10,6 +10,7 @@ export class SmallPublisher extends SmallPublisherCodegen {
     { authors: ["firstName"] },
     (sp) => sp.authors.get.map((a) => a.firstName).join(", "),
   );
+  static afterMetadataHasBaseTypes = false;
   public beforeFlushRan = false;
   public beforeCreateRan = false;
   public beforeUpdateRan = false;
@@ -17,6 +18,10 @@ export class SmallPublisher extends SmallPublisherCodegen {
   public afterValidationRan = false;
   public afterCommitRan = false;
 }
+
+config.afterMetadata((meta) => {
+  SmallPublisher.afterMetadataHasBaseTypes = meta.baseTypes.length > 0;
+});
 
 config.addRule((p) => {
   if (p.name === "large") {


### PR DESCRIPTION
Fixes base and sub type metadata access within the `afterMetadata` lifecycle hook by calling `hookUpBaseTypeAndSubTypes` before `fireAfterMetadata` within `configureMetadata`.