### PR TITLE
fix: Add entty to CustomReferenceOpts.isLoaded.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -38,6 +38,7 @@ import {
   PartialOrNull,
   PolymorphicReferenceImpl,
   ReactionLogger,
+  Reference,
   TimestampSerde,
   UniqueFilter,
   ValidationError,
@@ -53,6 +54,7 @@ import {
   getMetadata,
   getRelationEntries,
   getRelations,
+  isLoadedReference,
   keyToTaggedId,
   loadLens,
   parseFindQuery,
@@ -1749,6 +1751,11 @@ export function sameEntity(a: Entity | string | number | undefined, b: Entity | 
   const aId = isEntity(a) ? a.idTaggedMaybe : a;
   const bId = isEntity(b) ? b.idTaggedMaybe : b;
   return aId === bId;
+}
+
+/** Compares the value `a` to `b`, with handling of new entities w/o ids assigned yet. */
+export function sameReference<T extends Entity>(a: Reference<any, T, any>, b: Reference<any, T, any>): boolean {
+  return sameEntity(isLoadedReference(a) ? a.get : a.idTaggedMaybe, isLoadedReference(b) ? b.get : b.idTaggedMaybe);
 }
 
 /** Thrown by `findOneOrFail`, 'load' & 'loadAll' if an entity is not found. */

--- a/packages/orm/src/keys.ts
+++ b/packages/orm/src/keys.ts
@@ -17,7 +17,7 @@ type HasTagName = {
   idDbType: "bigint" | "int" | "uuid";
 };
 
-/** Converts our internal/always-tagged `id` to the domain entity's `id` type. */
+/** Converts our internal/always-tagged `id` to the domain entity's `id` type (could be a number or uuid). */
 export function toIdOf<T extends Entity>(meta: EntityMetadata<T>, id: TaggedId | undefined): IdOf<T> | undefined {
   if (!id) return undefined;
   switch (meta.idType) {

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -199,7 +199,7 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
     return toIdOf(this.otherMeta, this.idTaggedMaybe);
   }
 
-  /** Returns the tagged id of the current value. */
+  /** Returns the tagged id of the current value, or undefined if unset or a new entity. */
   get idTaggedMaybe(): TaggedId | undefined {
     ensureNotDeleted(this.entity, "pending");
     return maybeResolveReferenceToId(this.current());

--- a/packages/orm/src/relations/Reference.ts
+++ b/packages/orm/src/relations/Reference.ts
@@ -21,12 +21,14 @@ export const ReferenceN = Symbol();
 export interface Reference<T extends Entity, U extends Entity, N extends never | undefined> extends Relation<T, U> {
   [ReferenceN]: N;
 
+  // ...would be great to use a type-guard, but we're a property
   readonly isLoaded: boolean;
 
   load(opts?: { withDeleted?: boolean; forceReload?: true }): Promise<U | N>;
 
   set(other: U | N): void;
 
+  /** Returns the always-tagged id of the current value, or undefined if unset or new. */
   idTaggedMaybe: TaggedId | undefined;
 }
 

--- a/packages/orm/src/relations/index.ts
+++ b/packages/orm/src/relations/index.ts
@@ -1,6 +1,6 @@
 export { Collection, LoadedCollection, isCollection, isLoadedCollection } from "./Collection";
 export { CustomCollection } from "./CustomCollection";
-export { CustomReference } from "./CustomReference";
+export { CustomReference, hasCustomReference } from "./CustomReference";
 export { AsyncMethod, LoadedMethod, hasAsyncMethod } from "./hasAsyncMethod";
 export {
   AsyncProperty,


### PR DESCRIPTION
Just an oversight that assumed the entity could be accessed via a captured `this`.