### PR TITLE
fix: Fix findWithNewOrChanged not filtering deleted changed items.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -554,7 +554,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
     const persisted = await this.find(type, { ...(where as any) }, { softDeletes });
     const unchanged = persisted.filter((e) => !e.isNewEntity && !e.isDirtyEntity && !e.isDeletedEntity);
     const maybeNew = this.entities.filter(
-      (e) => e instanceof type && (e.isNewEntity || e.isDirtyEntity) && entityMatches(e, where),
+      (e) => e instanceof type && (e.isNewEntity || e.isDirtyEntity) && !e.isDeletedEntity && entityMatches(e, where),
     );
     const found = [...unchanged, ...maybeNew];
     if (populate) {

--- a/packages/tests/integration/src/EntityManager.test.ts
+++ b/packages/tests/integration/src/EntityManager.test.ts
@@ -1344,6 +1344,25 @@ describe("EntityManager", () => {
       expect(authors).toMatchEntity([]);
     });
 
+    it("ignores deleted entities", async () => {
+      await insertAuthor({ first_name: "a1" });
+      const em = newEntityManager();
+      const a = await em.load(Author, "a:1");
+      em.delete(a);
+      const authors = await em.findWithNewOrChanged(Author, { firstName: "a1" });
+      expect(authors).toMatchEntity([]);
+    });
+
+    it("ignores deleted and changed entities", async () => {
+      await insertAuthor({ first_name: "a1" });
+      const em = newEntityManager();
+      const a = await em.load(Author, "a:1");
+      a.lastName = "l1";
+      em.delete(a);
+      const authors = await em.findWithNewOrChanged(Author, { firstName: "a1" });
+      expect(authors).toMatchEntity([]);
+    });
+
     it("can populate found & created entities", async () => {
       await insertPublisher({ name: "p1" });
       await insertPublisher({ id: 2, name: "p2" });


### PR DESCRIPTION
If an entity was both deleted & mutated, it would get returned from findWithNewOrChanged, instead of completely filtered out.