### PR TITLE
fix: Simplify base setPartial/setDeepPartial types.

### DIFF
--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -1,16 +1,5 @@
 import { IdType } from "./Entity";
-import {
-  DeepPartialOrNull,
-  Entity,
-  EntityManager,
-  InstanceData,
-  OptsOf,
-  PartialOrNull,
-  TaggedId,
-  deTagId,
-  getMetadata,
-  keyToNumber,
-} from "./index";
+import { Entity, EntityManager, InstanceData, TaggedId, deTagId, getMetadata, keyToNumber } from "./index";
 
 export let currentlyInstantiatingEntity: Entity | undefined;
 
@@ -74,17 +63,17 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
     return deTagId(getMetadata(this), this.id);
   }
 
-  abstract set(values: Partial<OptsOf<Entity>>): void;
+  abstract set(opts: unknown): void;
 
   /**
    * Similar to `set` but applies "Partial API" semantics, i.e. `null` means unset and `undefined` means don't change.
    */
-  abstract setPartial(values: PartialOrNull<OptsOf<Entity>>): void;
+  abstract setPartial(opts: unknown): void;
 
   /**
    * Similar to `set` but applies "Partial API" semantics, i.e. `null` means unset and `undefined` means don't change.
    */
-  abstract setDeepPartial(values: DeepPartialOrNull<OptsOf<Entity>>): Promise<void>;
+  abstract setDeepPartial(opts: unknown): Promise<void>;
 
   /**
    * Returns whether the entity is new.

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -1,5 +1,5 @@
-import { EntityManager, OptsOf, TaggedId } from "./EntityManager";
-import { BaseEntity, DeepPartialOrNull, PartialOrNull } from "./index";
+import { EntityManager, TaggedId } from "./EntityManager";
+import { BaseEntity } from "./index";
 
 export function isEntity(maybeEntity: unknown): maybeEntity is Entity {
   return maybeEntity instanceof BaseEntity;
@@ -19,9 +19,9 @@ export interface Entity {
   readonly isNewEntity: boolean;
   readonly isDeletedEntity: boolean;
   readonly isDirtyEntity: boolean;
-  set(opts: Partial<OptsOf<this>>): void;
-  setPartial(opts: PartialOrNull<OptsOf<this>>): void;
-  setDeepPartial(opts: DeepPartialOrNull<this>): Promise<void>;
+  set(opts: unknown): void;
+  setPartial(opts: unknown): void;
+  setDeepPartial(opts: unknown): Promise<void>;
   /**
    * Returns `type:id`, i.e. `Author:1` for persisted entities and `Author#1` for new entities.
    *


### PR DESCRIPTION
The new `setDeepPartial` method was causing our internal tsc build to OOME; my guess was maybe because of tsc type-checking that the `...Codegen.setDeepPartial`s sufficiently implement the base type `Entity.setDeepPartial` / `BaseEntity.setDeepPartial` methods.

Particularly given that the base `setDeepPartial` used various "probably not cheap" things like `OptsOf<Entity>` or `OptsOf<this>`.

This PR simplies the base types to just `set...(opts: unknown)` with the rationale that anyone doing metaprogramming against Entity or BaseEntity will likely be doing `any`-ish type stuff anyway, and for anyone else going through concrete entities, they'll get the `Codegen.set...` methods to enforce type-safety.