### PR TITLE
fix: Fix specialized default dependencies.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1244,7 +1244,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
           // Run our hooks
           let todos = createTodos([...pendingHooks]);
 
-          await setAsyncDefaults(suppressedDefaultTypeErrors, this.ctx, Todo.groupByType(todos));
+          await setAsyncDefaults(suppressedDefaultTypeErrors, this.ctx, Todo.groupInsertsByTypeAndSubType(todos));
           maybeBumpUpdatedAt(todos, now);
 
           for (const group of maybeSetupHookOrdering(todos)) {

--- a/packages/orm/src/Todo.ts
+++ b/packages/orm/src/Todo.ts
@@ -8,7 +8,8 @@ import { groupBy } from "./utils";
 
 /** A group of insert/update/delete operations for a given entity. */
 export class Todo {
-  static groupByType(todos: Record<string, Todo>): Map<EntityMetadata, Entity[]> {
+  /** Groups `todos` by their base/subtype, currently only inserts. */
+  static groupInsertsByTypeAndSubType(todos: Record<string, Todo>): Map<EntityMetadata, Entity[]> {
     return new Map(
       Object.values(todos).flatMap((todo) => {
         return todo.metadata.inheritanceType

--- a/packages/tests/integration/src/FieldLogging.test.ts
+++ b/packages/tests/integration/src/FieldLogging.test.ts
@@ -46,12 +46,12 @@ describe("FieldLogging", () => {
      [
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
-       "a#1.nickNames = a1 at defaults.ts:162↩",
+       "a#1.nickNames = a1 at defaults.ts:159↩",
        "b#1.title = title at newBook.ts:9↩",
        "b#1.order = 1 at newBook.ts:9↩",
        "b#1.author = Author#1 at newBook.ts:9↩",
        "b#1.notes = Notes for title at defaults.ts:38↩",
-       "b#1.authorsNickNames = a1 at defaults.ts:162↩",
+       "b#1.authorsNickNames = a1 at defaults.ts:159↩",
      ]
     `);
   });
@@ -64,7 +64,7 @@ describe("FieldLogging", () => {
      [
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
-       "a#1.nickNames = a1 at defaults.ts:162↩",
+       "a#1.nickNames = a1 at defaults.ts:159↩",
      ]
     `);
   });


### PR DESCRIPTION
A single `config.setDefault("type", { identity: "type" })` might actually have separate dependency resolutions, if subtypes are in place.

See the example in the code, but a regular RPV.type default doesn't have a dependency, b/c the hint's RP.type is not an async default.

But a POV.type, which knows its identity is a PV, it turns out that PV.type does have an async default.

We were already doing some separate of "set defaults on base type separately from defaults on sub types", but weren't letting them have different dependency resolutions.