### PR TITLE
feat: Allow o2m subtype specialization.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -938,11 +938,14 @@ function createRelations(config: Config, meta: EntityDbMetadata, entity: Entity)
   });
   // Specialize
   const o2mBase: Relation[] =
-    meta.baseType?.oneToManys.map((o2m) => {
-      const { fieldName, otherEntity } = o2m;
-      const decl = code`${Collection}<${entity.type}, ${otherEntity.type}>`;
-      return { kind: "super", fieldName, decl };
-    }) ?? [];
+    meta.baseType?.oneToManys
+      // Skip o2ms that are already specialized to a different otherEntity, i.e. `SmallPublisherGroup.publishers: SmallPublisher`
+      .filter((o2m) => !meta.oneToManys.find((o) => o.fieldName === o2m.fieldName))
+      .map((o2m) => {
+        const { fieldName, otherEntity } = o2m;
+        const decl = code`${Collection}<${entity.type}, ${otherEntity.type}>`;
+        return { kind: "super", fieldName, decl };
+      }) ?? [];
 
   // Add large OneToMany
   const lo2m: Relation[] = meta.largeOneToManys.map((o2m) => {

--- a/packages/orm/src/dataloaders/oneToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyDataLoader.ts
@@ -36,7 +36,7 @@ export function oneToManyDataLoader<T extends Entity, U extends Entity>(
         conditions: [
           {
             kind: "column",
-            alias,
+            alias: `${alias}${meta.allFields[collection.otherFieldName].aliasSuffix}`,
             column: collection.otherColumnName,
             dbType: meta.idDbType,
             cond: { kind: "in", value: keys },

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -143,7 +143,7 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     this.#hasBeenSet = true;
 
     // If we're changing `a1.books = [b1, b2]` to `a1.books = [b2]`, then implicitly delete the old book
-    const otherCannotChange = this.otherMeta.fields[this.otherFieldName].immutable;
+    const otherCannotChange = this.otherMeta.allFields[this.otherFieldName].immutable;
     if (this.isCascadeDelete && otherCannotChange) {
       const implicitlyDeleted = this.loaded.filter((e) => !values.includes(e));
       implicitlyDeleted.forEach((e) => this.entity.em.delete(e));

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -76,7 +76,7 @@
       },
       "tag": "p"
     },
-    "SmallPublisherGroup": { "tag": "pg" },
+    "SmallPublisherGroup": { "relations": { "publishers": { "subType": "SmallPublisher" } }, "tag": "pg" },
     "Tag": { "tag": "t" },
     "Task": {
       "fields": {

--- a/packages/tests/integration/src/ClassTableInheritance.test.ts
+++ b/packages/tests/integration/src/ClassTableInheritance.test.ts
@@ -10,6 +10,7 @@ import {
   newPublisher,
   newPublisherGroup,
   newSmallPublisher,
+  newSmallPublisherGroup,
   newUser,
   Publisher,
   PublisherGroup,
@@ -513,5 +514,13 @@ describe("ClassTableInheritance", () => {
     );
     // And em.flush fails
     await expect(em.flush()).rejects.toThrow("group must be a SmallPublisherGroup not PublisherGroup#1");
+  });
+
+  it("can specialize a base type o2m", async () => {
+    // Given we create a SmallPublisherGroup
+    const em = newEntityManager();
+    const spg = newSmallPublisherGroup(em, { publishers: [{}] });
+    // Then we know it's publishers are SmallPublishers
+    expect(spg.publishers.get[0].city).toBe("city");
   });
 });

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
@@ -4,10 +4,15 @@ import {
   type Collection,
   ConfigApi,
   type DeepPartialOrNull,
+  type EntityFilter,
+  type EntityGraphQLFilter,
   type EntityMetadata,
   failNoIdYet,
+  type FilterOf,
   type Flavor,
   getField,
+  type GraphQLFilterOf,
+  hasMany,
   isLoaded,
   type JsonPayload,
   type Lens,
@@ -33,7 +38,6 @@ import {
   type Entity,
   EntityManager,
   newSmallPublisherGroup,
-  Publisher,
   PublisherGroup,
   type PublisherGroupFields,
   type PublisherGroupFilter,
@@ -41,8 +45,11 @@ import {
   type PublisherGroupIdsOpts,
   type PublisherGroupOpts,
   type PublisherGroupOrder,
+  SmallPublisher,
   SmallPublisherGroup,
   smallPublisherGroupMeta,
+  type SmallPublisherId,
+  smallPublisherMeta,
 } from "../entities";
 
 export type SmallPublisherGroupId = Flavor<string, SmallPublisherGroup> & Flavor<string, "PublisherGroup">;
@@ -54,17 +61,21 @@ export interface SmallPublisherGroupFields extends PublisherGroupFields {
 
 export interface SmallPublisherGroupOpts extends PublisherGroupOpts {
   smallName?: string | null;
+  publishers?: SmallPublisher[];
 }
 
 export interface SmallPublisherGroupIdsOpts extends PublisherGroupIdsOpts {
+  publisherIds?: SmallPublisherId[] | null;
 }
 
 export interface SmallPublisherGroupFilter extends PublisherGroupFilter {
   smallName?: ValueFilter<string, null>;
+  publishers?: EntityFilter<SmallPublisher, SmallPublisherId, FilterOf<SmallPublisher>, null | undefined>;
 }
 
 export interface SmallPublisherGroupGraphQLFilter extends PublisherGroupGraphQLFilter {
   smallName?: ValueGraphQLFilter<string>;
+  publishers?: EntityGraphQLFilter<SmallPublisher, SmallPublisherId, GraphQLFilterOf<SmallPublisher>, null | undefined>;
 }
 
 export interface SmallPublisherGroupOrder extends PublisherGroupOrder {
@@ -260,7 +271,14 @@ export abstract class SmallPublisherGroupCodegen extends PublisherGroup implemen
     return !hint || typeof hint === "string" ? super.toJSON() : toJSON(this, hint);
   }
 
-  get publishers(): Collection<SmallPublisherGroup, Publisher> {
-    return super.publishers as Collection<SmallPublisherGroup, Publisher>;
+  get publishers(): Collection<SmallPublisherGroup, SmallPublisher> {
+    return this.__data.relations.publishers ??= hasMany(
+      this,
+      smallPublisherMeta,
+      "publishers",
+      "group",
+      "group_id",
+      undefined,
+    );
   }
 }

--- a/packages/tests/integration/src/entities/codegen/metadata.ts
+++ b/packages/tests/integration/src/entities/codegen/metadata.ts
@@ -747,7 +747,11 @@ export const smallPublisherGroupMeta: EntityMetadata<SmallPublisherGroup> = {
   idDbType: "int",
   tagName: "pg",
   tableName: "small_publisher_groups",
-  fields: { "id": { kind: "primaryKey", fieldName: "id", fieldIdName: undefined, required: true, serde: new KeySerde("pg", "id", "id", "int"), immutable: true }, "smallName": { kind: "primitive", fieldName: "smallName", fieldIdName: undefined, derived: false, required: false, protected: false, type: "string", serde: new PrimitiveSerde("smallName", "small_name", "text"), immutable: false } },
+  fields: {
+    "id": { kind: "primaryKey", fieldName: "id", fieldIdName: undefined, required: true, serde: new KeySerde("pg", "id", "id", "int"), immutable: true },
+    "smallName": { kind: "primitive", fieldName: "smallName", fieldIdName: undefined, derived: false, required: false, protected: false, type: "string", serde: new PrimitiveSerde("smallName", "small_name", "text"), immutable: false },
+    "publishers": { kind: "o2m", fieldName: "publishers", fieldIdName: "publisherIds", required: false, otherMetadata: () => smallPublisherMeta, otherFieldName: "group", serde: undefined, immutable: false },
+  },
   allFields: {},
   orderBy: undefined,
   timestampFields: undefined!,


### PR DESCRIPTION
Similar to a SmallPublisher.group: SmallPublisherGroup m2o specialization, allow a SmallPublisherGroup.publishers: SmallPublishers specialization.

Note that these may go hand-in-hand, and be set on both sides of a relation, but not necessarily, i.e. it could be valid for the SmallPublisherGroup to have any type of Publisher, until this hint was specifically added, in addition to the "SmallPublisher.group is a SmallPublisherGroup hint".