### PR TITLE
fix: Fix toString to sequentially assign new entities.

### DIFF
--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -98,7 +98,7 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
     // Even if we've been `em.assignNewIds`-d before an `em.flush`, also have new entities
     // return the `Author#1` syntax because it's really helpful for debugging to see what's new.
     if (this.isNewEntity || this.idMaybe === undefined) {
-      const sameType = this.em.entities.filter((e) => e instanceof meta.cstr);
+      const sameType = this.em.entities.filter((e) => e instanceof meta.cstr && e.isNewEntity);
       // Returns `Author#1` as a hint that it's a test id and not the real id
       return `${meta.type}#${sameType.indexOf(this) + 1}`;
     } else {

--- a/packages/tests/integration/src/Entity.test.ts
+++ b/packages/tests/integration/src/Entity.test.ts
@@ -24,6 +24,15 @@ describe("Entity", () => {
     expect(a.toString()).toBe("Author#1");
   });
 
+  it("can toString a new entity with existing entities", async () => {
+    await insertAuthor({ first_name: "a1" });
+    const em = newEntityManager();
+    const a1 = await em.load(Author, "a:1");
+    const a2 = newAuthor(em);
+    expect(a1.toString()).toBe("Author:1");
+    expect(a2.toString()).toBe("Author#1");
+  });
+
   it("can toJSON a new entity", () => {
     const em = newEntityManager();
     const a = newAuthor(em);

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -591,7 +591,7 @@ describe("Author", () => {
     const a3 = newAuthor(em);
     expect((a1 as any)[inspect]()).toEqual("Author:1");
     expect((a2 as any)[inspect]()).toEqual("Author:2");
-    expect((a3 as any)[inspect]()).toEqual("Author#3");
+    expect((a3 as any)[inspect]()).toEqual("Author#1");
   });
 
   it("can access deleted children", async () => {


### PR DESCRIPTION
Previously the `1` part of a new entity's `Author#1` toString() was "the index within all authors in the EntityManager".

This was fine, but I had been using the `#1` as a quick easy to count the number of entities created during an em.flush, i.e. seeing `Author#5` === "the 5th newly created Author".

But previously the `#5` could have been "the 1st newly created Author, after we loaded 4 other existing Authors".

This PR changes the `#` numbers to only increment/indexOf against other also-newly-created entities.