### PR TITLE
feat: Type GraphQL subtyped m2os as Like.

### DIFF
--- a/packages/graphql-codegen/src/graphqlUtils.ts
+++ b/packages/graphql-codegen/src/graphqlUtils.ts
@@ -76,9 +76,10 @@ function createFieldDoc(objectName: string, fields: GqlField[]): DocumentNode {
   const type = objectType === "output" ? "type" : objectType;
   const maybeArgs = (f: GqlField) => (f.argsString ? `(${f.argsString})` : "");
   const maybeExtends = fields.some((f: GqlField) => f.extends) ? "extend " : "";
-  return parse(`${maybeExtends}${type} ${objectName} {
+  const source = `${maybeExtends}${type} ${objectName} {
     ${fields.map((f) => `${f.fieldName}${maybeArgs(f)}: ${f.fieldType}`)}
-  }`);
+  }`;
+  return parse(source);
 }
 
 function createUnionDoc(union: GqlUnion): DocumentNode {

--- a/packages/graphql-codegen/src/index.ts
+++ b/packages/graphql-codegen/src/index.ts
@@ -1,4 +1,4 @@
-import { Config, EntityDbMetadata, EnumMetadata } from "joist-codegen";
+import { Config, DbMetadata } from "joist-codegen";
 import { CodegenFile } from "ts-poet";
 import { generateEnumDetailResolvers } from "./generateEnumDetailResolvers";
 import { generateEnumsGraphql } from "./generateEnumsGraphql";
@@ -9,13 +9,14 @@ import { generateSaveResolvers } from "./generateSaveResolvers";
 import { loadHistory, writeHistory } from "./history";
 import { Fs, newFsImpl } from "./utils";
 
-export async function run(config: Config, entities: EntityDbMetadata[], enums: EnumMetadata): Promise<CodegenFile[]> {
+export async function run(config: Config, dbMeta: DbMetadata): Promise<CodegenFile[]> {
   const fs = newFsImpl("./schema");
 
   // We upsert directly into schema files so we don't use the usual `CodeGenFile[]` return type;
-  await generateGraphqlSchemaFiles(fs, entities);
+  await generateGraphqlSchemaFiles(fs, dbMeta);
 
   // We use the history file to ensure we only generate these once
+  const { entities, enums } = dbMeta;
   const conditionalResolvers = [
     ...generateObjectResolvers(config, entities),
     ...generateSaveResolvers(config, entities),

--- a/packages/graphql-codegen/src/testUtils.ts
+++ b/packages/graphql-codegen/src/testUtils.ts
@@ -1,5 +1,5 @@
 import { snakeCase } from "change-case";
-import { EntityDbMetadata, EnumField, makeEntity, PrimitiveField } from "joist-codegen";
+import { EntityDbMetadata, EnumField, makeEntity, ManyToOneField, PrimitiveField } from "joist-codegen";
 import { plural } from "pluralize";
 import { imp } from "ts-poet";
 import { Fs } from "./utils";
@@ -89,6 +89,28 @@ export function newEnumField(fieldName: string, opts: Partial<EnumField> = {}): 
     enumRows: [],
     isArray: false,
     hasConfigDefault: false,
+    ...opts,
+  };
+}
+
+export function newManyToOneField(
+  fieldName: string,
+  otherEntity: string,
+  opts: Partial<ManyToOneField> = {},
+): ManyToOneField {
+  return {
+    kind: "m2o",
+    fieldName,
+    columnName: snakeCase(fieldName),
+    derived: false,
+    notNull: true,
+    hasConfigDefault: false,
+    dbType: "int",
+    otherFieldName: `other${fieldName}`,
+    otherEntity: makeEntity(otherEntity),
+    isDeferredAndDeferrable: true,
+    constraintName: "",
+    onDelete: "NO ACTION" as any,
     ...opts,
   };
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -22,3 +22,22 @@ export function groupBy<T, Y = T>(
   });
   return result;
 }
+
+export function keyBy<T, K extends PropertyKey, Y = T>(
+  list: readonly T[],
+  fnOrKey: CallbackFn<T, K> | keyof T[][number],
+  valueFn?: CallbackFn<T, Y>,
+) {
+  const result = {} as Record<K, Y>;
+  const fn = typeof fnOrKey === "function" ? fnOrKey : (x: T) => x[fnOrKey] as K;
+  list.forEach((e, i, a) => {
+    const group = fn(e, i, a);
+    if (result[group] !== undefined) {
+      throw new Error(`${String(group)} already had a value assigned`);
+    }
+    result[group] = valueFn ? valueFn(e, i, a) : (e as any as Y);
+  });
+  return result;
+}
+
+export type CallbackFn<T, R = any> = (element: T, index: number, array: readonly T[]) => R;


### PR DESCRIPTION
Fixes #1282.

Also changes the plugin api to `run(Config, DbMeta)` which is better, more "parameter/context object" API than passing the entities, enums, etc. all as separate params.