### PR TITLE
feat: Export temporal CustomSerde mappers.

### DIFF
--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -89,6 +89,7 @@ export {
 } from "./rules";
 export { setRuntimeConfig, type RuntimeConfig } from "./runtimeConfig";
 export * from "./serde";
+export * from "./temporalMappers";
 export * from "./typeMap";
 export { asNew, assertNever, cleanStringValue, fail, indexBy } from "./utils";
 export { ensureWithLoaded, WithLoaded, withLoaded } from "./withLoaded";

--- a/packages/orm/src/temporalMappers.ts
+++ b/packages/orm/src/temporalMappers.ts
@@ -9,6 +9,7 @@ const temporalNotAvailable = {
   toDb: () => fail("Temporal not available"),
 };
 
+/** Converts Postgres `DATE` to/from Temporal.PlainDate. */
 export const plainDateMapper: CustomSerde<Temporal.PlainDate, string> = t
   ? {
       fromDb: t.PlainDate.from,
@@ -16,6 +17,7 @@ export const plainDateMapper: CustomSerde<Temporal.PlainDate, string> = t
     }
   : temporalNotAvailable;
 
+/** Converts Postgres `TIME` to/from Temporal.PlainTime. */
 export const plainTimeMapper: CustomSerde<Temporal.PlainTime, string> = t
   ? {
       fromDb: t.PlainTime.from,
@@ -23,6 +25,7 @@ export const plainTimeMapper: CustomSerde<Temporal.PlainTime, string> = t
     }
   : temporalNotAvailable;
 
+/** Converts Postgres `TIMESTAMP` / `TIMESTAMP WITHOUT TIME ZONE` to/from Temporal.PlainDateTime. */
 export const plainDateTimeMapper: CustomSerde<Temporal.PlainDateTime, string> = t
   ? {
       // Should look like `2018-01-01 10:00:00`
@@ -31,6 +34,14 @@ export const plainDateTimeMapper: CustomSerde<Temporal.PlainDateTime, string> = 
     }
   : temporalNotAvailable;
 
+/**
+ * Converts Postgres `TIMESTAMPTZ`, `TIMESTAMPTZ WITH TIME ZONE` to/from Temporal.PlainDateTime.
+ *
+ * Specifically Postgres uses ISO 8601, which Temporal does as well, except that:
+ *
+ * - PG uses a space instead of `T` between the date/time, and
+ * - Temporal needs `[UTC]`appended, b/c even with the numeric offset, it wants to know which specific zone.
+ */
 export const zonedDateTimeMapper: CustomSerde<Temporal.ZonedDateTime, string> = t
   ? {
       // Should we use the application's time zone here? Afaiu we're using an explicit


### PR DESCRIPTION
This lets downstream applications use them in their own code, to use when reading the now-raw-strings date values off the wire of custom SQL queries.

I.e. previously node-pg converted all of DATE/TIMESTAMP/TIMESTAMPTZ to JS Dates, but now Joist proactively tells the node-pg driver to leave them as strings, and maps them in its serde layer.

We could potentially add a configuration option that pushes the Temporal-ization back into the node-pg driver, so that users would immediately see the Temporal types, even from their custom SQL queries, but it seemed cute (admittedly maybe too cute) to let Joist's serde layer do this, b/c it can convert the dates lazily, only upon access.

But it's likely subjective whether this perf benefit is worth the decreased DX of custom queries getting back strings (granted, they were already getting back "the wrong thing" in JS dates, so the custom handling is not new per se).