### PR TITLE
feat: Simplify id flavors, fix for base types.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -144,7 +144,6 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
     ? code`extends ${imp("t:" + baseEntity.name + "GraphQLFilter@./entities.ts")}`
     : "";
   const maybeBaseOrder = baseEntity ? code`extends ${baseEntity.entity.orderType}` : "";
-  const maybeBaseId = baseEntity ? code` & Flavor<${idType}, "${baseEntity.name}">` : "";
   const maybePreventBaseTypeInstantiation = meta.abstract
     ? code`
     if (this.constructor === ${entity.type} && !(em as any).fakeInstance) {
@@ -194,7 +193,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
   }
 
   return code`
-    export type ${entityName}Id = ${Flavor}<${idType}, ${entityName}> ${maybeBaseId};
+    export type ${entityName}Id = ${Flavor}<${idType}, "${baseEntity ? baseEntity.name : entityName}">;
 
     ${generatePolymorphicTypes(meta)}
     

--- a/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
@@ -40,7 +40,7 @@ import {
 import { type Context } from "../../context.js";
 import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities.js";
 
-export type AuthorId = Flavor<string, Author>;
+export type AuthorId = Flavor<string, "Author">;
 
 export interface AuthorFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/esm-misc/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/BookCodegen.ts
@@ -48,7 +48,7 @@ import {
   newBook,
 } from "../entities.js";
 
-export type BookId = Flavor<string, Book>;
+export type BookId = Flavor<string, "Book">;
 
 export interface BookFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
@@ -47,7 +47,7 @@ import {
   t1BookMeta,
 } from "../entities";
 
-export type T1AuthorId = Flavor<number, T1Author>;
+export type T1AuthorId = Flavor<number, "T1Author">;
 
 export interface T1AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T1BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T1BookCodegen.ts
@@ -48,7 +48,7 @@ import {
   t1BookMeta,
 } from "../entities";
 
-export type T1BookId = Flavor<number, T1Book>;
+export type T1BookId = Flavor<number, "T1Book">;
 
 export interface T1BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
@@ -50,7 +50,7 @@ import {
   type T2BookOrder,
 } from "../entities";
 
-export type T2AuthorId = Flavor<number, T2Author>;
+export type T2AuthorId = Flavor<number, "T2Author">;
 
 export interface T2AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
@@ -50,7 +50,7 @@ import {
   t2BookMeta,
 } from "../entities";
 
-export type T2BookId = Flavor<number, T2Book>;
+export type T2BookId = Flavor<number, "T2Book">;
 
 export interface T2BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
@@ -50,7 +50,7 @@ import {
   type T3BookOrder,
 } from "../entities";
 
-export type T3AuthorId = Flavor<number, T3Author>;
+export type T3AuthorId = Flavor<number, "T3Author">;
 
 export interface T3AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
@@ -50,7 +50,7 @@ import {
   t3BookMeta,
 } from "../entities";
 
-export type T3BookId = Flavor<number, T3Book>;
+export type T3BookId = Flavor<number, "T3Book">;
 
 export interface T3BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
@@ -50,7 +50,7 @@ import {
   type T4BookOrder,
 } from "../entities";
 
-export type T4AuthorId = Flavor<number, T4Author>;
+export type T4AuthorId = Flavor<number, "T4Author">;
 
 export interface T4AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
@@ -50,7 +50,7 @@ import {
   t4BookMeta,
 } from "../entities";
 
-export type T4BookId = Flavor<number, T4Book>;
+export type T4BookId = Flavor<number, "T4Book">;
 
 export interface T4BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
@@ -47,7 +47,7 @@ import {
   t5BookMeta,
 } from "../entities";
 
-export type T5AuthorId = Flavor<number, T5Author>;
+export type T5AuthorId = Flavor<number, "T5Author">;
 
 export interface T5AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
@@ -53,7 +53,7 @@ import {
   t5BookReviewMeta,
 } from "../entities";
 
-export type T5BookId = Flavor<number, T5Book>;
+export type T5BookId = Flavor<number, "T5Book">;
 
 export interface T5BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookReviewCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookReviewCodegen.ts
@@ -48,7 +48,7 @@ import {
   t5BookReviewMeta,
 } from "../entities";
 
-export type T5BookReviewId = Flavor<number, T5BookReview>;
+export type T5BookReviewId = Flavor<number, "T5BookReview">;
 
 export interface T5BookReviewFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
@@ -48,7 +48,7 @@ import {
   type UserOrder,
 } from "../entities";
 
-export type AdminUserId = Flavor<string, AdminUser> & Flavor<string, "User">;
+export type AdminUserId = Flavor<string, "User">;
 
 export interface AdminUserFields extends UserFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
@@ -94,7 +94,7 @@ import {
   userMeta,
 } from "../entities";
 
-export type AuthorId = Flavor<string, Author>;
+export type AuthorId = Flavor<string, "Author">;
 
 export interface AuthorFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
@@ -48,7 +48,7 @@ import {
   newAuthorSchedule,
 } from "../entities";
 
-export type AuthorScheduleId = Flavor<string, AuthorSchedule>;
+export type AuthorScheduleId = Flavor<string, "AuthorSchedule">;
 
 export interface AuthorScheduleFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
@@ -32,7 +32,7 @@ import {
 import { type Context } from "src/context";
 import { AuthorStat, authorStatMeta, type Entity, EntityManager, newAuthorStat } from "../entities";
 
-export type AuthorStatId = Flavor<string, AuthorStat>;
+export type AuthorStatId = Flavor<string, "AuthorStat">;
 
 export interface AuthorStatFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
@@ -58,7 +58,7 @@ import {
   type SmallPublisherId,
 } from "../entities";
 
-export type BookAdvanceId = Flavor<string, BookAdvance>;
+export type BookAdvanceId = Flavor<string, "BookAdvance">;
 
 export interface BookAdvanceFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookCodegen.ts
@@ -73,7 +73,7 @@ import {
   tagMeta,
 } from "../entities";
 
-export type BookId = Flavor<string, Book>;
+export type BookId = Flavor<string, "Book">;
 
 export interface BookFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
@@ -64,7 +64,7 @@ import {
   tagMeta,
 } from "../entities";
 
-export type BookReviewId = Flavor<string, BookReview>;
+export type BookReviewId = Flavor<string, "BookReview">;
 
 export interface BookReviewFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
@@ -47,7 +47,7 @@ import {
   newChild,
 } from "../entities";
 
-export type ChildId = Flavor<string, Child>;
+export type ChildId = Flavor<string, "Child">;
 
 export interface ChildFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
@@ -57,7 +57,7 @@ import {
   type ParentGroupOrder,
 } from "../entities";
 
-export type ChildGroupId = Flavor<string, ChildGroup>;
+export type ChildGroupId = Flavor<string, "ChildGroup">;
 
 export interface ChildGroupFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
@@ -52,7 +52,7 @@ import {
   type ParentItemOrder,
 } from "../entities";
 
-export type ChildItemId = Flavor<string, ChildItem>;
+export type ChildItemId = Flavor<string, "ChildItem">;
 
 export interface ChildItemFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
@@ -66,7 +66,7 @@ import {
   type UserOrder,
 } from "../entities";
 
-export type CommentId = Flavor<string, Comment>;
+export type CommentId = Flavor<string, "Comment">;
 
 export type CommentParent = Author | Book | BookReview | Publisher | TaskOld;
 export function getCommentParentConstructors(): MaybeAbstractEntityConstructor<CommentParent>[] {

--- a/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
@@ -64,7 +64,7 @@ import {
   type SmallPublisherGroupId,
 } from "../entities";
 
-export type CriticId = Flavor<string, Critic>;
+export type CriticId = Flavor<string, "Critic">;
 
 export interface CriticFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
@@ -48,7 +48,7 @@ import {
   newCriticColumn,
 } from "../entities";
 
-export type CriticColumnId = Flavor<string, CriticColumn>;
+export type CriticColumnId = Flavor<string, "CriticColumn">;
 
 export interface CriticColumnFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
@@ -63,7 +63,7 @@ import {
   type SmallPublisherId,
 } from "../entities";
 
-export type ImageId = Flavor<string, Image>;
+export type ImageId = Flavor<string, "Image">;
 
 export interface ImageFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -65,7 +65,7 @@ import {
   userMeta,
 } from "../entities";
 
-export type LargePublisherId = Flavor<string, LargePublisher> & Flavor<string, "Publisher">;
+export type LargePublisherId = Flavor<string, "Publisher">;
 
 export interface LargePublisherFields extends PublisherFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
@@ -50,7 +50,7 @@ import {
   parentItemMeta,
 } from "../entities";
 
-export type ParentGroupId = Flavor<string, ParentGroup>;
+export type ParentGroupId = Flavor<string, "ParentGroup">;
 
 export interface ParentGroupFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
@@ -53,7 +53,7 @@ import {
   parentItemMeta,
 } from "../entities";
 
-export type ParentItemId = Flavor<string, ParentItem>;
+export type ParentItemId = Flavor<string, "ParentItem">;
 
 export interface ParentItemFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
@@ -82,7 +82,7 @@ import {
   taskOldMeta,
 } from "../entities";
 
-export type PublisherId = Flavor<string, Publisher>;
+export type PublisherId = Flavor<string, "Publisher">;
 
 export interface PublisherFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
@@ -59,7 +59,7 @@ import {
   type SmallPublisherId,
 } from "../entities";
 
-export type PublisherGroupId = Flavor<string, PublisherGroup>;
+export type PublisherGroupId = Flavor<string, "PublisherGroup">;
 
 export interface PublisherGroupFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -69,7 +69,7 @@ import {
   userMeta,
 } from "../entities";
 
-export type SmallPublisherId = Flavor<string, SmallPublisher> & Flavor<string, "Publisher">;
+export type SmallPublisherId = Flavor<string, "Publisher">;
 
 export interface SmallPublisherFields extends PublisherFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
@@ -52,7 +52,7 @@ import {
   smallPublisherMeta,
 } from "../entities";
 
-export type SmallPublisherGroupId = Flavor<string, SmallPublisherGroup> & Flavor<string, "PublisherGroup">;
+export type SmallPublisherGroupId = Flavor<string, "PublisherGroup">;
 
 export interface SmallPublisherGroupFields extends PublisherGroupFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TagCodegen.ts
@@ -59,7 +59,7 @@ import {
   taskMeta,
 } from "../entities";
 
-export type TagId = Flavor<string, Tag>;
+export type TagId = Flavor<string, "Tag">;
 
 export interface TagFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
@@ -67,7 +67,7 @@ import {
   TaskTypes,
 } from "../entities";
 
-export type TaskId = Flavor<string, Task>;
+export type TaskId = Flavor<string, "Task">;
 
 export interface TaskFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
@@ -55,7 +55,7 @@ import {
   type TaskOrder,
 } from "../entities";
 
-export type TaskItemId = Flavor<string, TaskItem>;
+export type TaskItemId = Flavor<string, "TaskItem">;
 
 export interface TaskItemFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
@@ -62,7 +62,7 @@ import {
   type TaskOrder,
 } from "../entities";
 
-export type TaskNewId = Flavor<string, TaskNew> & Flavor<string, "Task">;
+export type TaskNewId = Flavor<string, "Task">;
 
 export interface TaskNewFields extends TaskFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -66,7 +66,7 @@ import {
   type TaskOrder,
 } from "../entities";
 
-export type TaskOldId = Flavor<string, TaskOld> & Flavor<string, "Task">;
+export type TaskOldId = Flavor<string, "Task">;
 
 export interface TaskOldFields extends TaskFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -66,7 +66,7 @@ import {
   userMeta,
 } from "../entities";
 
-export type UserId = Flavor<string, User>;
+export type UserId = Flavor<string, "User">;
 
 export type UserFavoritePublisher = LargePublisher | SmallPublisher;
 export function getUserFavoritePublisherConstructors(): MaybeAbstractEntityConstructor<UserFavoritePublisher>[] {

--- a/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
@@ -38,7 +38,7 @@ import {
 import { type Context } from "src/context";
 import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
 
-export type AuthorId = Flavor<number, Author>;
+export type AuthorId = Flavor<number, "Author">;
 
 export interface AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
@@ -48,7 +48,7 @@ import {
   newBook,
 } from "../entities";
 
-export type BookId = Flavor<number, Book>;
+export type BookId = Flavor<number, "Book">;
 
 export interface BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };

--- a/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
@@ -47,7 +47,7 @@ import {
   paintingMeta,
 } from "../entities";
 
-export type ArtistId = Flavor<string, Artist>;
+export type ArtistId = Flavor<string, "Artist">;
 
 export interface ArtistFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
@@ -40,7 +40,7 @@ import {
 import { type Context } from "src/context";
 import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
 
-export type AuthorId = Flavor<string, Author>;
+export type AuthorId = Flavor<string, "Author">;
 
 export interface AuthorFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
@@ -48,7 +48,7 @@ import {
   newBook,
 } from "../entities";
 
-export type BookId = Flavor<string, Book>;
+export type BookId = Flavor<string, "Book">;
 
 export interface BookFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
@@ -32,7 +32,7 @@ import {
 import { type Context } from "src/context";
 import { DatabaseOwner, databaseOwnerMeta, type Entity, EntityManager, newDatabaseOwner } from "../entities";
 
-export type DatabaseOwnerId = Flavor<string, DatabaseOwner>;
+export type DatabaseOwnerId = Flavor<string, "DatabaseOwner">;
 
 export interface DatabaseOwnerFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/schema-misc/src/entities/codegen/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/PaintingCodegen.ts
@@ -48,7 +48,7 @@ import {
   paintingMeta,
 } from "../entities";
 
-export type PaintingId = Flavor<string, Painting>;
+export type PaintingId = Flavor<string, "Painting">;
 
 export interface PaintingFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
@@ -39,7 +39,7 @@ import { type Context } from "src/context";
 import { Temporal } from "temporal-polyfill";
 import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
 
-export type AuthorId = Flavor<string, Author>;
+export type AuthorId = Flavor<string, "Author">;
 
 export interface AuthorFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/temporal/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/temporal/src/entities/codegen/BookCodegen.ts
@@ -49,7 +49,7 @@ import {
   newBook,
 } from "../entities";
 
-export type BookId = Flavor<string, Book>;
+export type BookId = Flavor<string, "Book">;
 
 export interface BookFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
@@ -50,7 +50,7 @@ import {
   newAuthor,
 } from "../entities";
 
-export type AuthorId = Flavor<string, Author>;
+export type AuthorId = Flavor<string, "Author">;
 
 export interface AuthorFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
@@ -53,7 +53,7 @@ import {
   newBook,
 } from "../entities";
 
-export type BookId = Flavor<string, Book>;
+export type BookId = Flavor<string, "Book">;
 
 export interface BookFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
@@ -40,7 +40,7 @@ import {
 import { type Context } from "src/context";
 import { Author, Book, Comment, commentMeta, type Entity, EntityManager, newComment } from "../entities";
 
-export type CommentId = Flavor<string, Comment>;
+export type CommentId = Flavor<string, "Comment">;
 
 export type CommentParent = Author | Book;
 export function getCommentParentConstructors(): MaybeAbstractEntityConstructor<CommentParent>[] {

--- a/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
@@ -38,7 +38,7 @@ import {
 import { type Context } from "src/context";
 import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
 
-export type AuthorId = Flavor<string, Author>;
+export type AuthorId = Flavor<string, "Author">;
 
 export interface AuthorFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };

--- a/packages/tests/uuid-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/BookCodegen.ts
@@ -51,7 +51,7 @@ import {
   newBook,
 } from "../entities";
 
-export type BookId = Flavor<string, Book>;
+export type BookId = Flavor<string, "Book">;
 
 export interface BookFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };


### PR DESCRIPTION
Subtypes had been trying to have "neater" flavored ids that combined their base flavored id & a subtype flavored id.

This worked for awhile, but with some `subType: self` & STI setups in our internal app, it causes type errors from the subtypes (like LargePublisher) don't implement the base type (Publisher), because of the `_type` flavoring being off.

This PR has subtypes use the same flavored id as their base type, which seems fine & matched how we handle tagged ids as well (using the same prefix).

It also moves the flavoring to use strings, i.e. `"Publisher"` instead of `Publisher` with the theory this is probably much simpler for the compiler to eval.