### PR TITLE
feat: Unblock CUID support.

### DIFF
--- a/packages/orm/src/EntityMetadata.ts
+++ b/packages/orm/src/EntityMetadata.ts
@@ -33,7 +33,7 @@ export interface EntityMetadata<T extends Entity = any> {
   /** Whether id field is a tagged string. */
   idType: "tagged-string" | "untagged-string" | "number";
   /** The database column type, i.e. used to do `::type` casts in Postgres. */
-  idDbType: "bigint" | "int" | "uuid";
+  idDbType: "bigint" | "int" | "uuid" | "text";
   tableName: string;
   /** If we're a subtype, our immediate base type's name, e.g. for `SmallPublisher` this would be `Publisher`. */
   baseType: string | undefined;

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -581,7 +581,7 @@ export function parseEntityFilter(meta: EntityMetadata, filter: any): ParsedEnti
     return {
       kind: "in",
       value: filter.map((v: string | number | Entity) => {
-        return isEntity(v) ? v.idTaggedMaybe ?? nilIdValue(meta) : v;
+        return isEntity(v) ? (v.idTaggedMaybe ?? nilIdValue(meta)) : v;
       }),
     };
   } else if (isEntity(filter)) {
@@ -652,6 +652,8 @@ function nilIdValue(meta: EntityMetadata): any {
       return -1;
     case "uuid":
       return "00000000-0000-0000-0000-000000000000";
+    case "text":
+      return "0";
     default:
       return assertNever(meta.idDbType);
   }

--- a/packages/orm/src/serde.ts
+++ b/packages/orm/src/serde.ts
@@ -297,13 +297,13 @@ export class DecimalToNumberSerde implements FieldSerde {
 export class KeySerde implements FieldSerde {
   isArray = false;
   columns = [this];
-  private meta: { tagName: string; idDbType: "bigint" | "int" | "uuid" };
+  private meta: { tagName: string; idDbType: "bigint" | "int" | "uuid" | "text" };
 
   constructor(
     tagName: string,
     private fieldName: string,
     public columnName: string,
-    public dbType: "bigint" | "int" | "uuid",
+    public dbType: "bigint" | "int" | "uuid" | "text",
   ) {
     this.meta = { tagName, idDbType: dbType };
   }

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -4,6 +4,7 @@
   "entities": {
     "Author": { "tag": "a" },
     "Book": { "tag": "b" },
+    "BookReview": { "tag": "br" },
     "Comment": { "relations": { "parent": { "polymorphic": "notNull" } }, "tag": "c" }
   },
   "entitiesDirectory": "./src/entities",

--- a/packages/tests/untagged-ids/migrations/1580658856631_author.ts
+++ b/packages/tests/untagged-ids/migrations/1580658856631_author.ts
@@ -28,4 +28,12 @@ export function up(b: MigrationBuilder): void {
   });
   b.addIndex("comments", ["parent_author_id"], { method: "btree" });
   b.addIndex("comments", ["parent_book_id"], { method: "btree" });
+
+  // For testing cuid/etc ids
+  b.createTable("book_reviews", {
+    id: { type: "text", primaryKey: true },
+    rating: { type: "smallint", notNull: true },
+    book_id: { type: "uuid", references: "authors", notNull: true, deferrable: true, deferred: true },
+  });
+  b.createIndex("book_reviews", ["book_id"], { method: "btree" });
 }

--- a/packages/tests/untagged-ids/src/entities/BookReview.test.ts
+++ b/packages/tests/untagged-ids/src/entities/BookReview.test.ts
@@ -1,0 +1,12 @@
+import { newEntityManager } from "@src/setupDbTests";
+import { BookReview, newBookReview } from "./entities";
+
+describe("BookReview", () => {
+  it("works", async () => {
+    const em = newEntityManager();
+    newBookReview(em);
+    await em.flush();
+
+    await em.find(BookReview, {});
+  });
+});

--- a/packages/tests/untagged-ids/src/entities/BookReview.ts
+++ b/packages/tests/untagged-ids/src/entities/BookReview.ts
@@ -1,0 +1,8 @@
+import { BookReviewCodegen } from "./entities";
+
+import { bookReviewConfig as config } from "./entities";
+
+export class BookReview extends BookReviewCodegen {}
+
+// remove once you have actual rules/hooks
+config.placeholder();

--- a/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
@@ -42,6 +42,9 @@ import {
   Book,
   type BookId,
   bookMeta,
+  BookReview,
+  type BookReviewId,
+  bookReviewMeta,
   Comment,
   type CommentId,
   commentMeta,
@@ -64,11 +67,13 @@ export interface AuthorOpts {
   firstName: string;
   lastName?: string | null;
   books?: Book[];
+  bookReviews?: BookReview[];
   comments?: Comment[];
 }
 
 export interface AuthorIdsOpts {
   bookIds?: BookId[] | null;
+  bookReviewIds?: BookReviewId[] | null;
   commentIds?: CommentId[] | null;
 }
 
@@ -79,6 +84,7 @@ export interface AuthorFilter {
   createdAt?: ValueFilter<Date, never>;
   updatedAt?: ValueFilter<Date, never>;
   books?: EntityFilter<Book, BookId, FilterOf<Book>, null | undefined>;
+  bookReviews?: EntityFilter<BookReview, BookReviewId, FilterOf<BookReview>, null | undefined>;
   comments?: EntityFilter<Comment, CommentId, FilterOf<Comment>, null | undefined>;
 }
 
@@ -89,6 +95,7 @@ export interface AuthorGraphQLFilter {
   createdAt?: ValueGraphQLFilter<Date>;
   updatedAt?: ValueGraphQLFilter<Date>;
   books?: EntityGraphQLFilter<Book, BookId, GraphQLFilterOf<Book>, null | undefined>;
+  bookReviews?: EntityGraphQLFilter<BookReview, BookReviewId, GraphQLFilterOf<BookReview>, null | undefined>;
   comments?: EntityGraphQLFilter<Comment, CommentId, GraphQLFilterOf<Comment>, null | undefined>;
 }
 
@@ -310,6 +317,17 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
 
   get books(): Collection<Author, Book> {
     return this.__data.relations.books ??= hasMany(this, bookMeta, "books", "author", "author_id", undefined);
+  }
+
+  get bookReviews(): Collection<Author, BookReview> {
+    return this.__data.relations.bookReviews ??= hasMany(
+      this,
+      bookReviewMeta,
+      "bookReviews",
+      "book",
+      "book_id",
+      undefined,
+    );
   }
 
   get comments(): Collection<Author, Comment> {

--- a/packages/tests/untagged-ids/src/entities/codegen/BookReviewCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/BookReviewCodegen.ts
@@ -1,0 +1,281 @@
+import {
+  BaseEntity,
+  type Changes,
+  ConfigApi,
+  type DeepPartialOrNull,
+  type EntityFilter,
+  type EntityGraphQLFilter,
+  type EntityMetadata,
+  failNoIdYet,
+  type FilterOf,
+  type Flavor,
+  getField,
+  type GraphQLFilterOf,
+  hasOne,
+  isLoaded,
+  type JsonPayload,
+  type Lens,
+  type Loaded,
+  type LoadHint,
+  loadLens,
+  type ManyToOneReference,
+  newChangesProxy,
+  newRequiredRule,
+  type OptsOf,
+  type OrderBy,
+  type PartialOrNull,
+  setField,
+  setOpts,
+  type TaggedId,
+  toIdOf,
+  toJSON,
+  type ToJsonHint,
+  updatePartial,
+  type ValueFilter,
+  type ValueGraphQLFilter,
+} from "joist-orm";
+import { type Context } from "src/context";
+import {
+  Author,
+  type AuthorId,
+  authorMeta,
+  type AuthorOrder,
+  BookReview,
+  bookReviewMeta,
+  type Entity,
+  EntityManager,
+  newBookReview,
+} from "../entities";
+
+export type BookReviewId = Flavor<string, "BookReview">;
+
+export interface BookReviewFields {
+  id: { kind: "primitive"; type: string; unique: true; nullable: never };
+  rating: { kind: "primitive"; type: number; unique: false; nullable: never; derived: false };
+  book: { kind: "m2o"; type: Author; nullable: never; derived: false };
+}
+
+export interface BookReviewOpts {
+  rating: number;
+  book: Author | AuthorId;
+}
+
+export interface BookReviewIdsOpts {
+  bookId?: AuthorId | null;
+}
+
+export interface BookReviewFilter {
+  id?: ValueFilter<BookReviewId, never> | null;
+  rating?: ValueFilter<number, never>;
+  book?: EntityFilter<Author, AuthorId, FilterOf<Author>, never>;
+}
+
+export interface BookReviewGraphQLFilter {
+  id?: ValueGraphQLFilter<BookReviewId>;
+  rating?: ValueGraphQLFilter<number>;
+  book?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>, never>;
+}
+
+export interface BookReviewOrder {
+  id?: OrderBy;
+  rating?: OrderBy;
+  book?: AuthorOrder;
+}
+
+export const bookReviewConfig = new ConfigApi<BookReview, Context>();
+
+bookReviewConfig.addRule(newRequiredRule("rating"));
+bookReviewConfig.addRule(newRequiredRule("book"));
+
+declare module "joist-orm" {
+  interface TypeMap {
+    BookReview: {
+      entityType: BookReview;
+      filterType: BookReviewFilter;
+      gqlFilterType: BookReviewGraphQLFilter;
+      orderType: BookReviewOrder;
+      optsType: BookReviewOpts;
+      fieldsType: BookReviewFields;
+      optIdsType: BookReviewIdsOpts;
+      factoryOptsType: Parameters<typeof newBookReview>[1];
+    };
+  }
+}
+
+export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string> implements Entity {
+  static readonly tagName = "br";
+  static readonly metadata: EntityMetadata<BookReview>;
+
+  declare readonly __type: { 0: "BookReview" };
+
+  constructor(em: EntityManager, opts: BookReviewOpts) {
+    super(em, opts);
+    setOpts(this as any as BookReview, opts, { calledFromConstructor: true });
+  }
+
+  get id(): BookReviewId {
+    return this.idMaybe || failNoIdYet("BookReview");
+  }
+
+  get idMaybe(): BookReviewId | undefined {
+    return toIdOf(bookReviewMeta, this.idTaggedMaybe);
+  }
+
+  get idTagged(): TaggedId {
+    return this.idTaggedMaybe || failNoIdYet("BookReview");
+  }
+
+  get idTaggedMaybe(): TaggedId | undefined {
+    return getField(this, "id");
+  }
+
+  get rating(): number {
+    return getField(this, "rating");
+  }
+
+  set rating(rating: number) {
+    setField(this, "rating", rating);
+  }
+
+  /**
+   * Partial update taking any subset of the entities fields.
+   *
+   * Unlike `set`, null is used as a marker to mean "unset this field", and undefined
+   * is left as untouched.
+   *
+   * Collections are exhaustively set to the new values, however,
+   * {@link https://joist-orm.io/docs/features/partial-update-apis#incremental-collection-updates | Incremental collection updates} are supported.
+   *
+   * @example
+   * ```
+   * entity.setPartial({
+   *   firstName: 'foo' // updated
+   *   lastName: undefined // do nothing
+   *   age: null // unset, (i.e. set it as undefined)
+   * });
+   * ```
+   * @see {@link https://joist-orm.io/docs/features/partial-update-apis | Partial Update APIs} on the Joist docs
+   */
+  set(opts: Partial<BookReviewOpts>): void {
+    setOpts(this as any as BookReview, opts);
+  }
+
+  /**
+   * Partial update taking any subset of the entities fields.
+   *
+   * Unlike `set`, null is used as a marker to mean "unset this field", and undefined
+   * is left as untouched.
+   *
+   * Collections are exhaustively set to the new values, however,
+   * {@link https://joist-orm.io/docs/features/partial-update-apis#incremental-collection-updates | Incremental collection updates} are supported.
+   *
+   * @example
+   * ```
+   * entity.setPartial({
+   *   firstName: 'foo' // updated
+   *   lastName: undefined // do nothing
+   *   age: null // unset, (i.e. set it as undefined)
+   * });
+   * ```
+   * @see {@link https://joist-orm.io/docs/features/partial-update-apis | Partial Update APIs} on the Joist docs
+   */
+  setPartial(opts: PartialOrNull<BookReviewOpts>): void {
+    setOpts(this as any as BookReview, opts as OptsOf<BookReview>, { partial: true });
+  }
+
+  /**
+   * Partial update taking any nested subset of the entities fields.
+   *
+   * Unlike `set`, null is used as a marker to mean "unset this field", and undefined
+   * is left as untouched.
+   *
+   * Collections are exhaustively set to the new values, however,
+   * {@link https://joist-orm.io/docs/features/partial-update-apis#incremental-collection-updates | Incremental collection updates} are supported.
+   *
+   * @example
+   * ```
+   * entity.setDeepPartial({
+   *   firstName: 'foo' // updated
+   *   lastName: undefined // do nothing
+   *   age: null // unset, (i.e. set it as undefined)
+   *   books: [{ title: "b1" }], // create a child book
+   * });
+   * ```
+   * @see {@link https://joist-orm.io/docs/features/partial-update-apis | Partial Update APIs} on the Joist docs
+   */
+  setDeepPartial(opts: DeepPartialOrNull<BookReview>): Promise<void> {
+    return updatePartial(this as any as BookReview, opts);
+  }
+
+  /**
+   * Details the field changes of the entity within the current unit of work.
+   *
+   * @see {@link https://joist-orm.io/docs/features/changed-fields | Changed Fields} on the Joist docs
+   */
+  get changes(): Changes<BookReview> {
+    return newChangesProxy(this) as any;
+  }
+
+  /**
+   * Traverse from this entity using a lens, and load the result.
+   *
+   * @see {@link https://joist-orm.io/docs/advanced/lenses | Lens Traversal} on the Joist docs
+   */
+  load<U, V>(fn: (lens: Lens<BookReview>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as BookReview, fn, opts);
+  }
+
+  /**
+   * Hydrate this entity using a load hint
+   *
+   * @see {@link https://joist-orm.io/docs/features/loading-entities#1-object-graph-navigation | Loading entities} on the Joist docs
+   */
+  populate<const H extends LoadHint<BookReview>>(hint: H): Promise<Loaded<BookReview, H>>;
+  populate<const H extends LoadHint<BookReview>>(
+    opts: { hint: H; forceReload?: boolean },
+  ): Promise<Loaded<BookReview, H>>;
+  populate<const H extends LoadHint<BookReview>, V>(hint: H, fn: (br: Loaded<BookReview, H>) => V): Promise<V>;
+  populate<const H extends LoadHint<BookReview>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (br: Loaded<BookReview, H>) => V,
+  ): Promise<V>;
+  populate<const H extends LoadHint<BookReview>, V>(
+    hintOrOpts: any,
+    fn?: (br: Loaded<BookReview, H>) => V,
+  ): Promise<Loaded<BookReview, H> | V> {
+    return this.em.populate(this as any as BookReview, hintOrOpts, fn);
+  }
+
+  /**
+   * Given a load hint, checks if it is loaded within the unit of work.
+   *
+   * Type Guarded via Loaded<>
+   */
+  isLoaded<const H extends LoadHint<BookReview>>(hint: H): this is Loaded<BookReview, H> {
+    return isLoaded(this as any as BookReview, hint);
+  }
+
+  /**
+   * Build a type-safe, loadable and relation aware POJO from this entity, given a hint.
+   *
+   * Note: As the hint might load, this returns a Promise
+   *
+   * @example
+   * ```
+   * const payload = await a.toJSON({
+   *   id: true,
+   *   books: { id: true, reviews: { rating: true } }
+   * });
+   * ```
+   * @see {@link https://joist-orm.io/docs/advanced/json-payloads | Json Payloads} on the Joist docs
+   */
+  toJSON(): object;
+  toJSON<const H extends ToJsonHint<BookReview>>(hint: H): Promise<JsonPayload<BookReview, H>>;
+  toJSON(hint?: any): object {
+    return !hint || typeof hint === "string" ? super.toJSON() : toJSON(this, hint);
+  }
+
+  get book(): ManyToOneReference<BookReview, Author, never> {
+    return this.__data.relations.book ??= hasOne(this, authorMeta, "book", "bookReviews");
+  }
+}

--- a/packages/tests/untagged-ids/src/entities/codegen/metadata.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/metadata.ts
@@ -2,8 +2,9 @@ import { configureMetadata, DateSerde, type Entity as Entity2, EntityManager as 
 import { type Context } from "src/context";
 import { Author } from "../Author";
 import { Book } from "../Book";
+import { BookReview } from "../BookReview";
 import { Comment } from "../Comment";
-import { authorConfig, bookConfig, commentConfig, newAuthor, newBook, newComment } from "../entities";
+import { authorConfig, bookConfig, bookReviewConfig, commentConfig, newAuthor, newBook, newBookReview, newComment } from "../entities";
 
 export class EntityManager extends EntityManager1<Context, Entity> {}
 
@@ -27,6 +28,7 @@ export const authorMeta: EntityMetadata<Author> = {
     "createdAt": { kind: "primitive", fieldName: "createdAt", fieldIdName: undefined, derived: "orm", required: false, protected: false, type: Date, serde: new DateSerde("createdAt", "created_at", "timestamp with time zone"), immutable: false },
     "updatedAt": { kind: "primitive", fieldName: "updatedAt", fieldIdName: undefined, derived: "orm", required: false, protected: false, type: Date, serde: new DateSerde("updatedAt", "updated_at", "timestamp with time zone"), immutable: false },
     "books": { kind: "o2m", fieldName: "books", fieldIdName: "bookIds", required: false, otherMetadata: () => bookMeta, otherFieldName: "author", serde: undefined, immutable: false },
+    "bookReviews": { kind: "o2m", fieldName: "bookReviews", fieldIdName: "bookReviewIds", required: false, otherMetadata: () => bookReviewMeta, otherFieldName: "book", serde: undefined, immutable: false },
     "comments": { kind: "o2m", fieldName: "comments", fieldIdName: "commentIds", required: false, otherMetadata: () => commentMeta, otherFieldName: "parent", serde: undefined, immutable: false },
   },
   allFields: {},
@@ -67,6 +69,30 @@ export const bookMeta: EntityMetadata<Book> = {
 
 (Book as any).metadata = bookMeta;
 
+export const bookReviewMeta: EntityMetadata<BookReview> = {
+  cstr: BookReview,
+  type: "BookReview",
+  baseType: undefined,
+  idType: "untagged-string",
+  idDbType: "text",
+  tagName: "br",
+  tableName: "book_reviews",
+  fields: {
+    "id": { kind: "primaryKey", fieldName: "id", fieldIdName: undefined, required: true, serde: new KeySerde("br", "id", "id", "text"), immutable: true },
+    "rating": { kind: "primitive", fieldName: "rating", fieldIdName: undefined, derived: false, required: true, protected: false, type: "number", serde: new PrimitiveSerde("rating", "rating", "smallint"), immutable: false },
+    "book": { kind: "m2o", fieldName: "book", fieldIdName: "bookId", derived: false, required: true, otherMetadata: () => authorMeta, otherFieldName: "bookReviews", serde: new KeySerde("a", "book", "book_id", "uuid"), immutable: false },
+  },
+  allFields: {},
+  orderBy: undefined,
+  timestampFields: { createdAt: undefined, updatedAt: undefined, deletedAt: undefined },
+  config: bookReviewConfig,
+  factory: newBookReview,
+  baseTypes: [],
+  subTypes: [],
+};
+
+(BookReview as any).metadata = bookReviewMeta;
+
 export const commentMeta: EntityMetadata<Comment> = {
   cstr: Comment,
   type: "Comment",
@@ -93,5 +119,5 @@ export const commentMeta: EntityMetadata<Comment> = {
 
 (Comment as any).metadata = commentMeta;
 
-export const allMetadata = [authorMeta, bookMeta, commentMeta];
+export const allMetadata = [authorMeta, bookMeta, bookReviewMeta, commentMeta];
 configureMetadata(allMetadata);

--- a/packages/tests/untagged-ids/src/entities/entities.ts
+++ b/packages/tests/untagged-ids/src/entities/entities.ts
@@ -6,12 +6,15 @@
 
 export * from "./codegen/AuthorCodegen";
 export * from "./codegen/BookCodegen";
+export * from "./codegen/BookReviewCodegen";
 export * from "./codegen/CommentCodegen";
 export * from "./Author";
 export * from "./Book";
+export * from "./BookReview";
 export * from "./Comment";
 
 export * from "./factories/newAuthor";
 export * from "./factories/newBook";
+export * from "./factories/newBookReview";
 export * from "./factories/newComment";
 export * from "./codegen/metadata";

--- a/packages/tests/untagged-ids/src/entities/factories/newBookReview.ts
+++ b/packages/tests/untagged-ids/src/entities/factories/newBookReview.ts
@@ -1,0 +1,6 @@
+import { type DeepNew, type FactoryOpts, newTestInstance } from "joist-orm";
+import { BookReview, type EntityManager } from "../entities";
+
+export function newBookReview(em: EntityManager, opts: FactoryOpts<BookReview> = {}): DeepNew<BookReview> {
+  return newTestInstance(em, BookReview, opts, {});
+}


### PR DESCRIPTION
Users would still need to bring-their-own IdAssigner interface, but in theory it will work, as we support/don't blow up on `id` columns that are type `text`.