### PR TITLE
feat: Support ordering by o2m attributes.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -678,7 +678,10 @@ function generateOrderFields(meta: EntityDbMetadata): Code[] {
   const m2o = meta.manyToOnes.map(({ fieldName, otherEntity }) => {
     return code`${fieldName}?: ${otherEntity.orderType};`;
   });
-  return [...maybeId, ...primitives, ...enums, ...pgEnums, ...m2o];
+  const o2m = meta.oneToManys.map(({ fieldName, otherEntity }) => {
+    return code`${fieldName}?: ${otherEntity.orderType};`;
+  });
+  return [...maybeId, ...primitives, ...enums, ...pgEnums, ...m2o, ...o2m];
 }
 
 function createPrimitives(meta: EntityDbMetadata, entity: Entity) {

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -551,7 +551,7 @@ export function parseFindQuery(
         if (lateralJoins.length === 0) {
           // We can add the orderBy directly against the column
           orderBys.push({
-            alias: `${alias}${field.aliasSuffix ?? ""}`,
+            alias: `${alias}${field.aliasSuffix}`,
             column: column.columnName,
             order: value as OrderBy,
           });
@@ -561,7 +561,7 @@ export function parseFindQuery(
           const lastJoin = rest[rest.length - 1] ?? topJoin;
           const as = `_${alias}_${column.columnName}_sum`;
           lastJoin.query.selects.push({
-            sql: `SUM(${alias}.${column.columnName}) AS ${as}`,
+            sql: `SUM(${alias}${field.aliasSuffix}.${column.columnName}) AS ${as}`,
             aliases: [alias],
             bindings: [],
           });

--- a/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
@@ -38,7 +38,17 @@ import {
   type ValueGraphQLFilter,
 } from "joist-orm";
 import { type Context } from "../../context.js";
-import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities.js";
+import {
+  Author,
+  authorMeta,
+  Book,
+  type BookId,
+  bookMeta,
+  type BookOrder,
+  type Entity,
+  EntityManager,
+  newAuthor,
+} from "../entities.js";
 
 export type AuthorId = Flavor<string, "Author">;
 
@@ -89,6 +99,7 @@ export interface AuthorOrder {
   delete?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
+  books?: BookOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
@@ -45,6 +45,7 @@ import {
   T1Book,
   type T1BookId,
   t1BookMeta,
+  type T1BookOrder,
 } from "../entities";
 
 export type T1AuthorId = Flavor<number, "T1Author">;
@@ -78,6 +79,7 @@ export interface T1AuthorGraphQLFilter {
 export interface T1AuthorOrder {
   id?: OrderBy;
   firstName?: OrderBy;
+  t1Books?: T1BookOrder;
 }
 
 export const t1AuthorConfig = new ConfigApi<T1Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
@@ -87,6 +87,7 @@ export interface T2AuthorOrder {
   id?: OrderBy;
   firstName?: OrderBy;
   favoriteBook?: T2BookOrder;
+  t2Books?: T2BookOrder;
 }
 
 export const t2AuthorConfig = new ConfigApi<T2Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
@@ -87,6 +87,7 @@ export interface T2BookOrder {
   id?: OrderBy;
   title?: OrderBy;
   author?: T2AuthorOrder;
+  t2Authors?: T2AuthorOrder;
 }
 
 export const t2BookConfig = new ConfigApi<T2Book, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
@@ -87,6 +87,7 @@ export interface T3AuthorOrder {
   id?: OrderBy;
   firstName?: OrderBy;
   favoriteBook?: T3BookOrder;
+  t3Books?: T3BookOrder;
 }
 
 export const t3AuthorConfig = new ConfigApi<T3Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
@@ -87,6 +87,7 @@ export interface T3BookOrder {
   id?: OrderBy;
   title?: OrderBy;
   author?: T3AuthorOrder;
+  t3Authors?: T3AuthorOrder;
 }
 
 export const t3BookConfig = new ConfigApi<T3Book, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
@@ -87,6 +87,7 @@ export interface T4AuthorOrder {
   id?: OrderBy;
   firstName?: OrderBy;
   favoriteBook?: T4BookOrder;
+  t4Books?: T4BookOrder;
 }
 
 export const t4AuthorConfig = new ConfigApi<T4Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
@@ -87,6 +87,7 @@ export interface T4BookOrder {
   id?: OrderBy;
   title?: OrderBy;
   author?: T4AuthorOrder;
+  t4Authors?: T4AuthorOrder;
 }
 
 export const t4BookConfig = new ConfigApi<T4Book, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
@@ -45,6 +45,7 @@ import {
   T5Book,
   type T5BookId,
   t5BookMeta,
+  type T5BookOrder,
 } from "../entities";
 
 export type T5AuthorId = Flavor<number, "T5Author">;
@@ -78,6 +79,7 @@ export interface T5AuthorGraphQLFilter {
 export interface T5AuthorOrder {
   id?: OrderBy;
   firstName?: OrderBy;
+  t5Books?: T5BookOrder;
 }
 
 export const t5AuthorConfig = new ConfigApi<T5Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
@@ -51,6 +51,7 @@ import {
   T5BookReview,
   type T5BookReviewId,
   t5BookReviewMeta,
+  type T5BookReviewOrder,
 } from "../entities";
 
 export type T5BookId = Flavor<number, "T5Book">;
@@ -90,6 +91,7 @@ export interface T5BookOrder {
   id?: OrderBy;
   title?: OrderBy;
   author?: T5AuthorOrder;
+  reviews?: T5BookReviewOrder;
 }
 
 export const t5BookConfig = new ConfigApi<T5Book, Context>();

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -3567,6 +3567,33 @@ describe("EntityManager.queries", () => {
     });
   });
 
+  describe("orderBy", () => {
+    it("can order by child m2o", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ author_id: 1, title: "b1" });
+      await insertBook({ author_id: 1, title: "b2" });
+      await insertBookReview({ book_id: 1, rating: 1 });
+      await insertBookReview({ book_id: 2, rating: 1 });
+      await insertBookReview({ book_id: 2, rating: 1 });
+      const em = newEntityManager();
+      const books = await em.find(Book, {}, { orderBy: { reviews: { rating: "DESC" } } });
+      expect(books).toMatchEntity([{ title: "b2" }, { title: "b1" }]);
+    });
+
+    it("can order by nested child m2o", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ author_id: 1, title: "b1" });
+      await insertBook({ author_id: 2, title: "b2" });
+      await insertBookReview({ book_id: 1, rating: 1 });
+      await insertBookReview({ book_id: 2, rating: 1 });
+      await insertBookReview({ book_id: 2, rating: 1 });
+      const em = newEntityManager();
+      const authors = await em.find(Author, {}, { orderBy: { books: { reviews: { rating: "DESC" } } } });
+      expect(authors).toMatchEntity([{ firstName: "a2" }, { firstName: "a1" }]);
+    });
+  });
+
   describe("count", () => {
     it("can count", async () => {
       await insertAuthor({ first_name: "a1" });

--- a/packages/tests/integration/src/EntityManager.softDeletes.test.ts
+++ b/packages/tests/integration/src/EntityManager.softDeletes.test.ts
@@ -1,8 +1,7 @@
 import { insertAuthor, insertBook, insertBookToTag, insertPublisher, insertTag } from "@src/entities/inserts";
+import { newEntityManager } from "@src/testEm";
 import { Author, Book, Publisher, Tag } from "./entities";
 import { jan1 } from "./testDates";
-
-import { newEntityManager } from "@src/testEm";
 
 describe("EntityManager.softDeletes", () => {
   it("o2m.get skips soft deleted entities", async () => {

--- a/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
@@ -57,6 +57,7 @@ import {
   AuthorSchedule,
   type AuthorScheduleId,
   authorScheduleMeta,
+  type AuthorScheduleOrder,
   Book,
   type BookId,
   bookMeta,
@@ -68,6 +69,7 @@ import {
   Comment,
   type CommentId,
   commentMeta,
+  type CommentOrder,
   type Entity,
   EntityManager,
   FavoriteShape,
@@ -89,6 +91,7 @@ import {
   TaskNew,
   type TaskNewId,
   taskNewMeta,
+  type TaskNewOrder,
   User,
   type UserId,
   userMeta,
@@ -359,6 +362,13 @@ export interface AuthorOrder {
   currentDraftBook?: BookOrder;
   favoriteBook?: BookOrder;
   publisher?: PublisherOrder;
+  mentees?: AuthorOrder;
+  books?: BookOrder;
+  reviewerBooks?: BookOrder;
+  schedules?: AuthorScheduleOrder;
+  comments?: CommentOrder;
+  spotlightAuthorPublishers?: PublisherOrder;
+  tasks?: TaskNewOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/integration/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookCodegen.ts
@@ -54,10 +54,12 @@ import {
   BookAdvance,
   type BookAdvanceId,
   bookAdvanceMeta,
+  type BookAdvanceOrder,
   bookMeta,
   BookReview,
   type BookReviewId,
   bookReviewMeta,
+  type BookReviewOrder,
   Comment,
   type CommentId,
   commentMeta,
@@ -193,6 +195,9 @@ export interface BookOrder {
   author?: AuthorOrder;
   reviewer?: AuthorOrder;
   randomComment?: CommentOrder;
+  advances?: BookAdvanceOrder;
+  reviews?: BookReviewOrder;
+  comments?: CommentOrder;
 }
 
 export const bookConfig = new ConfigApi<Book, Context>();

--- a/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
@@ -41,6 +41,7 @@ import {
   ChildGroup,
   type ChildGroupId,
   childGroupMeta,
+  type ChildGroupOrder,
   childMeta,
   type Entity,
   EntityManager,
@@ -86,6 +87,7 @@ export interface ChildOrder {
   name?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
+  groups?: ChildGroupOrder;
 }
 
 export const childConfig = new ConfigApi<Child, Context>();

--- a/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
@@ -46,6 +46,7 @@ import {
   ChildItem,
   type ChildItemId,
   childItemMeta,
+  type ChildItemOrder,
   childMeta,
   type ChildOrder,
   type Entity,
@@ -108,6 +109,7 @@ export interface ChildGroupOrder {
   updatedAt?: OrderBy;
   childGroupId?: ChildOrder;
   parentGroup?: ParentGroupOrder;
+  childItems?: ChildItemOrder;
 }
 
 export const childGroupConfig = new ConfigApi<ChildGroup, Context>();

--- a/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
@@ -52,6 +52,7 @@ import {
   Book,
   type BookId,
   bookMeta,
+  type BookOrder,
   BookReview,
   Comment,
   commentMeta,
@@ -148,6 +149,7 @@ export interface CommentOrder {
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
   user?: UserOrder;
+  books?: BookOrder;
 }
 
 export const commentConfig = new ConfigApi<Comment, Context>();

--- a/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
@@ -44,6 +44,7 @@ import {
   BookReview,
   type BookReviewId,
   bookReviewMeta,
+  type BookReviewOrder,
   Critic,
   CriticColumn,
   type CriticColumnId,
@@ -131,6 +132,7 @@ export interface CriticOrder {
   updatedAt?: OrderBy;
   favoriteLargePublisher?: LargePublisherOrder;
   group?: PublisherGroupOrder;
+  bookReviews?: BookReviewOrder;
 }
 
 export const criticConfig = new ConfigApi<Critic, Context>();

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -44,6 +44,7 @@ import {
   Critic,
   type CriticId,
   criticMeta,
+  type CriticOrder,
   type Entity,
   EntityManager,
   Image,
@@ -63,6 +64,7 @@ import {
   User,
   type UserId,
   userMeta,
+  type UserOrder,
 } from "../entities";
 
 export type LargePublisherId = Flavor<string, "Publisher">;
@@ -104,6 +106,8 @@ export interface LargePublisherGraphQLFilter extends PublisherGraphQLFilter {
 export interface LargePublisherOrder extends PublisherOrder {
   sharedColumn?: OrderBy;
   country?: OrderBy;
+  critics?: CriticOrder;
+  users?: UserOrder;
 }
 
 export const largePublisherConfig = new ConfigApi<LargePublisher, Context>();

--- a/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
@@ -40,6 +40,7 @@ import {
   ChildGroup,
   type ChildGroupId,
   childGroupMeta,
+  type ChildGroupOrder,
   type Entity,
   EntityManager,
   newParentGroup,
@@ -48,6 +49,7 @@ import {
   ParentItem,
   type ParentItemId,
   parentItemMeta,
+  type ParentItemOrder,
 } from "../entities";
 
 export type ParentGroupId = Flavor<string, "ParentGroup">;
@@ -93,6 +95,8 @@ export interface ParentGroupOrder {
   name?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
+  childGroups?: ChildGroupOrder;
+  parentItems?: ParentItemOrder;
 }
 
 export const parentGroupConfig = new ConfigApi<ParentGroup, Context>();

--- a/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
@@ -42,6 +42,7 @@ import {
   ChildItem,
   type ChildItemId,
   childItemMeta,
+  type ChildItemOrder,
   type Entity,
   EntityManager,
   newParentItem,
@@ -98,6 +99,7 @@ export interface ParentItemOrder {
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
   parentGroup?: ParentGroupOrder;
+  childItems?: ChildItemOrder;
 }
 
 export const parentItemConfig = new ConfigApi<ParentItem, Context>();

--- a/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
@@ -51,14 +51,17 @@ import {
   BookAdvance,
   type BookAdvanceId,
   bookAdvanceMeta,
+  type BookAdvanceOrder,
   Comment,
   type CommentId,
   commentMeta,
+  type CommentOrder,
   type Entity,
   EntityManager,
   Image,
   type ImageId,
   imageMeta,
+  type ImageOrder,
   LargePublisher,
   newPublisher,
   Publisher,
@@ -219,6 +222,10 @@ export interface PublisherOrder {
   favoriteAuthor?: AuthorOrder;
   group?: PublisherGroupOrder;
   spotlightAuthor?: AuthorOrder;
+  authors?: AuthorOrder;
+  bookAdvances?: BookAdvanceOrder;
+  comments?: CommentOrder;
+  images?: ImageOrder;
 }
 
 export const publisherConfig = new ConfigApi<Publisher, Context>();

--- a/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
@@ -54,6 +54,7 @@ import {
   publisherGroupMeta,
   type PublisherId,
   publisherMeta,
+  type PublisherOrder,
   SmallPublisher,
   SmallPublisherGroup,
   type SmallPublisherId,
@@ -116,6 +117,7 @@ export interface PublisherGroupOrder {
   numberOfBookReviews?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
+  publishers?: PublisherOrder;
 }
 
 export const publisherGroupConfig = new ConfigApi<PublisherGroup, Context>();

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -67,6 +67,7 @@ import {
   User,
   type UserId,
   userMeta,
+  type UserOrder,
 } from "../entities";
 
 export type SmallPublisherId = Flavor<string, "Publisher">;
@@ -129,6 +130,8 @@ export interface SmallPublisherOrder extends PublisherOrder {
   allAuthorNames?: OrderBy;
   selfReferential?: SmallPublisherOrder;
   group?: SmallPublisherGroupOrder;
+  smallPublishers?: SmallPublisherOrder;
+  users?: UserOrder;
 }
 
 export const smallPublisherConfig = new ConfigApi<SmallPublisher, Context>();

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
@@ -50,6 +50,7 @@ import {
   smallPublisherGroupMeta,
   type SmallPublisherId,
   smallPublisherMeta,
+  type SmallPublisherOrder,
 } from "../entities";
 
 export type SmallPublisherGroupId = Flavor<string, "PublisherGroup">;
@@ -80,6 +81,7 @@ export interface SmallPublisherGroupGraphQLFilter extends PublisherGroupGraphQLF
 
 export interface SmallPublisherGroupOrder extends PublisherGroupOrder {
   smallName?: OrderBy;
+  publishers?: SmallPublisherOrder;
 }
 
 export const smallPublisherGroupConfig = new ConfigApi<SmallPublisherGroup, Context>();

--- a/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
@@ -57,6 +57,7 @@ import {
   TaskItem,
   type TaskItemId,
   taskItemMeta,
+  type TaskItemOrder,
   taskMeta,
   TaskNew,
   type TaskNewId,
@@ -160,6 +161,8 @@ export interface TaskOrder {
   updatedAt?: OrderBy;
   type?: OrderBy;
   copiedFrom?: TaskOrder;
+  copiedTo?: TaskOrder;
+  taskTaskItems?: TaskItemOrder;
 }
 
 export const taskConfig = new ConfigApi<Task, Context>();

--- a/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
@@ -56,6 +56,7 @@ import {
   TaskItem,
   type TaskItemId,
   taskItemMeta,
+  type TaskItemOrder,
   TaskNew,
   taskNewMeta,
   type TaskOpts,
@@ -116,6 +117,9 @@ export interface TaskNewOrder extends TaskOrder {
   selfReferential?: TaskNewOrder;
   specialNewAuthor?: AuthorOrder;
   copiedFrom?: TaskNewOrder;
+  newTaskTaskItems?: TaskItemOrder;
+  selfReferentialTasks?: TaskNewOrder;
+  copiedTo?: TaskNewOrder;
 }
 
 export const taskNewConfig = new ConfigApi<TaskNew, Context>();

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -45,6 +45,7 @@ import {
   Comment,
   type CommentId,
   commentMeta,
+  type CommentOrder,
   type Entity,
   EntityManager,
   newTaskOld,
@@ -60,6 +61,7 @@ import {
   TaskItem,
   type TaskItemId,
   taskItemMeta,
+  type TaskItemOrder,
   TaskOld,
   taskOldMeta,
   type TaskOpts,
@@ -122,6 +124,10 @@ export interface TaskOldOrder extends TaskOrder {
   specialOldField?: OrderBy;
   parentOldTask?: TaskOldOrder;
   copiedFrom?: TaskOldOrder;
+  comments?: CommentOrder;
+  oldTaskTaskItems?: TaskItemOrder;
+  tasks?: TaskOldOrder;
+  copiedTo?: TaskOldOrder;
 }
 
 export const taskOldConfig = new ConfigApi<TaskOld, Context>();

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -57,6 +57,7 @@ import {
   Comment,
   type CommentId,
   commentMeta,
+  type CommentOrder,
   type Entity,
   EntityManager,
   LargePublisher,
@@ -186,6 +187,8 @@ export interface UserOrder {
   updatedAt?: OrderBy;
   manager?: UserOrder;
   authorManyToOne?: AuthorOrder;
+  createdComments?: CommentOrder;
+  directs?: UserOrder;
 }
 
 export const userConfig = new ConfigApi<User, Context>();

--- a/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
@@ -36,7 +36,17 @@ import {
   type ValueGraphQLFilter,
 } from "joist-orm";
 import { type Context } from "src/context";
-import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
+import {
+  Author,
+  authorMeta,
+  Book,
+  type BookId,
+  bookMeta,
+  type BookOrder,
+  type Entity,
+  EntityManager,
+  newAuthor,
+} from "../entities";
 
 export type AuthorId = Flavor<number, "Author">;
 
@@ -82,6 +92,7 @@ export interface AuthorOrder {
   lastName?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
+  books?: BookOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
@@ -45,6 +45,7 @@ import {
   Painting,
   type PaintingId,
   paintingMeta,
+  type PaintingOrder,
 } from "../entities";
 
 export type ArtistId = Flavor<string, "Artist">;
@@ -91,6 +92,7 @@ export interface ArtistOrder {
   lastName?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
+  paintings?: PaintingOrder;
 }
 
 export const artistConfig = new ConfigApi<Artist, Context>();

--- a/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
@@ -38,7 +38,17 @@ import {
   type ValueGraphQLFilter,
 } from "joist-orm";
 import { type Context } from "src/context";
-import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
+import {
+  Author,
+  authorMeta,
+  Book,
+  type BookId,
+  bookMeta,
+  type BookOrder,
+  type Entity,
+  EntityManager,
+  newAuthor,
+} from "../entities";
 
 export type AuthorId = Flavor<string, "Author">;
 
@@ -89,6 +99,7 @@ export interface AuthorOrder {
   delete?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
+  books?: BookOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
@@ -37,7 +37,17 @@ import {
 } from "joist-orm";
 import { type Context } from "src/context";
 import { Temporal } from "temporal-polyfill";
-import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
+import {
+  Author,
+  authorMeta,
+  Book,
+  type BookId,
+  bookMeta,
+  type BookOrder,
+  type Entity,
+  EntityManager,
+  newAuthor,
+} from "../entities";
 
 export type AuthorId = Flavor<string, "Author">;
 
@@ -118,6 +128,7 @@ export interface AuthorOrder {
   timeToMicros?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
+  books?: BookOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
@@ -42,12 +42,15 @@ import {
   Book,
   type BookId,
   bookMeta,
+  type BookOrder,
   BookReview,
   type BookReviewId,
   bookReviewMeta,
+  type BookReviewOrder,
   Comment,
   type CommentId,
   commentMeta,
+  type CommentOrder,
   type Entity,
   EntityManager,
   newAuthor,
@@ -105,6 +108,9 @@ export interface AuthorOrder {
   lastName?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
+  books?: BookOrder;
+  bookReviews?: BookReviewOrder;
+  comments?: CommentOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
@@ -48,6 +48,7 @@ import {
   Comment,
   type CommentId,
   commentMeta,
+  type CommentOrder,
   type Entity,
   EntityManager,
   newBook,
@@ -98,6 +99,7 @@ export interface BookOrder {
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
   author?: AuthorOrder;
+  comments?: CommentOrder;
 }
 
 export const bookConfig = new ConfigApi<Book, Context>();

--- a/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
@@ -36,7 +36,17 @@ import {
   type ValueGraphQLFilter,
 } from "joist-orm";
 import { type Context } from "src/context";
-import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
+import {
+  Author,
+  authorMeta,
+  Book,
+  type BookId,
+  bookMeta,
+  type BookOrder,
+  type Entity,
+  EntityManager,
+  newAuthor,
+} from "../entities";
 
 export type AuthorId = Flavor<string, "Author">;
 
@@ -82,6 +92,7 @@ export interface AuthorOrder {
   lastName?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
+  books?: BookOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();


### PR DESCRIPTION
The new lateral join approach (which aggregates/counts each child separately during it's own `lateral join` subquery), makes it relatively easy to throw in an extra `SUM` into the subquery, and get support for ordering by "the sum of my children's column".

I.e. this find:

```ts
const authors = await em.find(
  Author,
  {},
  { orderBy: { books: { reviews: { rating: "DESC" } } } },
);
```

Generates the following SQL:

```sql
SELECT
  a.*
FROM authors AS a
CROSS JOIN LATERAL (
  SELECT
    count(*) as _,
    SUM(br._br_rating_sum) AS _br_rating_sum
  FROM books AS b CROSS JOIN LATERAL (
    SELECT
      count(*) as _,
      SUM(br.rating) AS _br_rating_sum
    FROM book_reviews AS br
    WHERE b.id = br.book_id
  ) AS br
  WHERE a.id = b.author_id AND b.deleted_at IS NULL
) AS b
WHERE a.deleted_at IS NULL
ORDER BY
  b._br_rating_sum DESC,
  a.id ASC 
```

Note that the `SUM` will only include child rows that *matched any inline conditions*.

I.e. this query:

```ts
const authors = await em.find(
  Author,
  { books: { reviews: { rating: 1 },
  { orderBy: { books: { reviews: { rating: "DESC" } } } },
);
```

Would return books that had a `rating: 1` review, and return them ordered by the number of the 1-rated reviews.

Although conditions be used to work around this:


```ts
const authors = await em.find(
  Author,
  { books: { reviews: { as: br },
  { orderBy: { books: { reviews: { rating: "DESC" } } } },
  {
     conditions: { and: [br.rating.eq(1)] },
  }
);
```

This moves the "rating eq 1" filtering to be "later" in the top-level `WHERE` clause, so all BookReviews will be included in the order by:

 ```sql
SELECT
  a.*
FROM authors AS a
CROSS JOIN LATERAL (
  SELECT
    count(*) as _,
    SUM(br._br_rating_sum) AS _br_rating_sum,
    BOOL_OR(br._br_rating_0 AS _br_rating_0,
  FROM books AS b CROSS JOIN LATERAL (
    SELECT
      count(*) as _,
      SUM(br.rating) AS _br_rating_sum,
      BOOL_OR(br.rating = 1) AS _br_rating_0,
    FROM book_reviews AS br
    WHERE b.id = br.book_id
  ) AS br
  WHERE a.id = b.author_id AND b.deleted_at IS NULL
) AS b
WHERE
  a.deleted_at IS NULL
  AND b._br_rating_0
ORDER BY
  b._br_rating_sum DESC,
  a.id ASC 
```

