### PR TITLE
fix: Fix inference for required hasReactiveReference.

### DIFF
--- a/packages/orm/src/reactiveHints.ts
+++ b/packages/orm/src/reactiveHints.ts
@@ -117,12 +117,19 @@ export type Reacted<T extends Entity, H> = Entity & {
   readonly __orm: { entityType: T };
 } & MaybeTransientFields<T>;
 
-/** Allow returning reacted entities from `hasReactiveAsyncProperties`. */
-export type MaybeReactedEntity<V> = V extends (infer T extends Entity) | undefined
-  ? { __orm: { entityType: T } } | undefined
-  : V extends Entity
-    ? { __orm: { entityType: V } }
-    : V;
+/** Allow returning reacted entities from `hasReactiveReference`. */
+export type MaybeReactedEntity<V> = V extends Entity ? { __orm: { entityType: V } } : V;
+
+/**
+ * Allow returning reacted entities from `hasReactiveAsyncProperty`.
+ *
+ * The `MaybeReactedEntity` is used by `hasReactiveReference` which already has `undefined | never`
+ * broken out as a separate generic; `hasReactiveAsyncProperty` does not, and so this type conditionally
+ * pulls `undefined` out first, and then defers to `MaybeReactedEntity`.
+ */
+export type MaybeReactedPropertyEntity<V> = V extends infer V1 | undefined
+  ? MaybeReactedEntity<V1> | undefined
+  : MaybeReactedEntity<V>;
 
 /**
  * A reactive hint that only allows fields immediately on the entity, i.e. no nested hints.

--- a/packages/orm/src/relations/ReactiveReference.ts
+++ b/packages/orm/src/relations/ReactiveReference.ts
@@ -51,6 +51,19 @@ export interface ReactiveReference<T extends Entity, U extends Entity, N extends
   idUntaggedIfSet: string | undefined;
 }
 
+export function hasReactiveReference<T extends Entity, U extends Entity, const H extends ReactiveHint<T>>(
+  otherMeta: EntityMetadata<U>,
+  fieldName: keyof T & string,
+  hint: H,
+  fn: (entity: Reacted<T, H>) => MaybeReactedEntity<U>,
+): ReactiveReference<T, U, never>;
+export function hasReactiveReference<T extends Entity, U extends Entity, const H extends ReactiveHint<T>>(
+  otherMeta: EntityMetadata<U>,
+  fieldName: keyof T & string,
+  hint: H,
+  fn: (entity: Reacted<T, H>) => MaybeReactedEntity<U> | undefined,
+): ReactiveReference<T, U, undefined>;
+/** Creates a `ReactiveReference`. */
 export function hasReactiveReference<
   T extends Entity,
   U extends Entity,

--- a/packages/orm/src/relations/hasAsyncProperty.ts
+++ b/packages/orm/src/relations/hasAsyncProperty.ts
@@ -2,7 +2,7 @@ import { currentlyInstantiatingEntity } from "../BaseEntity";
 import { Entity } from "../Entity";
 import { getMetadata } from "../EntityMetadata";
 import { LoadHint, Loaded } from "../loadHints";
-import { MaybeReactedEntity, Reacted, ReactiveHint, convertToLoadHint } from "../reactiveHints";
+import { MaybeReactedPropertyEntity, Reacted, ReactiveHint, convertToLoadHint } from "../reactiveHints";
 import { tryResolve } from "../utils";
 
 export const AsyncPropertyT = Symbol();
@@ -44,7 +44,7 @@ export function hasAsyncProperty<T extends Entity, const H extends LoadHint<T>, 
  */
 export function hasReactiveAsyncProperty<T extends Entity, const H extends ReactiveHint<T>, V>(
   reactiveHint: H,
-  fn: (entity: Reacted<T, H>) => MaybeReactedEntity<V>,
+  fn: (entity: Reacted<T, H>) => MaybeReactedPropertyEntity<V>,
 ): AsyncProperty<T, V> {
   const entity = currentlyInstantiatingEntity as T;
   return new AsyncPropertyImpl(entity, reactiveHint as any, fn as any, { isReactive: true });


### PR DESCRIPTION
The `N extends undefined | never` was not inferring, so use separate function overloads, which gets the right `never` overload to be inferred first, if possible/appropriate.