### PR TITLE
feat: Remove DISTINCT usage in em.find queries

### DIFF
--- a/packages/orm/src/AliasAssigner.ts
+++ b/packages/orm/src/AliasAssigner.ts
@@ -8,13 +8,19 @@ export class AliasAssigner {
     this.getAlias = this.getAlias.bind(this);
     // If we're assigning aliases into an existing query, get the current assignments
     if (query) {
-      for (const table of query.tables) {
-        // Ignore CTI base/sub aliases
-        if (table.alias.includes("_")) continue;
-        const abbrev = abbreviation(table.table);
-        const i = this.#aliases[abbrev] || 0;
-        const j = Number(table.alias.replace(abbrev, "")) + 1;
-        this.#aliases[abbrev] = Math.max(i, j);
+      const todo = [query];
+      while (todo.length > 0) {
+        const query = todo.pop()!;
+        for (const table of query.tables) {
+          // Ignore CTI base/sub aliases
+          if (table.alias.includes("_")) continue;
+          if (table.join === "lateral") {
+            this.maybeBumpIndex(table.table, table.alias);
+            todo.push(table.query);
+          } else {
+            this.maybeBumpIndex(table.table, table.alias);
+          }
+        }
       }
     }
   }
@@ -24,5 +30,14 @@ export class AliasAssigner {
     const i = this.#aliases[abbrev] || 0;
     this.#aliases[abbrev] = i + 1;
     return i === 0 ? abbrev : `${abbrev}${i}`;
+  }
+
+  /** Given an existing alias, like `a5`, make sure our internal `a = N` is at least 5 or higher. */
+  private maybeBumpIndex(tableName: string, alias: string): void {
+    const tag = abbreviation(tableName);
+    const ourN = this.#aliases[tag] || 0;
+    // Recover the `5` out of `pi5` by stripping the `pi` prefix
+    const newN = Number(alias.replace(tag, "")) + 1;
+    this.#aliases[tag] = Math.max(ourN, newN);
   }
 }

--- a/packages/orm/src/Aliases.ts
+++ b/packages/orm/src/Aliases.ts
@@ -453,6 +453,7 @@ class PolyReferenceAlias<T extends Entity> {
 class CountAliasImpl implements CountAlias {
   constructor(protected callbacks: BindCallback[]) {}
   eq(count: number | undefined | null): ExpressionCondition {
+    if (count === undefined) return skipCondition;
     const cond: ColumnCondition = {
       kind: "column",
       alias: "unset",

--- a/packages/orm/src/Aliases.ts
+++ b/packages/orm/src/Aliases.ts
@@ -37,7 +37,10 @@ export type Alias<T extends Entity> = {
         : FieldsOf<T>[P] extends { kind: "poly"; type: infer U extends Entity }
           ? PolyReferenceAlias<U>
           : never;
-} & { $count: CountAlias };
+} & {
+  /** Allow querying on "a parent that has no children". This is only valid when bound to child/collection relations. */
+  $count: CountAlias;
+};
 
 export interface PrimitiveAlias<V, N extends null | never> {
   eq(value: V | N | undefined | PrimitiveAlias<V, any>): ExpressionCondition;
@@ -72,8 +75,8 @@ export interface EntityAlias<T> {
 /**
  * Allows complex conditions on the number of matching children.
  *
- * The `$count` value will only children that match *inline* conditions, i.e.
- * a query like:
+ * Note that `$count` value will only count children that match *inline* conditions,
+ * i.e. a query like:
  *
  * ```ts
  * await em.find(Author, { books: { $count: 1, status: BookStatus.Draft } });

--- a/packages/orm/src/EntityFilter.ts
+++ b/packages/orm/src/EntityFilter.ts
@@ -33,7 +33,7 @@ export type EntityFilter<T extends Entity, I = IdOf<T>, F = FilterOf<T>, N = nev
   | I
   | readonly I[]
   // Note that this is a weak type (all optional keys) but TS still enforces at least one overlap
-  | ({ as?: Alias<T> } & F)
+  | ({ as?: Alias<T>; $count?: number } & F)
   // Always allow `undefined` for condition pruning
   | undefined
   // But only allow `null` for `nullable` relations

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -184,9 +184,11 @@ export function parseFindQuery(
       ef && ef.kind === "join"
         ? ef.subFilter
         : // If `ef` is set, it's already parsed, which `parseFindQuery` won't expect, so pass the original `filter`
-          ef !== undefined
+          typeof filter === "string"
           ? { id: filter }
-          : {};
+          : ef !== undefined
+            ? filter
+            : {};
     const count = "$count" in subFilter ? subFilter["$count"] : undefined;
     const subQuery = parseFindQuery(
       meta,

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -227,8 +227,14 @@ export function parseFindQuery(
       }
     }
 
-    // If there are complex conditions looking at our data, we don't need an extra check
-    if (complexConditions.length === 0) {
+    // If there are complex conditions looking at our data, we don't want a "make sure at least one matched"
+    const usedByComplexCondition =
+      selects.some((s) => typeof s === "object" && "aliases" in s && s.aliases.includes(alias)) ||
+      (!opts.topLevelCondition &&
+        deepFindConditions(cb.expressions[0], true).some((c) => {
+          return c.kind === "raw" && c.aliases.includes(alias);
+        }));
+    if (!usedByComplexCondition) {
       cb.addSimpleCondition({
         kind: "column",
         alias,

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -952,6 +952,9 @@ export class ConditionBuilder {
     if (conditions.length === 0 && expressions.length === 1) {
       // If no inline conditions, and just 1 opt expression, just use that
       return expressions[0];
+    } else if (expressions.length === 1 && expressions[0].op === "and") {
+      // Merge the 1 `AND` expression with the other simple conditions
+      return { kind: "exp", op: "and", conditions: [...conditions, ...expressions[0].conditions] };
     } else if (conditions.length > 0 || expressions.length > 0) {
       // Combine the conditions within the `em.find` join literal & the `conditions` as ANDs
       return { kind: "exp", op: "and", conditions: [...conditions, ...expressions] };

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -198,6 +198,8 @@ export function parseFindQuery(
           return { subFilter: {}, count: { kind: "gt", value: 0 } };
         } else if (ef.kind === "is-null") {
           return { subFilter: {}, count: { kind: "eq", value: 0 } };
+        } else if (ef.kind === "eq") {
+          return { subFilter: { id: ef.value }, count: undefined };
         } else {
           // If `ef` is set, it's already parsed, which `parseFindQuery` won't expect, so pass the original `filter`
           return { subFilter: { id: filter }, count: undefined };

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -363,31 +363,17 @@ export function parseFindQuery(
             (ef.subFilter as any)[key],
           );
         } else if (field.kind === "o2m") {
-          // ...don't outer join, instead do a lateral join...
-          // old code
-          // const a = getAlias(field.otherMetadata().tableName);
-          // const otherField = field.otherMetadata().allFields[field.otherFieldName];
-          // let otherColumn = otherField.serde!.columns[0].columnName;
-          // // If the other field is a poly, we need to find the right column
-          // if (otherField.kind === "poly") {
-          //   // For a subcomponent that matches field's metadata
-          //   const otherComponent =
-          //     otherField.components.find((c) => c.otherMetadata() === meta) ??
-          //     fail(`No poly component found for ${otherField.fieldName}`);
-          //   otherColumn = otherComponent.columnName;
-          // }
-          // addTable(
-          //   field.otherMetadata(),
-          //   a,
-          //   "outer",
-          //   kqDot(alias, "id"),
-          //   kqDot(a, otherColumn),
-          //   (ef.subFilter as any)[key],
-          // );
-
           const a = getAlias(field.otherMetadata().tableName);
           const otherField = field.otherMetadata().allFields[field.otherFieldName];
           let otherColumn = otherField.serde!.columns[0].columnName;
+          // If the other field is a poly, we need to find the right column
+          if (otherField.kind === "poly") {
+            // For a subcomponent that matches field's metadata
+            const otherComponent =
+              otherField.components.find((c) => c.otherMetadata() === meta) ??
+              fail(`No poly component found for ${otherField.fieldName}`);
+            otherColumn = otherComponent.columnName;
+          }
           addLateralJoin(
             field.otherMetadata(),
             alias,

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -200,6 +200,8 @@ export function parseFindQuery(
           return { subFilter: {}, count: { kind: "eq", value: 0 } };
         } else if (ef.kind === "eq") {
           return { subFilter: { id: ef.value }, count: undefined };
+        } else if (ef.kind === "in") {
+          return { subFilter: { id: { in: ef.value } }, count: undefined };
         } else {
           // If `ef` is set, it's already parsed, which `parseFindQuery` won't expect, so pass the original `filter`
           return { subFilter: { id: filter }, count: undefined };

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -580,11 +580,7 @@ export function parseFindQuery(
   maybeAddOrderBy(query, meta, alias);
 
   if (pruneJoins) {
-    pruneUnusedJoins(
-      query,
-      // (opts.topLevelCondition ?? cb).expressions[0],
-      keepAliases,
-    );
+    pruneUnusedJoins(query, keepAliases);
   }
 
   return query;
@@ -645,12 +641,7 @@ function pruneUnusedJoins(parsed: ParsedFindQuery, keepAliases: string[]): void 
   });
   parsed.orderBys.forEach((o) => used.add(o.alias));
   keepAliases.forEach((a) => used.add(a));
-  const allConditions = [
-    ...deepFindConditions(parsed.condition, true),
-    // topLevelCondition will be set if we're within a lateral join
-    // ...deepFindConditions(topLevelCondition, true),
-  ];
-  allConditions.forEach((c) => {
+  deepFindConditions(parsed.condition, true).forEach((c) => {
     if (c.kind === "column") {
       used.add(c.alias);
     } else if (c.kind === "raw") {
@@ -666,11 +657,7 @@ function pruneUnusedJoins(parsed: ParsedFindQuery, keepAliases: string[]): void 
       // Recurse into the join...
       // pruneUnusedJoins(t.query, keepAliases);
       // how can I tell if this join is used?
-      const hasRealCondition =
-        [
-          // ...deepFindConditions(topLevelCondition, true),
-          ...deepFindConditions(t.query.condition, true),
-        ].length > 0;
+      const hasRealCondition = deepFindConditions(t.query.condition, true).length > 0;
       if (hasRealCondition) used.add(t.alias);
       const a1 = t.fromAlias;
       const a2 = t.alias;

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -85,12 +85,22 @@ export interface CrossJoinTable {
 
 export type ParsedTable = PrimaryTable | JoinTable | CrossJoinTable | LateralJoinTable;
 
-/** Joins into 0-N relations, i.e. parent down to many children. */
+/**
+ * Joins into 0-N relations, i.e. parent down to many children.
+ *
+ * It's expect that the `query` will fundamentally be an aggregate query that
+ * counts (for `em.find`s) or rolls up (for JSON preloading) the children into
+ * a single row, such that our top-level query does not need to DISTINCT-away
+ * any duplication that comes from having multiple children rows.
+ */
 export interface LateralJoinTable {
   join: "lateral";
   alias: string;
+  /** Used for join dependency tracking. */
   fromAlias: string;
+  /** Used more for bookkeeping/consistency with other join tables than the query itself. */
   table: string;
+  /** The subquery that will look for/roll-up N children. */
   query: ParsedFindQuery;
 }
 

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -197,7 +197,7 @@ export function parseFindQuery(
           : ef !== undefined
             ? filter
             : {};
-    const count = "$count" in subFilter ? subFilter["$count"] : undefined;
+    const count = subFilter && "$count" in subFilter ? subFilter["$count"] : subFilter === null ? 0 : undefined;
     const subQuery = parseFindQuery(
       meta,
       { as: a, ...subFilter },

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -166,9 +166,15 @@ export function parseFindQuery(
   // what would the format look like? probably just nested JSON...
   function addLateralJoin(meta: EntityMetadata, alias: string, col1: string, col2: string, filter: any) {
     const a = newAliasProxy(meta.cstr);
+    const subFilter = typeof filter === "string" ? { id: filter } : { ...filter };
+    let count = undefined;
+    if ("$count" in subFilter) {
+      count = subFilter["$count"];
+      delete subFilter["$count"];
+    }
     const subQuery = parseFindQuery(
       meta,
-      { as: a, ...(typeof filter === "string" ? { id: filter } : filter) },
+      { as: a, ...subFilter },
       {
         conditions: {
           and: [
@@ -194,7 +200,7 @@ export function parseFindQuery(
       alias,
       column: "_",
       dbType: "int",
-      cond: { kind: "gt", value: 0 },
+      cond: count !== undefined ? { kind: "eq", value: count } : { kind: "gt", value: 0 },
     });
   }
 

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -175,11 +175,7 @@ export function parseFindQuery(
     const a = newAliasProxy(meta.cstr);
 
     const subFilter = ef && ef.kind === "join" ? ef.subFilter : (ef ?? {});
-    let count = undefined;
-    if ("$count" in subFilter) {
-      count = subFilter["$count"];
-      delete subFilter["$count"];
-    }
+    const count = "$count" in subFilter ? subFilter["$count"] : undefined;
     const subQuery = parseFindQuery(
       meta,
       { as: a, ...subFilter },
@@ -261,7 +257,7 @@ export function parseFindQuery(
       // subFilter really means we're matching against the entity columns/further joins
       Object.keys(ef.subFilter).forEach((key) => {
         // Skip the `{ as: ... }` alias binding
-        if (key === "as") return;
+        if (key === "as" || key === "$count") return;
         const field =
           meta.allFields[key] ??
           meta.polyComponentFields?.[key] ??

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -194,15 +194,13 @@ export function parseFindQuery(
         if (ef.kind === "join") {
           // subFilter will be unprocessed, so we can pass it recursively into `parseFindQuery`
           return { subFilter: ef.subFilter, count: undefined };
-        } else if (typeof filter === "string") {
-          // If `ef` is set, it's already parsed, which `parseFindQuery` won't expect, so pass the original `filter`
-          return { subFilter: { id: filter }, count: undefined };
         } else if (ef.kind === "not-null") {
           return { subFilter: {}, count: { kind: "gt", value: 0 } };
         } else if (ef.kind === "is-null") {
           return { subFilter: {}, count: { kind: "eq", value: 0 } };
         } else {
-          return { subFilter: { id: ef }, count: undefined };
+          // If `ef` is set, it's already parsed, which `parseFindQuery` won't expect, so pass the original `filter`
+          return { subFilter: { id: filter }, count: undefined };
         }
       } else {
         return { subFilter: {}, count: undefined };

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -1047,8 +1047,10 @@ export class ConditionBuilder {
    * `ConditionBuilder`s for building their internal query, but it's not exposed to the user,
    * so won't have any truly-complex conditions that should need rewritten).
    *
-   * @param topLevelLateralJoin
-   * @param alias
+   * @param topLevelLateralJoin the outermost lateral join alias, as that will be the only alias
+   *   that is visible to the rewritten condition, i.e. `_alias._whatever_condition_`.
+   * @param alias the alias being "hidden" in a lateral join, and so its columns/data won't be
+   *   available for the top-level condition to directly AND/OR against.
    */
   findAndRewrite(topLevelLateralJoin: string, alias: string): { cond: ColumnCondition; as: string }[] {
     let j = 0;

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -954,7 +954,7 @@ export function parseValueFilter<V>(filter: ValueFilter<V, any>): ParsedValueFil
 /** Converts domain-level values like string ids/enums into their db equivalent. */
 export class ConditionBuilder {
   /** Simple, single-column conditions, which will be AND-d together. */
-  conditions: ColumnCondition[] = [];
+  conditions: (ColumnCondition | RawCondition)[] = [];
   /** Complex expressions, which will also be AND-d together with `conditions`. */
   expressions: ParsedExpressionFilter[] = [];
 
@@ -967,6 +967,15 @@ export class ConditionBuilder {
   /** Adds an already-db-level condition to the simple conditions list. */
   addSimpleCondition(condition: ColumnCondition): void {
     this.conditions.push(condition);
+  }
+
+  /** Adds an already-db-level condition to the simple conditions list. */
+  addRawCondition(condition: PartialSome<RawCondition, "kind" | "bindings">): void {
+    this.conditions.push({
+      kind: "raw",
+      bindings: [],
+      ...condition,
+    });
   }
 
   /** Adds an already-db-level expression to the expressions list. */
@@ -1357,3 +1366,5 @@ class DependencyTracker {
     this.required = new Set([...this.required, ...marked]);
   }
 }
+
+type PartialSome<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -113,12 +113,6 @@ export interface ParsedFindQuery {
   selects: ParsedSelect[];
   /** The primary table plus any joins. */
   tables: ParsedTable[];
-  /** Any cross lateral joins, where the `joins: string[]` has the full join as raw SQL; currently only for preloading. */
-  lateralJoins?: {
-    // I.e. `cross join lateral join (select ... from ...) as _b`
-    joins: string[];
-    bindings: any[];
-  };
   /** The query's conditions. */
   condition?: ParsedExpressionFilter;
   /** Any optional orders to add before the default 'order by id'. */

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -203,8 +203,12 @@ export function parseFindQuery(
     // Look for complex conditions...
     const complexConditions = cb.findAndRewrite(alias);
     for (const cc of complexConditions) {
-      const [sql, bindings] = buildCondition(cc.cond);
-      subQuery.selects.push({ sql: `BOOL_OR(${sql}) as ${cc.as}`, bindings });
+      if (cc.cond.kind === "column" && cc.cond.column === "$count") {
+        subQuery.selects.push({ sql: `count(*) > ${(cc.cond.cond as any).value} as ${cc.as}`, bindings: [] });
+      } else {
+        const [sql, bindings] = buildCondition(cc.cond);
+        subQuery.selects.push({ sql: `BOOL_OR(${sql}) as ${cc.as}`, bindings });
+      }
     }
 
     // If there are complex conditions looking at our data, we don't need an extra check

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -633,6 +633,10 @@ function pruneUnusedJoins(parsed: ParsedFindQuery, keepAliases: string[]): void 
       }
     });
   }
+  // Remove any `{ and: [...] }`s that are empty; we should probably do this deeply?
+  if (parsed.condition && parsed.condition.conditions.length === 0) {
+    parsed.condition = undefined;
+  }
 }
 
 /** Pulls out a flat list of all `ColumnCondition`s from a `ParsedExpressionFilter` tree. */

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -1,5 +1,4 @@
 import { groupBy, isPlainObject } from "joist-utils";
-import { PartialSome } from "ts-patch/utils";
 import { aliasMgmt, isAlias, newAliasProxy } from "./Aliases";
 import { Entity, isEntity } from "./Entity";
 import { ExpressionFilter, OrderBy, ValueFilter } from "./EntityFilter";

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -165,24 +165,13 @@ export function parseFindQuery(
   // ...how do we pull up data to use in any conditions?...
   // what would the format look like? probably just nested JSON...
   function addLateralJoin(meta: EntityMetadata, alias: string, col1: string, col2: string, filter: any) {
-    // const join = `
-    //   cross join lateral (
-    //     select count(*) as _
-    //     from ${kq(meta.tableName)} ${kq(alias)}
-    //     where ${col1} = ${col2} and b.title like 'b1%'
-    //     group by ${kq(alias)}.id
-    //   ) AS ${kq(alias)}
-    // `;
-    // lateralJoins.joins.push(join);
-
-    // recurse into the filter
     const a = newAliasProxy(meta.cstr);
     const subQuery = parseFindQuery(
       meta,
       { as: a, ...filter },
       {
         conditions: {
-          or: [
+          and: [
             {
               kind: "raw",
               aliases: [] as string[],

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -168,7 +168,7 @@ export function parseFindQuery(
     const a = newAliasProxy(meta.cstr);
     const subQuery = parseFindQuery(
       meta,
-      { as: a, ...filter },
+      { as: a, ...(typeof filter === "string" ? { id: filter } : filter) },
       {
         conditions: {
           and: [

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -206,7 +206,6 @@ export function parseFindQuery(
         softDeletes: opts.softDeletes,
         pruneJoins: opts.pruneJoins,
         keepAliases: opts.keepAliases,
-        ...opts,
         // And set our own complex condition as the join condition
         conditions: {
           and: [

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -1282,18 +1282,6 @@ export function getTables(query: ParsedFindQuery): [PrimaryTable, JoinTable[], L
   return [primary!, joins, laterals, crosses];
 }
 
-export function joinKeywords(join: JoinTable): string {
-  return join.join === "inner" ? "JOIN" : "LEFT OUTER JOIN";
-}
-
-export function joinClause(join: JoinTable): string {
-  return `${joinKeywords(join)} ${kq(join.table)} ${kq(join.alias)} ON ${join.col1} = ${join.col2}`;
-}
-
-export function joinClauses(joins: ParsedTable[]): string[] {
-  return joins.map((t) => (t.join === "inner" || t.join === "outer" ? joinClause(t) : ""));
-}
-
 function needsClassPerTableJoins(meta: EntityMetadata): boolean {
   return meta.inheritanceType === "cti" && (meta.subTypes.length > 0 || meta.baseTypes.length > 0);
 }

--- a/packages/orm/src/QueryVisitor.ts
+++ b/packages/orm/src/QueryVisitor.ts
@@ -4,7 +4,7 @@ import { ColumnCondition, ParsedExpressionFilter, ParsedFindQuery, RawCondition 
 interface Visitor {
   visitExp?(c: ParsedExpressionFilter): ParsedExpressionFilter | void;
   visitRaw?(c: RawCondition): RawCondition | ParsedExpressionFilter | void;
-  visitCond(c: ColumnCondition): ColumnCondition | ParsedExpressionFilter | void;
+  visitCond(c: ColumnCondition): ColumnCondition | ParsedExpressionFilter | RawCondition | void;
 }
 
 /**
@@ -36,4 +36,12 @@ export function visitConditions(query: ParsedFindQuery, visitor: Visitor): void 
     });
   }
   if (query.condition) visit(query.condition);
+  for (const table of query.tables) {
+    // ...we probably need better recursion here?
+    if (table.join === "lateral") {
+      if (table.query.condition) {
+        visit(table.query.condition);
+      }
+    }
+  }
 }

--- a/packages/orm/src/QueryVisitor.ts
+++ b/packages/orm/src/QueryVisitor.ts
@@ -35,12 +35,13 @@ export function visitConditions(query: ParsedFindQuery, visitor: Visitor): void 
       }
     });
   }
-  if (query.condition) visit(query.condition);
-  for (const table of query.tables) {
-    // ...we probably need better recursion here?
-    if (table.join === "lateral") {
-      if (table.query.condition) {
-        visit(table.query.condition);
+  const todo = [query];
+  while (todo.length > 0) {
+    const query = todo.pop()!;
+    if (query.condition) visit(query.condition);
+    for (const table of query.tables) {
+      if (table.join === "lateral") {
+        todo.push(table.query);
       }
     }
   }

--- a/packages/orm/src/dataloaders/findByUniqueDataLoader.ts
+++ b/packages/orm/src/dataloaders/findByUniqueDataLoader.ts
@@ -32,7 +32,7 @@ export function findByUniqueDataLoader<T extends Entity>(
     };
 
     addTablePerClassJoinsAndClassTag(query, meta, alias, true);
-    maybeAddNotSoftDeleted(conditions, meta, alias, softDeletes);
+    maybeAddNotSoftDeleted(conditions, softDeletes, meta, alias);
 
     let column: Column;
     switch (field.kind) {

--- a/packages/orm/src/dataloaders/findCountDataLoader.ts
+++ b/packages/orm/src/dataloaders/findCountDataLoader.ts
@@ -3,13 +3,12 @@ import { Entity } from "../Entity";
 import { FilterAndSettings } from "../EntityFilter";
 import { EntityManager, MaybeAbstractEntityConstructor } from "../EntityManager";
 import { getMetadata } from "../EntityMetadata";
-import { getTables, joinKeywords, parseFindQuery } from "../QueryParser";
-import { kq } from "../keywords";
+import { ParsedFindQuery, parseFindQuery } from "../QueryParser";
+import { buildRawQuery } from "../drivers/buildRawQuery";
 import { cleanSql, fail } from "../utils";
 import {
-  buildConditions,
   buildValuesCte,
-  collectArgs,
+  collectAndReplaceArgs,
   createBindings,
   getBatchKeyFromGenericStructure,
   whereFilterHash,
@@ -22,7 +21,7 @@ export function findCountDataLoader<T extends Entity>(
 ): DataLoader<FilterAndSettings<T>, number> {
   const { where, ...opts } = filter;
   if (opts.limit || opts.offset) {
-    throw new Error("Cannot use limit/offset with findDataLoader");
+    throw new Error("Cannot use limit/offset with findCountDataLoader");
   }
 
   const meta = getMetadata(type);
@@ -40,44 +39,50 @@ export function findCountDataLoader<T extends Entity>(
         const { where, ...options } = queries[0];
         const query = parseFindQuery(getMetadata(type), where, options);
         const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
-        query.selects = [`count(distinct "${primary.alias}".id) as count`];
+        query.selects = [`count("${primary.alias}".id) as count`];
         query.orderBys = [];
         const rows = await em.driver.executeFind(em, query, {});
         return [Number(rows[0].count)];
       }
 
-      // WITH data(tag, arg1, arg2) AS (VALUES
+      // WITH _find (tag, arg1, arg2) AS (VALUES
       //   (0::int, 'a'::varchar, 'a'::varchar),
       //   (1, 'b', 'b'),
       //   (2, 'c', 'c')
       // )
-      // SELECT d.tag, count(*)
-      // FROM authors a
-      // JOIN data d ON (d.arg1 = a.first_name OR d.arg2 = a.last_name)
-      // group by d.tag;
+      // SELECT _find.tag, _data.count
+      // FROM _find
+      // CROSS JOIN LATERAL (
+      //   SELECT count(*) as count
+      //   FROM author a WHERE a.first_name = _find.arg1 OR a.last_name = _find.arg2
+      // ) _data
 
       // Build the list of 'arg1', 'arg2', ... strings
-      const args = collectArgs(query);
+      const { where, ...options } = queries[0];
+      const query = parseFindQuery(getMetadata(type), where, options);
+      const args = collectAndReplaceArgs(query);
       args.unshift({ columnName: "tag", dbType: "int" });
 
-      const [primary, joins] = getTables(query);
-      // Use count(distinct id) in case two o2m joins end up duplicating rows
-      const selects = ["_find.tag as tag", `count(distinct ${kq(primary.alias)}.id) as count`];
+      // We're not returning the entities, just counting them...
+      query.selects = ["count(*) as count"];
+      query.orderBys = [];
 
-      // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
-      const bindings = createBindings(meta, queries);
-      // Create the JOIN clause, i.e. ON a.firstName = _find.arg0
-      const [conditions] = buildConditions(query.condition!);
+      const query2: ParsedFindQuery = {
+        selects: ["_find.tag as tag", "_data.count as count"],
+        tables: [
+          { join: "primary", table: "_find", alias: "_find" },
+          // Not sure what fromAlias is for/that it matters...
+          { join: "lateral", query: query, table: meta.tableName, alias: "_data", fromAlias: "_f" },
+        ],
+        // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
+        cte: {
+          sql: buildValuesCte("_find", args, queries),
+          bindings: createBindings(meta, queries),
+        },
+        orderBys: [],
+      };
 
-      const sql = `
-        ${buildValuesCte("_find", args, queries)}
-        SELECT ${selects.join(", ")}
-        FROM ${primary.table} as ${kq(primary.alias)}
-        ${joins.map((j) => `${joinKeywords(j)} ${j.table} ${kq(j.alias)} ON ${j.col1} = ${j.col2}`).join(" ")}
-        JOIN _find ON ${conditions}
-        GROUP BY _find.tag
-      `;
-
+      const { sql, bindings } = buildRawQuery(query2, {});
       const rows = await em.driver.executeQuery(em, cleanSql(sql), bindings);
 
       // Make an empty array for each batched query, per the dataloader contract

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -89,6 +89,7 @@ export function findDataLoader<T extends Entity>(
 
       // Because we want to use `array_agg(tag)`, add `GROUP BY`s to the values we're selecting
       const groupBys = selects
+        .filter((s) => typeof s === "string")
         .filter((s) => !s.includes("array_agg") && !s.includes("CASE") && !s.includes(" as "))
         .map((s) => s.replace("*", "id"));
 

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -171,7 +171,7 @@ export function whereFilterHash(where: FilterAndSettings<any>): any {
 }
 
 class ArgCounter {
-  index = 0;
+  private index = 0;
   next(): number {
     return this.index++;
   }

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -215,7 +215,7 @@ export function collectAndReplaceArgs(query: ParsedFindQuery): { columnName: str
           return {
             kind: "raw",
             aliases: [c.alias],
-            condition: `${negate ? "NOT " : ""}${c.alias}.${c.column} ${op}`,
+            condition: `${negate ? "NOT " : ""}${kqDot(c.alias, c.column)} ${op}`,
             pruneable: c.pruneable ?? false,
             bindings: [],
           } satisfies RawCondition;

--- a/packages/orm/src/drivers/Driver.ts
+++ b/packages/orm/src/drivers/Driver.ts
@@ -13,7 +13,7 @@ export interface Driver {
   ): Promise<any[]>;
 
   /** Executes a raw SQL query with bindings. */
-  executeQuery(em: EntityManager, sql: string, bindings: any[]): Promise<any[]>;
+  executeQuery(em: EntityManager, sql: string, bindings: readonly any[]): Promise<any[]>;
 
   transaction<T>(em: EntityManager, fn: (txn: Knex.Transaction) => Promise<T>): Promise<T>;
 

--- a/packages/orm/src/drivers/buildKnexQuery.ts
+++ b/packages/orm/src/drivers/buildKnexQuery.ts
@@ -46,6 +46,9 @@ export function buildKnexQuery(
         break;
       case "lateral":
         throw new Error("Lateral joins are not implemented in buildKnexQuery yet");
+      case "cross":
+        query.crossJoin(asRaw(t));
+        break;
       default:
         assertNever(t);
     }

--- a/packages/orm/src/drivers/buildKnexQuery.ts
+++ b/packages/orm/src/drivers/buildKnexQuery.ts
@@ -30,7 +30,11 @@ export function buildKnexQuery(
   let query: Knex.QueryBuilder = knex.from(asRaw(primary));
 
   parsed.selects.forEach((s) => {
-    query.select(knex.raw(s));
+    if (typeof s === "string") {
+      query.select(knex.raw(s));
+    } else {
+      query.select(knex.raw(s.sql));
+    }
   });
 
   parsed.tables.forEach((t) => {

--- a/packages/orm/src/drivers/buildKnexQuery.ts
+++ b/packages/orm/src/drivers/buildKnexQuery.ts
@@ -54,10 +54,6 @@ export function buildKnexQuery(
     }
   });
 
-  if (parsed.lateralJoins) {
-    query.joinRaw(parsed.lateralJoins.joins.join("\n"), parsed.lateralJoins.bindings);
-  }
-
   if (parsed.condition) {
     const where = buildWhereClause(parsed.condition, true);
     if (where) {

--- a/packages/orm/src/drivers/buildKnexQuery.ts
+++ b/packages/orm/src/drivers/buildKnexQuery.ts
@@ -22,19 +22,15 @@ export function buildKnexQuery(
 ): QueryBuilder<{}, unknown[]> {
   const { limit, offset } = settings;
 
-  // If we're doing o2m joins, add a `DISTINCT` clause to avoid duplicates
-  const needsDistinct = parsed.tables.some((t) => t.join === "outer" && t.distinct !== false);
-
   // We need the `knex` param to call `knex.raw`
   const asRaw = (t: ParsedTable) => knex.raw(`${kq(t.table)} as ${kq(t.alias)}`);
 
   const primary = parsed.tables.find((t) => t.join === "primary")!;
 
-  let query: Knex.QueryBuilder<any, any> = knex.from(asRaw(primary));
+  let query: Knex.QueryBuilder = knex.from(asRaw(primary));
 
-  parsed.selects.forEach((s, i) => {
-    const maybeDistinct = i === 0 && needsDistinct ? "distinct " : "";
-    query.select(knex.raw(`${maybeDistinct}${s}`));
+  parsed.selects.forEach((s) => {
+    query.select(knex.raw(s));
   });
 
   parsed.tables.forEach((t) => {
@@ -69,10 +65,6 @@ export function buildKnexQuery(
 
   parsed.orderBys &&
     parsed.orderBys.forEach(({ alias, column, order }) => {
-      // If we're doing "select distinct" for o2m joins, then all order bys must be selects
-      if (needsDistinct) {
-        query.select(knex.raw(kqDot(alias, column)));
-      }
       query.orderBy(knex.raw(kqDot(alias, column)) as any, order);
     });
 

--- a/packages/orm/src/drivers/buildKnexQuery.ts
+++ b/packages/orm/src/drivers/buildKnexQuery.ts
@@ -33,7 +33,7 @@ export function buildKnexQuery(
     if (typeof s === "string") {
       query.select(knex.raw(s));
     } else {
-      query.select(knex.raw(s.sql));
+      query.select(knex.raw(s.sql, s.bindings));
     }
   });
 
@@ -49,7 +49,9 @@ export function buildKnexQuery(
         // ignore
         break;
       case "lateral":
-        throw new Error("Lateral joins are not implemented in buildKnexQuery yet");
+        const { sql, bindings } = buildKnexQuery(knex, t.query, {}).toSQL();
+        query.crossJoin(knex.raw(`lateral (${sql}) as ${kq(t.alias)}`, bindings));
+        break;
       case "cross":
         query.crossJoin(asRaw(t));
         break;

--- a/packages/orm/src/drivers/buildRawQuery.ts
+++ b/packages/orm/src/drivers/buildRawQuery.ts
@@ -26,7 +26,12 @@ export function buildRawQuery(
   sql += "SELECT ";
   parsed.selects.forEach((s, i) => {
     const maybeComma = i === parsed.selects.length - 1 ? "" : ", ";
-    sql += s + maybeComma;
+    if (typeof s === "string") {
+      sql += s + maybeComma;
+    } else {
+      sql += s.sql + maybeComma;
+      bindings.push(...s.bindings);
+    }
   });
 
   // Make sure the primary is first

--- a/packages/orm/src/drivers/buildRawQuery.ts
+++ b/packages/orm/src/drivers/buildRawQuery.ts
@@ -57,11 +57,6 @@ export function buildRawQuery(
     }
   }
 
-  if (parsed.lateralJoins) {
-    sql += " " + parsed.lateralJoins.joins.join("\n");
-    bindings.push(...parsed.lateralJoins.bindings);
-  }
-
   if (parsed.condition) {
     const where = buildWhereClause(parsed.condition, true);
     if (where) {

--- a/packages/orm/src/drivers/buildRawQuery.ts
+++ b/packages/orm/src/drivers/buildRawQuery.ts
@@ -50,6 +50,8 @@ export function buildRawQuery(
       const { sql: subQ, bindings: subB } = buildRawQuery(t.query, {});
       sql += ` CROSS JOIN LATERAL (${subQ}) AS ${kq(t.alias)}`;
       bindings.push(...subB);
+    } else if (t.join === "cross") {
+      sql += ` CROSS JOIN ${as(t)}`;
     } else {
       assertNever(t.join);
     }
@@ -66,6 +68,10 @@ export function buildRawQuery(
       sql += " WHERE " + where[0];
       bindings.push(...where[1]);
     }
+  }
+
+  if (parsed.groupBys && parsed.groupBys.length > 0) {
+    sql += " GROUP BY " + parsed.groupBys.map((ob) => kqDot(ob.alias, ob.column)).join(", ");
   }
 
   if (parsed.orderBys.length > 0) {

--- a/packages/orm/src/drivers/buildUtils.ts
+++ b/packages/orm/src/drivers/buildUtils.ts
@@ -33,7 +33,7 @@ function buildRawCondition(raw: RawCondition): [string, any[]] {
 }
 
 /** Returns a tuple of `["column op ?"`, bindings]`. */
-function buildCondition(cc: ColumnCondition): [string, any[]] {
+export function buildCondition(cc: ColumnCondition): [string, any[]] {
   const { alias, column, cond } = cc;
   const columnName = kqDot(alias, column);
   switch (cond.kind) {

--- a/packages/orm/src/drivers/buildUtils.ts
+++ b/packages/orm/src/drivers/buildUtils.ts
@@ -25,11 +25,9 @@ export function buildWhereClause(exp: ParsedExpressionFilter, topLevel = false):
   return [sql, tuples.flatMap(([, bindings]) => bindings)];
 }
 
+/** Returns a tuple of `["column op ?"`, bindings]`. */
 function buildRawCondition(raw: RawCondition): [string, any[]] {
-  if (raw.bindings.length > 0) {
-    throw new Error("Not implemented");
-  }
-  return [raw.condition, []];
+  return [raw.condition, raw.bindings];
 }
 
 /** Returns a tuple of `["column op ?"`, bindings]`. */

--- a/packages/orm/src/plugins/PreloadPlugin.ts
+++ b/packages/orm/src/plugins/PreloadPlugin.ts
@@ -81,6 +81,4 @@ export type JoinResult = {
   join: LateralJoinTable;
   /** The processor for this child's lateral join, which itself might recursively processor subjoins. */
   hydrator: PreloadHydrator;
-  /** Any bindings for filtering subjoins by a subset of the root entities, to avoid over-fetching. */
-  bindings: any[];
 };

--- a/packages/orm/src/plugins/PreloadPlugin.ts
+++ b/packages/orm/src/plugins/PreloadPlugin.ts
@@ -3,7 +3,7 @@ import { EntityManager } from "../EntityManager";
 import { EntityMetadata } from "../EntityMetadata";
 import { EntityOrId, HintNode } from "../HintTree";
 import { LoadHint, NestedLoadHint } from "../loadHints";
-import { ParsedFindQuery } from "../QueryParser";
+import { LateralJoinTable, ParsedFindQuery } from "../QueryParser";
 
 /**
  * This is a plugin API dedicated to preloading data for subtrees of entities.
@@ -78,7 +78,7 @@ export type JoinResult = {
   /** The select clause(s) for this join, i.e. `b._ as _b` or `c._ as _c`. */
   selects: { value: string; as: string }[];
   /** The SQL for this child's lateral join, which itself might have recursive lateral joins. */
-  join: string;
+  join: LateralJoinTable;
   /** The processor for this child's lateral join, which itself might recursively processor subjoins. */
   hydrator: PreloadHydrator;
   /** Any bindings for filtering subjoins by a subset of the root entities, to avoid over-fetching. */

--- a/packages/plugins/join-preloading/src/JsonAggregatePreloader.ts
+++ b/packages/plugins/join-preloading/src/JsonAggregatePreloader.ts
@@ -205,9 +205,11 @@ function addJoins<I extends EntityOrId>(
         cb.addRawCondition({
           aliases: [root.alias],
           condition: `${kqDot(root.alias, "id")} = ANY(?)`,
-          bindings: [...subTree.entities]
-            .filter((e) => typeof e === "string" || !e.isNewEntity)
-            .map((e) => keyToNumber(root.meta, typeof e === "string" ? e : e.id)),
+          bindings: [
+            [...subTree.entities]
+              .filter((e) => typeof e === "string" || !e.isNewEntity)
+              .map((e) => keyToNumber(root.meta, typeof e === "string" ? e : e.id)),
+          ],
           pruneable: true,
         });
       }

--- a/packages/plugins/join-preloading/src/JsonAggregatePreloader.ts
+++ b/packages/plugins/join-preloading/src/JsonAggregatePreloader.ts
@@ -219,8 +219,10 @@ function addJoins<I extends EntityOrId>(
       const join: LateralJoinTable = {
         join: "lateral",
         alias: otherAlias,
+        // Do we need to say which alias we're coming from, to avoid having it pruned?
+        // ...maybe not because preloading is always on the primary table?
         fromAlias: "unset",
-        table: "...unused...",
+        table: otherMeta.tableName,
         query: {
           selects: [`json_agg(json_build_array(${selects.join(", ")}) order by ${kq(otherAlias)}.id) as _`],
           tables: [

--- a/packages/plugins/join-preloading/src/JsonAggregatePreloader.ts
+++ b/packages/plugins/join-preloading/src/JsonAggregatePreloader.ts
@@ -21,10 +21,8 @@ import {
   PreloadHydrator,
   PreloadPlugin,
 } from "joist-orm";
-import { builders } from "prettier/doc";
 import { canPreload } from "./canPreload";
 import { partitionHint } from "./partitionHint";
-import join = builders.join;
 
 /**
  * A PreloadPlugin implementation that uses `CROSS LATERAL JOIN` and `json_aggregate`

--- a/packages/tests/integration/src/EntityManager.find.batch.test.ts
+++ b/packages/tests/integration/src/EntityManager.find.batch.test.ts
@@ -382,10 +382,9 @@ describe("EntityManager.find.batch", () => {
     expect(queries).toEqual([
       [
         `WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) )`,
-        ` SELECT _find.tag as tag, count(distinct "as".id) as count`,
-        ` FROM author_schedules as "as"`,
-        ` JOIN _find ON "as".id = _find.arg0`,
-        ` GROUP BY _find.tag`,
+        ` SELECT _find.tag as tag, _data.count as count`,
+        ` FROM _find AS _find`,
+        ` CROSS JOIN LATERAL (SELECT count(*) as count FROM author_schedules AS "as" WHERE "as".id = _find.arg0) AS _data`,
       ].join(""),
     ]);
     expect(q1).toEqual(0);

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -741,10 +741,22 @@ describe("EntityManager.queries", () => {
     await insertAuthor({ first_name: "a1" });
     await insertAuthor({ first_name: "a2" });
     await insertBook({ title: "b1", author_id: 1 });
-    await insertBook({ title: "b1", author_id: 1 });
+    await insertBook({ title: "b2", author_id: 1 });
 
     const em = newEntityManager();
     const where = { books: ["b:1"] } satisfies AuthorFilter;
+    const authors = await em.find(Author, where);
+    expect(authors).toMatchEntity([{ firstName: "a1" }]);
+  });
+
+  it("can find by o2m has as id", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2" });
+    await insertBook({ title: "b1", author_id: 1 });
+    await insertBook({ title: "b2", author_id: 1 });
+
+    const em = newEntityManager();
+    const where = { books: { id: "b:1" } } satisfies AuthorFilter;
     const authors = await em.find(Author, where);
     expect(authors).toMatchEntity([{ firstName: "a1" }]);
   });

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2235,7 +2235,6 @@ describe("EntityManager.queries", () => {
             condition: {
               op: "and",
               conditions: [
-                { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
                 { alias: "b", column: "title", dbType: "character varying", cond: { kind: "like", value: "b1%" } },
                 { kind: "raw", condition: "a.id = b.author_id" },
               ],
@@ -2276,7 +2275,6 @@ describe("EntityManager.queries", () => {
             condition: {
               op: "and",
               conditions: [
-                { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
                 { alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b3" } },
                 { kind: "raw", condition: "a.id = b.author_id" },
               ],
@@ -2314,7 +2312,6 @@ describe("EntityManager.queries", () => {
             condition: {
               op: "and",
               conditions: [
-                { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
                 { alias: "b", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } },
                 { condition: "a.id = b.author_id" },
               ],
@@ -2428,7 +2425,6 @@ describe("EntityManager.queries", () => {
             condition: {
               op: "and",
               conditions: [
-                { alias: "a", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
                 { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
                 { kind: "raw", condition: "lp.id = a.publisher_id" },
               ],
@@ -2843,14 +2839,6 @@ describe("EntityManager.queries", () => {
                 kind: "exp",
                 op: "and",
                 conditions: [
-                  {
-                    kind: "column",
-                    alias: "b",
-                    column: "deleted_at",
-                    dbType: "timestamp with time zone",
-                    cond: { kind: "is-null" },
-                    pruneable: true,
-                  },
                   { kind: "raw", aliases: ["a", "b"], condition: "a.id = b.author_id", bindings: [], pruneable: true },
                 ],
               },
@@ -2908,10 +2896,7 @@ describe("EntityManager.queries", () => {
               selects: ["count(*) as _", { sql: "BOOL_OR(b.title = ?) as _b_title_0", bindings: ["b1"] }],
               tables: [{ table: "books", join: "primary" }],
               condition: {
-                conditions: [
-                  { kind: "column", column: "deleted_at" },
-                  { kind: "raw", condition: "a.id = b.author_id" },
-                ],
+                conditions: [{ kind: "raw", condition: "a.id = b.author_id" }],
               },
             },
           },

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2294,8 +2294,8 @@ describe("EntityManager.queries", () => {
             condition: {
               op: "and",
               conditions: [
-                { alias: "b", column: "title", dbType: "character varying", cond: { kind: "like", value: "b1%" } },
                 { kind: "raw", condition: "a.id = b.author_id" },
+                { alias: "b", column: "title", dbType: "character varying", cond: { kind: "like", value: "b1%" } },
               ],
             },
           },
@@ -2334,8 +2334,8 @@ describe("EntityManager.queries", () => {
             condition: {
               op: "and",
               conditions: [
-                { alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b3" } },
                 { kind: "raw", condition: "a.id = b.author_id" },
+                { alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b3" } },
               ],
             },
           },
@@ -2371,8 +2371,8 @@ describe("EntityManager.queries", () => {
             condition: {
               op: "and",
               conditions: [
-                { alias: "b", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } },
                 { condition: "a.id = b.author_id" },
+                { alias: "b", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } },
               ],
             },
           },
@@ -2410,9 +2410,9 @@ describe("EntityManager.queries", () => {
             condition: {
               op: "and",
               conditions: [
+                { kind: "raw", condition: "a.id = b.author_id" },
                 { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
                 { alias: "b", column: "acknowledgements", dbType: "text", cond: { kind: "is-null" } },
-                { kind: "raw", condition: "a.id = b.author_id" },
               ],
             },
           },
@@ -2484,8 +2484,8 @@ describe("EntityManager.queries", () => {
             condition: {
               op: "and",
               conditions: [
-                { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
                 { kind: "raw", condition: "lp.id = a.publisher_id" },
+                { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
               ],
             },
           },
@@ -2898,7 +2898,7 @@ describe("EntityManager.queries", () => {
                 kind: "exp",
                 op: "and",
                 conditions: [
-                  { kind: "raw", aliases: ["a", "b"], condition: "a.id = b.author_id", bindings: [], pruneable: true },
+                  { kind: "raw", aliases: ["b", "a"], condition: "a.id = b.author_id", bindings: [], pruneable: true },
                 ],
               },
               orderBys: [],
@@ -3548,7 +3548,7 @@ describe("EntityManager.queries", () => {
     const where = { books: { title: "b1" } } satisfies AuthorFilter;
     const q = buildQuery(em.ctx.knex, Author, { where });
     expect(q.toSQL().sql).toMatchInlineSnapshot(
-      `"select a.* from authors as a cross join lateral (select count(*) as _ from books as b where b.deleted_at IS NULL AND b.title = ? AND a.id = b.author_id) as b where a.deleted_at IS NULL AND b._ > ? order by a.id ASC"`,
+      `"select a.* from authors as a cross join lateral (select count(*) as _ from books as b where a.id = b.author_id AND b.deleted_at IS NULL AND b.title = ?) as b where a.deleted_at IS NULL AND b._ > ? order by a.id ASC"`,
     );
     const rows = await q;
     expect(rows.length).toBe(0);

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -737,6 +737,18 @@ describe("EntityManager.queries", () => {
     expect(authors).toMatchEntity([{ firstName: "a1" }]);
   });
 
+  it("can find by o2m has list of ids", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2" });
+    await insertBook({ title: "b1", author_id: 1 });
+    await insertBook({ title: "b1", author_id: 1 });
+
+    const em = newEntityManager();
+    const where = { books: ["b:1"] } satisfies AuthorFilter;
+    const authors = await em.find(Author, where);
+    expect(authors).toMatchEntity([{ firstName: "a1" }]);
+  });
+
   it("can find through a o2o entity", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertAuthor({ first_name: "a2" });

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -890,8 +890,8 @@ describe("EntityManager.queries", () => {
       ],
       tables: [
         { alias: "p", table: "publishers", join: "primary" },
-        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id", distinct: false },
-        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id", distinct: false },
+        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id" },
+        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id" },
       ],
       condition: {
         op: "and",
@@ -950,8 +950,8 @@ describe("EntityManager.queries", () => {
       ],
       tables: [
         { alias: "p", table: "publishers", join: "primary" },
-        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id", distinct: false },
-        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id", distinct: false },
+        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id" },
+        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id" },
       ],
       condition: {
         op: "and",
@@ -982,8 +982,8 @@ describe("EntityManager.queries", () => {
       ],
       tables: [
         { alias: "p", table: "publishers", join: "primary" },
-        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id", distinct: false },
-        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id", distinct: false },
+        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id" },
+        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id" },
       ],
       condition: {
         op: "and",
@@ -1625,8 +1625,8 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        { alias: "b", table: "books", join: "outer", col1: "a.current_draft_book_id", col2: "b.id", distinct: false },
-        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id", distinct: false },
+        { alias: "b", table: "books", join: "outer", col1: "a.current_draft_book_id", col2: "b.id" },
+        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id" },
       ],
       orderBys: [
         { alias: "b", column: "title", order: "ASC" },
@@ -1654,8 +1654,8 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id", distinct: false },
-        { alias: "b", table: "books", join: "outer", col1: "a.current_draft_book_id", col2: "b.id", distinct: false },
+        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id" },
+        { alias: "b", table: "books", join: "outer", col1: "a.current_draft_book_id", col2: "b.id" },
       ],
       orderBys: [
         { alias: "p", column: "name", order: "ASC" },
@@ -1682,7 +1682,7 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id", distinct: false },
+        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id" },
       ],
       orderBys: [
         { alias: "p", column: "name", order: "ASC" },
@@ -2084,7 +2084,7 @@ describe("EntityManager.queries", () => {
       selects: [`u.*`, "u_s0.*", "u.id as id", expect.anything()],
       tables: [
         { alias: "u", table: "users", join: "primary" },
-        { alias: "u_s0", table: "admin_users", join: "outer", col1: "u.id", col2: "u_s0.id", distinct: false },
+        { alias: "u_s0", table: "admin_users", join: "outer", col1: "u.id", col2: "u_s0.id" },
       ],
       condition: {
         op: "or",

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2704,6 +2704,25 @@ describe("EntityManager.queries", () => {
       expect(authors.length).toEqual(1);
     });
 
+    it("can use aliases as an o2m entity filter with zero or some children", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBook({ title: "b2", author_id: 1 });
+      const em = newEntityManager();
+      const b = alias(Book);
+      const authors = await em.find(
+        Author,
+        { books: b },
+        {
+          conditions: {
+            or: [b.$count.eq(0), b.id.in(["b:1"])],
+          },
+        },
+      );
+      expect(authors.length).toEqual(2);
+    });
+
     it("can use aliases as an o2m entity filter with primary key in tagged ids", async () => {
       await insertAuthor({ first_name: "a1" });
       await insertAuthor({ first_name: "a2" });

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -3030,7 +3030,7 @@ describe("EntityManager.queries", () => {
       const conditionalFilter: ExpressionFilter | undefined = undefined;
       expect(
         parseFindQuery(am, where, {
-          conditions: { and: [a.firstName.eq("a"), undefined] },
+          conditions: { and: [a.firstName.eq("a"), conditionalFilter] },
         }),
       ).toMatchObject({
         selects: [`a.*`],
@@ -3045,12 +3045,7 @@ describe("EntityManager.queries", () => {
               cond: { kind: "is-null" },
               pruneable: true,
             },
-            {
-              conditions: [
-                { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a" } },
-              ],
-              op: "and",
-            },
+            { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a" } },
           ],
         },
         orderBys: [expect.anything()],

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2423,13 +2423,25 @@ describe("EntityManager.queries", () => {
         { alias: "c", table: "critics", join: "primary" },
         { alias: "lp", table: "large_publishers", join: "outer", col1: "c.favorite_large_publisher_id", col2: "lp.id" },
         // Perhaps ideally the `col1` would be `lp_b0.id` but it doesn't matter
-        { alias: "a", table: "authors", join: "outer", col1: "lp.id", col2: "a.publisher_id" },
+        {
+          alias: "a",
+          table: "authors",
+          join: "lateral",
+          query: {
+            condition: {
+              op: "and",
+              conditions: [
+                { alias: "a", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
+                { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
+                { op: "and", conditions: [{ kind: "raw", condition: "lp.id = a.publisher_id" }] },
+              ],
+            },
+          },
+        },
       ],
       condition: {
         op: "and",
-        conditions: [
-          { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
-        ],
+        conditions: [{ alias: "a", column: "_", dbType: "int", cond: { kind: "gt", value: 0 } }],
       },
       orderBys: [expect.anything()],
     });

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2309,11 +2309,25 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
+        {
+          alias: "b",
+          table: "books",
+          join: "lateral",
+          query: {
+            condition: {
+              op: "and",
+              conditions: [
+                { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
+                { alias: "b", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } },
+                { op: "and", conditions: [{ condition: "a.id = b.author_id" }] },
+              ],
+            },
+          },
+        },
       ],
       condition: {
         op: "and",
-        conditions: [{ alias: "b", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } }],
+        conditions: [{ alias: "b", column: "_", dbType: "int", cond: { kind: "gt", value: 0 } }],
       },
       orderBys: [expect.anything()],
     });

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2568,7 +2568,7 @@ describe("EntityManager.queries", () => {
       await insertBook({ title: "b1", author_id: 1 });
       const em = newEntityManager();
       const b = alias(Book);
-      const authors = await em.find(Author, { books: b }, { conditions: { and: [b.id.eq(null)] } });
+      const authors = await em.find(Author, { books: b }, { conditions: { and: [b.$count.eq(0)] } });
       expect(authors.length).toEqual(1);
     });
 

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -8,6 +8,7 @@ import {
   insertImage,
   insertLargePublisher,
   insertPublisher,
+  insertSmallPublisherGroup,
   insertTag,
   insertUser,
   update,
@@ -48,6 +49,7 @@ import {
   PublisherId,
   PublisherSize,
   SmallPublisher,
+  SmallPublisherGroup,
   Tag,
   TaskItem,
   TaskItemFilter,
@@ -2721,6 +2723,21 @@ describe("EntityManager.queries", () => {
         },
       );
       expect(authors.length).toEqual(2);
+    });
+
+    it("can use aliases as an o2m entity filter against a base type", async () => {
+      await insertSmallPublisherGroup({ id: 1, name: "pg1" });
+      await insertPublisher({ name: "p1", group_id: 1 });
+      const em = newEntityManager();
+      const p = alias(SmallPublisher);
+      const pgs = await em.find(
+        SmallPublisherGroup,
+        { publishers: p },
+        {
+          conditions: { and: [p.name.eq("p1")] },
+        },
+      );
+      expect(pgs.length).toEqual(1);
     });
 
     it("can use aliases as an o2m entity filter with primary key in tagged ids", async () => {

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2231,6 +2231,14 @@ describe("EntityManager.queries", () => {
           query: {
             selects: [`count(*) as _`],
             tables: [{ alias: "b", table: "books", join: "primary" }],
+            condition: {
+              op: "and",
+              conditions: [
+                { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
+                { alias: "b", column: "title", dbType: "character varying", cond: { kind: "like", value: "b1%" } },
+                { op: "and", conditions: [{ kind: "raw", condition: "a.id = b.author_id" }] },
+              ],
+            },
           },
           join: "lateral",
         },
@@ -2259,11 +2267,29 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
+        {
+          alias: "b",
+          table: "books",
+          join: "lateral",
+          query: {
+            condition: {
+              op: "and",
+              conditions: [
+                { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
+                { alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b3" } },
+                {
+                  kind: "exp",
+                  op: "and",
+                  conditions: [{ kind: "raw", condition: "a.id = b.author_id" }],
+                },
+              ],
+            },
+          },
+        },
       ],
       condition: {
         op: "and",
-        conditions: [{ alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b3" } }],
+        conditions: [{ alias: "b", column: "_", dbType: "int", cond: { kind: "gt", value: 0 } }],
       },
       orderBys: [expect.anything()],
     });

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2913,7 +2913,6 @@ describe("EntityManager.queries", () => {
             },
           ],
         },
-
         orderBys: [expect.anything()],
       });
     });

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -715,6 +715,17 @@ describe("EntityManager.queries", () => {
     });
   });
 
+  it("can find by o2m is null", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2" });
+    await insertBook({ title: "b1", author_id: 1 });
+
+    const em = newEntityManager();
+    const where = { books: null } satisfies AuthorFilter;
+    const authors = await em.find(Author, where);
+    expect(authors.length).toEqual(1);
+  });
+
   it("can find through a o2o entity", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertAuthor({ first_name: "a2" });

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -761,6 +761,18 @@ describe("EntityManager.queries", () => {
     expect(authors).toMatchEntity([{ firstName: "a1" }]);
   });
 
+  it("can find by o2m in ids", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2" });
+    await insertBook({ title: "b1", author_id: 1 });
+    await insertBook({ title: "b2", author_id: 1 });
+
+    const em = newEntityManager();
+    const where = { books: { id: { in: ["b:1", "b:3"] } } } satisfies AuthorFilter;
+    const authors = await em.find(Author, where);
+    expect(authors).toMatchEntity([{ firstName: "a1" }]);
+  });
+
   it("can find through a o2o entity", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertAuthor({ first_name: "a2" });

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2211,6 +2211,7 @@ describe("EntityManager.queries", () => {
   it("can find through o2m with all children matching", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertAuthor({ first_name: "a2" });
+    await insertAuthor({ first_name: "a3" });
     await insertBook({ title: "b10", author_id: 1 });
     await insertBook({ title: "b11", author_id: 1 });
     await insertBook({ title: "b2", author_id: 2 });

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -723,7 +723,18 @@ describe("EntityManager.queries", () => {
     const em = newEntityManager();
     const where = { books: null } satisfies AuthorFilter;
     const authors = await em.find(Author, where);
-    expect(authors.length).toEqual(1);
+    expect(authors).toMatchEntity([{ firstName: "a2" }]);
+  });
+
+  it("can find by o2m is ne null", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2" });
+    await insertBook({ title: "b1", author_id: 1 });
+
+    const em = newEntityManager();
+    const where = { books: { ne: null } } satisfies AuthorFilter;
+    const authors = await em.find(Author, where);
+    expect(authors).toMatchEntity([{ firstName: "a1" }]);
   });
 
   it("can find through a o2o entity", async () => {

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -752,7 +752,7 @@ describe("EntityManager.queries", () => {
     expect(authors).toMatchEntity([{ firstName: "a1" }]);
   });
 
-  it("can find by o2m has as id", async () => {
+  it("can find by o2m is an id", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertAuthor({ first_name: "a2" });
     await insertBook({ title: "b1", author_id: 1 });
@@ -760,6 +760,17 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { books: { id: "b:1" } } satisfies AuthorFilter;
+    const authors = await em.find(Author, where);
+    expect(authors).toMatchEntity([{ firstName: "a1" }]);
+  });
+
+  it("can find by nested o2m is an id", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2" });
+    await insertBook({ title: "b1", author_id: 1 });
+    await insertBookReview({ book_id: 1, rating: 1 });
+    const em = newEntityManager();
+    const where = { books: { reviews: { id: "br:1" } } } satisfies AuthorFilter;
     const authors = await em.find(Author, where);
     expect(authors).toMatchEntity([{ firstName: "a1" }]);
   });

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2237,7 +2237,7 @@ describe("EntityManager.queries", () => {
               conditions: [
                 { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
                 { alias: "b", column: "title", dbType: "character varying", cond: { kind: "like", value: "b1%" } },
-                { op: "and", conditions: [{ kind: "raw", condition: "a.id = b.author_id" }] },
+                { kind: "raw", condition: "a.id = b.author_id" },
               ],
             },
           },
@@ -2278,11 +2278,7 @@ describe("EntityManager.queries", () => {
               conditions: [
                 { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
                 { alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b3" } },
-                {
-                  kind: "exp",
-                  op: "and",
-                  conditions: [{ kind: "raw", condition: "a.id = b.author_id" }],
-                },
+                { kind: "raw", condition: "a.id = b.author_id" },
               ],
             },
           },
@@ -2320,7 +2316,7 @@ describe("EntityManager.queries", () => {
               conditions: [
                 { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
                 { alias: "b", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } },
-                { op: "and", conditions: [{ condition: "a.id = b.author_id" }] },
+                { condition: "a.id = b.author_id" },
               ],
             },
           },
@@ -2360,7 +2356,7 @@ describe("EntityManager.queries", () => {
               conditions: [
                 { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
                 { alias: "b", column: "acknowledgements", dbType: "text", cond: { kind: "is-null" } },
-                { op: "and", conditions: [{ condition: "a.id = b.author_id" }] },
+                { kind: "raw", condition: "a.id = b.author_id" },
               ],
             },
           },
@@ -2434,7 +2430,7 @@ describe("EntityManager.queries", () => {
               conditions: [
                 { alias: "a", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
                 { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
-                { op: "and", conditions: [{ kind: "raw", condition: "lp.id = a.publisher_id" }] },
+                { kind: "raw", condition: "lp.id = a.publisher_id" },
               ],
             },
           },

--- a/packages/tests/integration/src/QueryParser.quotes.test.ts
+++ b/packages/tests/integration/src/QueryParser.quotes.test.ts
@@ -15,7 +15,7 @@ describe("QueryParser", () => {
         "SELECT b.*",
         " FROM books AS b",
         " JOIN authors AS a ON b.author_id = a.id",
-        ' CROSS JOIN LATERAL (SELECT count(*) as _ FROM author_schedules AS "as" WHERE "as".id = ? AND a.id = "as".author_id) AS "as"',
+        ' CROSS JOIN LATERAL (SELECT count(*) as _ FROM author_schedules AS "as" WHERE a.id = "as".author_id AND "as".id = ?) AS "as"',
         " WHERE b.deleted_at IS NULL",
         " AND a.deleted_at IS NULL",
         " AND a.first_name = ?",

--- a/packages/tests/integration/src/QueryParser.quotes.test.ts
+++ b/packages/tests/integration/src/QueryParser.quotes.test.ts
@@ -1,10 +1,9 @@
 import { Book } from "@src/entities";
-import { knex } from "@src/testEm";
 import { getMetadata, ParsedFindQuery, parseFindQuery } from "joist-orm";
-import { buildKnexQuery } from "joist-orm/build/drivers/buildKnexQuery";
+import { buildRawQuery } from "joist-orm/build/drivers/buildRawQuery";
 
 function generateSql(t: ParsedFindQuery) {
-  return buildKnexQuery(knex, t, {}).toSQL().sql;
+  return buildRawQuery(t, {}).sql;
 }
 
 const bm = getMetadata(Book);
@@ -13,15 +12,15 @@ describe("QueryParser", () => {
   it("quotes with abbreviation", () => {
     expect(generateSql(parseFindQuery(bm, { author: { firstName: "jeff", schedules: { id: 4 } } }))).toEqual(
       [
-        "select distinct b.*, b.title, b.id",
-        " from books as b",
-        " inner join authors as a on b.author_id = a.id",
-        ' left outer join author_schedules as "as" on a.id = "as".author_id',
-        " where b.deleted_at IS NULL",
+        "SELECT b.*",
+        " FROM books AS b",
+        " JOIN authors AS a ON b.author_id = a.id",
+        ' CROSS JOIN LATERAL (SELECT count(*) as _ FROM author_schedules AS "as" WHERE "as".id = ? AND a.id = "as".author_id) AS "as"',
+        " WHERE b.deleted_at IS NULL",
         " AND a.deleted_at IS NULL",
         " AND a.first_name = ?",
-        ' AND "as".id = ?',
-        " order by b.title ASC, b.id ASC",
+        ' AND "as"._ > ?',
+        " ORDER BY b.title ASC, b.id ASC",
       ].join(""),
     );
   });

--- a/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
@@ -22,7 +22,7 @@ describe("ReactiveQueryField", () => {
        "select nextval('publishers_id_seq') from generate_series(1, 1)",
        "INSERT INTO "publishers" ("id", "name", "latitude", "longitude", "huge_number", "number_of_book_reviews", "deleted_at", "titles_of_favorite_books", "base_sync_default", "base_async_default", "created_at", "updated_at", "size_id", "type_id", "favorite_author_id", "group_id", "spotlight_author_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)",
        "INSERT INTO "large_publishers" ("id", "shared_column", "country") VALUES ($1, $2, $3)",
-       "SELECT DISTINCT count(distinct "br".id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2",
+       "SELECT count("br".id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2",
        "COMMIT;",
      ]
     `);
@@ -41,7 +41,7 @@ describe("ReactiveQueryField", () => {
     // After the INSERTs, there is a SELECT to calc the data, and then an `UPDATE`
     expect(queries).toMatchInlineSnapshot(`
      [
-       "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::character varying), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.last_name = _find.arg0 GROUP BY a.id ORDER BY a.id ASC LIMIT 50000;",
+       "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::character varying), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find WHERE a.deleted_at IS NULL AND a.last_name = _find.arg0 GROUP BY a.id ORDER BY a.id ASC LIMIT $5",
        "select nextval('publishers_id_seq') from generate_series(1, 1) UNION ALL select nextval('authors_id_seq') from generate_series(1, 1) UNION ALL select nextval('books_id_seq') from generate_series(1, 2) UNION ALL select nextval('book_reviews_id_seq') from generate_series(1, 2)",
        "BEGIN;",
        "INSERT INTO "publishers" ("id", "name", "latitude", "longitude", "huge_number", "number_of_book_reviews", "deleted_at", "titles_of_favorite_books", "base_sync_default", "base_async_default", "created_at", "updated_at", "size_id", "type_id", "favorite_author_id", "group_id", "spotlight_author_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)",
@@ -49,7 +49,7 @@ describe("ReactiveQueryField", () => {
        "INSERT INTO "authors" ("id", "first_name", "last_name", "ssn", "initials", "number_of_books", "book_comments", "is_popular", "age", "graduated", "nick_names", "nick_names_upper", "was_ever_popular", "is_funny", "mentor_names", "address", "business_address", "quotes", "number_of_atoms", "deleted_at", "number_of_public_reviews", "numberOfPublicReviews2", "tags_of_all_books", "search", "certificate", "created_at", "updated_at", "favorite_shape", "range_of_books", "favorite_colors", "mentor_id", "root_mentor_id", "current_draft_book_id", "favorite_book_id", "publisher_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35)",
        "INSERT INTO "books" ("id", "title", "order", "notes", "acknowledgements", "authors_nick_names", "search", "deleted_at", "created_at", "updated_at", "prequel_id", "author_id", "reviewer_id", "random_comment_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14),($15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)",
        "INSERT INTO "book_reviews" ("id", "rating", "is_public", "is_test", "created_at", "updated_at", "book_id", "critic_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8),($9, $10, $11, $12, $13, $14, $15, $16)",
-       "SELECT DISTINCT count(distinct "br".id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2",
+       "SELECT count("br".id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2",
        "WITH data (id, number_of_book_reviews, updated_at, __original_updated_at) AS (VALUES ($1::int, $2::int, $3::timestamp with time zone, $4::timestamptz) ) UPDATE publishers SET number_of_book_reviews = data.number_of_book_reviews, updated_at = data.updated_at FROM data WHERE publishers.id = data.id AND date_trunc('milliseconds', publishers.updated_at) = data.__original_updated_at RETURNING publishers.id",
        "COMMIT;",
        "select * from "publishers" order by "id" asc",
@@ -106,8 +106,8 @@ describe("ReactiveQueryField", () => {
       id: 1,
       number_of_book_reviews: 1,
     });
-    expect(queries).toContain(
-      `SELECT DISTINCT count(distinct "br".id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2`,
+    expect(queries[2]).toMatchInlineSnapshot(
+      `"SELECT count("br".id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2"`,
     );
   });
 

--- a/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
@@ -106,8 +106,9 @@ describe("ReactiveQueryField", () => {
       id: 1,
       number_of_book_reviews: 1,
     });
-    expect(queries[2]).toMatchInlineSnapshot(
-      `"SELECT count("br".id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2"`,
+    // The query count changes when preloading is enabled (right?) so use `toContain`
+    expect(queries).toContain(
+      `SELECT count("br".id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2`,
     );
   });
 

--- a/packages/tests/integration/src/setupTestEnv.ts
+++ b/packages/tests/integration/src/setupTestEnv.ts
@@ -2,7 +2,7 @@ import { GetEnvVars } from "env-cmd";
 
 export default async function globalSetup() {
   process.env.TZ = "UTC";
-  process.env.DEBUG = "knex:query,knex:bindings";
+  // process.env.DEBUG = "knex:query,knex:bindings";
   // process.env.DEBUG = "knex:*";
   Object.entries(await GetEnvVars()).forEach(([key, value]) => (process.env[key] = value));
 }

--- a/packages/tests/integration/src/setupTestEnv.ts
+++ b/packages/tests/integration/src/setupTestEnv.ts
@@ -2,7 +2,7 @@ import { GetEnvVars } from "env-cmd";
 
 export default async function globalSetup() {
   process.env.TZ = "UTC";
-  // process.env.DEBUG = "knex:query,knex:bindings";
+  process.env.DEBUG = "knex:query,knex:bindings";
   // process.env.DEBUG = "knex:*";
   Object.entries(await GetEnvVars()).forEach(([key, value]) => (process.env[key] = value));
 }


### PR DESCRIPTION
This is a fairly massive rewrite of the SQL that `em.find` issues for o2m queries.

Specifically when filtering on children, i.e. `em.find(Author, { books: ...conditions... })`, previously we would `LEFT OUTER JOIN` into whatever `N` child rows, and then use `SELECT DISTINCT` against the `a.id`, to avoid having a singular `authors` row returned multiple times (i.e. once per book):

```sql
SELECT DISTINCT a.* FROM authors as A
  LEFT OUTER JOIN books b ON b.author_id = a.id
  LEFT OUTER JOIN comments c ON c.author_id = a.id
```

This `SELECT DISTINCT` worked, but created performance issues if multiple large child collections were queried, i.e. something like `em.find(Author, { books: ...conditions..., comments: ...conditions... })`.

With this query, if a single Author has `N` books and `M` comments, doing a `LEFT OUTER JOIN` into both of these `books` and `comments` tables would create `N x M` tuples, which Postgres had to hold in memory, to evaluate the "did any of this author's books match ...conditions... and any of this author's comments match ...conditions..." before `DISTINCT`-ing all the tuples back down to a single author.

Granted, for small values of `N` and `M` this was fine, but in production we've had ~3-4 queries have big enough values that it caused ~1-2 second long queries.

To avoid this `N x M` explosion, this PR rewrites the SQL that is generated for the query from `SELECT FROM authors LEFT OUTER JOIN books on b.author_id = a.id LEFT OUTER JOIN comments on c.author_id = a.id` (which causes a combination of rows) to use `CROSS JOIN LATERAL`s:

```sql
SELECT * FROM authors as A
  CROSS JOIN LATERAL (
    SELECT count(*) as _ FROM books b WHERE b.author_id = a.id
  ) as b
  CROSS JOIN LATERAL (
    SELECT count(*) as _ FROM comments c WHERE c.author_id = a.id
  )
```

Where now each `CROSS JOIN LATERAL` is an aggregate query (that is guaranteed to return only 1 row, for all of the author's books, and 1 row for all of the author's comments), such that having multiple o2m clauses in an `em.find`, no longer causes the `N x M` combination of tuples.

Which means we can stop adding the `SELECT DISTINCT` to the queries all together, as we'll never have "more than 1 row per author" to worry about.

---

In addition to just better/more performant queries, the "aggregate all children" approach also gives us an easy way to count the number of children (see the `count(*)` above), so we can add that support to the API like:

```
// find authors with exactly 2 books
em.find(Author, { books: { $count: 2 } });

// find authors with more than 3 books
em.find(Author, { books: { $count: { gt: 3 } } });
```

---

Lateral joins are somewhat esoteric, but actually widely supported outside of Postgres, and also had already been a tool we're using for the (opt-in / disabled-by-default) JSON preloading.

The JSON preloading in particular wanted to use the same "aggregate all of my (books) children into a single (per author) row", so `LATERAL JOIN`s were a great fit.

Given `em.find` itself uses `LATERAL JOIN`s, this PR also re-worked the JSON preloading to use the new/blessed lateral join infra, instead of it's original/proof-of-concept version.

---

Moving the child relations into "aggregate only" lateral join rows also meant that `em.find` batching had to be written from a "final join with a really big `ON` clause" to an "up-front cross join than injects each parameter set as a new row".

This is likely a better query pattern anyway.