### PR TITLE
fix: Allow defaults to try twice.

### DIFF
--- a/packages/orm/src/defaults.ts
+++ b/packages/orm/src/defaults.ts
@@ -130,12 +130,18 @@ export class AsyncDefault<T extends Entity> {
             if (!isRelation(baseMetadata.allFields[this.fieldName])) {
               const hasBeenSet = this.fieldName in getInstanceData(entity).data;
               if (!hasBeenSet) {
-                (entity as any)[this.fieldName] = await this.getValue(entity, ctx);
+                const value = await this.getValue(entity, ctx);
+                if (value !== undefined) {
+                  (entity as any)[this.fieldName] = value;
+                }
               }
             } else {
               const value = (entity as any)[this.fieldName];
               if (isLoadedReference(value) && !value.isSet && !value.hasBeenSet) {
-                value.set(await this.getValue(entity, ctx));
+                const val = await this.getValue(entity, ctx);
+                if (val !== undefined) {
+                  value.set(val);
+                }
               }
             }
           })

--- a/packages/tests/integration/src/EntityManager.defaults.test.ts
+++ b/packages/tests/integration/src/EntityManager.defaults.test.ts
@@ -93,6 +93,21 @@ describe("EntityManager.defaults", () => {
     expect(p).toMatchEntity({ spotlightAuthor: undefined });
   });
 
+  it("re-tries defaults during em.flush", async () => {
+    const em = newEntityManager();
+    // Given we create a Publisher (w/o going through the factory triggered defaults)
+    const p = em.create(LargePublisher, { name: "p1" });
+    // And invoke `em.setDefaults`
+    await em.setDefaults([p]);
+    // And the spotlightAuthor default returned undefined
+    expect(p).toMatchEntity({ spotlightAuthor: undefined });
+    // When we create data that would trigger the default, and em.flush
+    const a = newAuthor(em, { publisher: p });
+    await em.flush();
+    // Then the default is tried again
+    expect(p).toMatchEntity({ spotlightAuthor: a });
+  });
+
   it("can default an asynchronous m2o field", async () => {
     const em = newEntityManager();
     // Given an author with lastName t1

--- a/packages/tests/integration/src/FieldLogging.test.ts
+++ b/packages/tests/integration/src/FieldLogging.test.ts
@@ -46,12 +46,12 @@ describe("FieldLogging", () => {
      [
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
-       "a#1.nickNames = a1 at defaults.ts:182↩",
+       "a#1.nickNames = a1 at defaults.ts:188↩",
        "b#1.title = title at newBook.ts:9↩",
        "b#1.order = 1 at newBook.ts:9↩",
        "b#1.author = Author#1 at newBook.ts:9↩",
        "b#1.notes = Notes for title at defaults.ts:45↩",
-       "b#1.authorsNickNames = a1 at defaults.ts:182↩",
+       "b#1.authorsNickNames = a1 at defaults.ts:188↩",
      ]
     `);
   });
@@ -64,7 +64,7 @@ describe("FieldLogging", () => {
      [
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
-       "a#1.nickNames = a1 at defaults.ts:182↩",
+       "a#1.nickNames = a1 at defaults.ts:188↩",
      ]
     `);
   });


### PR DESCRIPTION
If an explicit `await em.setDefaults(...)` invokes defaults that return `undefined`, we want to avoid setting that on the entity, so that during `em.flush`, the `setDefault` logic gets to "try again".