### PR TITLE
feat: Update factories to set defaults immediately.

### DIFF
--- a/packages/orm/src/defaults.ts
+++ b/packages/orm/src/defaults.ts
@@ -17,6 +17,7 @@ export function hasDefaultValue(meta: EntityMetadata, fieldName: string): boolea
 /** Run the sync defaults for `entity`. */
 export function setSyncDefaults(entity: Entity): void {
   const meta = getMetadata(entity);
+  // Allow subtypes to override base setDefaults
   const syncDefaults: Record<string, any> = getBaseAndSelfMetas(meta).reduce(
     (acc, m) => ({ ...acc, ...m.config.__data.syncDefaults }),
     {},
@@ -73,10 +74,13 @@ export function setAsyncDefaults(
 
 /** Sets async defaults *synchronously*, only safe for factories with `DeepNew` entities. */
 export function setAsyncDefaultsSynchronously(ctx: unknown, entity: Entity): void {
-  for (const meta of getBaseAndSelfMetas(getMetadata(entity))) {
-    for (const df of Object.values(meta.config.__data.asyncDefaults)) {
-      df.setOnFactoryEntity(ctx, entity);
-    }
+  // Allow subtypes to override base setDefaults
+  const defaults: Record<string, AsyncDefault<any>> = getBaseAndSelfMetas(getMetadata(entity)).reduce(
+    (acc, m) => ({ ...acc, ...m.config.__data.asyncDefaults }),
+    {},
+  );
+  for (const df of Object.values(defaults)) {
+    df.setOnFactoryEntity(ctx, entity);
   }
 }
 

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -248,7 +248,10 @@ export function newTestInstance<T extends Entity>(
 
   entity.set(Object.fromEntries(additionalOpts.filter((t) => t.length > 0)));
 
-  // Would be nice to log these in the output...
+  // em.create applied synchronous defaults automatically; since we're a factory with likely
+  // deeply-loaded instances, go ahead and synchronously invoke the async defaults, at least
+  // the ones that just use load hints + a synchronous lambda.
+  // (...would be nice to log these in the setFactoryLogging output)
   setAsyncDefaultsSynchronously(em.ctx, entity);
 
   // Set it back to undefined

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -23,7 +23,7 @@ import {
   PolymorphicField,
   PrimitiveField,
 } from "./EntityMetadata";
-import { hasDefaultValue } from "./defaults";
+import { hasDefaultValue, setAsyncDefaultsSynchronously } from "./defaults";
 import { DeepNew, New } from "./index";
 import { tagId } from "./keys";
 import { FactoryLogger } from "./logging/FactoryLogger";
@@ -94,12 +94,19 @@ export function newTestInstance<T extends Entity>(
     .map((field) => {
       const { fieldName } = field;
 
+      // Don't fill in required fields if told not to
+      const ignoreAllDefaults = "useFactoryDefaults" in opts && opts.useFactoryDefaults === "none";
+      // If the field has a default value, don't force fill it, even if passed `author: undefined`
+      const required = field.required && !ignoreAllDefaults && !hasDefaultValue(meta, fieldName);
+
       // Use the opts value if they passed one in
       if (fieldName in opts && (opts as any)[fieldName] !== defaultValueMarker) {
         const optValue = (opts as any)[fieldName];
         // We don't explicitly support null (callers should pass undefined), but we accept it
-        // for good measure.
-        if (optValue === null || (optValue === undefined && !field.required)) {
+        // because the factory might have done `const { author, ... } = opts` and is accidentally
+        // passing an `author: undefined` without meaning too.
+        const shouldRespectUndefined = !required;
+        if (optValue === null || (optValue === undefined && shouldRespectUndefined)) {
           return [];
         }
         switch (field.kind) {
@@ -132,10 +139,6 @@ export function newTestInstance<T extends Entity>(
             return assertNever(field);
         }
       }
-
-      // Don't fill in required fields if told not to
-      const ignoreAllDefaults = "useFactoryDefaults" in opts && opts.useFactoryDefaults === "none";
-      const required = field.required && !ignoreAllDefaults && !hasDefaultValue(meta, fieldName);
 
       if (
         field.kind === "primitive" &&
@@ -244,6 +247,9 @@ export function newTestInstance<T extends Entity>(
   }
 
   entity.set(Object.fromEntries(additionalOpts.filter((t) => t.length > 0)));
+
+  // Would be nice to log these in the output...
+  setAsyncDefaultsSynchronously(em.ctx, entity);
 
   // Set it back to undefined
   logger?.dedent();

--- a/packages/tests/integration/src/EntityManager.defaults.test.ts
+++ b/packages/tests/integration/src/EntityManager.defaults.test.ts
@@ -41,12 +41,12 @@ describe("EntityManager.defaults", () => {
     const a = newAuthor(em);
     const b1 = newBook(em, { author: a, order: undefined });
     const b2 = newBook(em, { author: a, order: undefined });
-    // And the factory/sync default didn't get applied
-    expect(b1.order).toBeUndefined();
-    expect(b2.order).toBeUndefined();
+    // And the factory/sync default got applied (neat!)
+    expect(b1.order).toBe(1);
+    expect(b2.order).toBe(2);
     // When we flush
     await em.flush();
-    // Then the async default kicked in
+    // The defaults stayed
     expect(b1.order).toBe(1);
     expect(b2.order).toBe(2);
   });

--- a/packages/tests/integration/src/FieldLogging.test.ts
+++ b/packages/tests/integration/src/FieldLogging.test.ts
@@ -46,10 +46,12 @@ describe("FieldLogging", () => {
      [
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
+       "a#1.nickNames = a1 at defaults.ts:165↩",
        "b#1.title = title at newBook.ts:9↩",
        "b#1.order = 1 at newBook.ts:9↩",
        "b#1.author = Author#1 at newBook.ts:9↩",
-       "b#1.notes = Notes for title at defaults.ts:38↩",
+       "b#1.notes = Notes for title at defaults.ts:39↩",
+       "b#1.authorsNickNames = a1 at defaults.ts:165↩",
      ]
     `);
   });
@@ -62,6 +64,7 @@ describe("FieldLogging", () => {
      [
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
+       "a#1.nickNames = a1 at defaults.ts:165↩",
      ]
     `);
   });

--- a/packages/tests/integration/src/entities/Book.ts
+++ b/packages/tests/integration/src/entities/Book.ts
@@ -81,9 +81,10 @@ config.setDefault(
     tags: { publishers: "authors" },
     title: {},
   },
-  async (b, { em }) => {
+  (b, { em }) => {
     // Test returning a Reacted<Author> can pass type check
     const maybeAuthor = b.tags.get[0]?.publishers.get[0]?.authors.get[0];
+    // ...and also synchronously returning an entity from an async default
     if (maybeAuthor) return maybeAuthor;
     // See if we have an author with the same name as the book title
     return em.findOne(Author, { lastName: b.title });

--- a/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
@@ -70,8 +70,8 @@ describe("ReactiveQueryField", () => {
       "numberOfBookReviews",
       "type",
       "baseSyncDefault",
-      "titlesOfFavoriteBooks",
       "baseAsyncDefault",
+      "titlesOfFavoriteBooks",
     ]);
   });
 


### PR DESCRIPTION
Because factory entities are DeepNew/deeply loaded, it's very likely that what would, in production, usually be an async `setDefault` call (requiring a Promise to load data from the db) can, in a test, actually be done synchronously (by assuming the test instance has the data already in memory).

This PR leans into that assumption, and uses a cute `async () => {}.constructor` check to guess at whether a `setDefault` lambda is synchronous or not.

It's not foolproof but should work.