### PR TITLE
fix: Allow defaults to recalc during flush.

### DIFF
--- a/packages/orm/src/defaults.ts
+++ b/packages/orm/src/defaults.ts
@@ -173,6 +173,8 @@ export class AsyncDefault<T extends Entity> {
           throw new Error(
             `Use the \`async\` keyword for the setDefault "${this.fieldName}" function that returns a Promise`,
           );
+        } else if (val === undefined) {
+          // If val is undefined, let the setDefault get invoked again later
         } else {
           if (isLoadedReference(value)) {
             value.set(val);

--- a/packages/tests/integration/src/FieldLogging.test.ts
+++ b/packages/tests/integration/src/FieldLogging.test.ts
@@ -46,12 +46,12 @@ describe("FieldLogging", () => {
      [
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
-       "a#1.nickNames = a1 at defaults.ts:180↩",
+       "a#1.nickNames = a1 at defaults.ts:182↩",
        "b#1.title = title at newBook.ts:9↩",
        "b#1.order = 1 at newBook.ts:9↩",
        "b#1.author = Author#1 at newBook.ts:9↩",
        "b#1.notes = Notes for title at defaults.ts:45↩",
-       "b#1.authorsNickNames = a1 at defaults.ts:180↩",
+       "b#1.authorsNickNames = a1 at defaults.ts:182↩",
      ]
     `);
   });
@@ -64,7 +64,7 @@ describe("FieldLogging", () => {
      [
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
-       "a#1.nickNames = a1 at defaults.ts:180↩",
+       "a#1.nickNames = a1 at defaults.ts:182↩",
      ]
     `);
   });

--- a/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
@@ -71,6 +71,7 @@ describe("ReactiveQueryField", () => {
         "updatedAt",
         "name",
         "numberOfBookReviews",
+        "spotlightAuthor",
         "type",
         "baseSyncDefault",
         "favoriteAuthor",


### PR DESCRIPTION
If a factory invokes a default, and it returns `undefined`, we want to try the default again during `em.flush`.