### PR TITLE
feat: Add easier overloads to EM.setFieldLogging.

### DIFF
--- a/docs/docs/logging/field-logging.md
+++ b/docs/docs/logging/field-logging.md
@@ -10,12 +10,11 @@ Joist provides field logging to visualize when/why fields are being set on entit
 Field logging is currently enabled on an individual `EntityManager` instance:
 
 ```ts
-import { FieldLogger} from "joist-orm";
-// This will log any field set field sets on this EntityManager
-em.setFieldLogging(new FieldLogger());
+// Logs all field sets on this EntityManager
+em.setFieldLogging(true);
 ```
 
-This will produce output like:
+This will produce console output like:
 
 ```
 a#1.firstName = a1 at newAuthor.ts:13
@@ -26,7 +25,7 @@ b#1.author = Author#1 at newBook.ts:9
 b#1.notes = Notes for title at defaults.ts:28
 ```
 
-Where `a#1` is the tagged id of a new/unsaved `Author` instance, and `b#` is the tagged if of a new/unsaved `Book` instance.
+Where `a#1` is the tagged id of a new/unsaved `Author` instance, and `b#` is the tagged id of a new/unsaved `Book` instance.
 
 The `at (file):(line)`, which should help track down which hook or method is setting the field.
 
@@ -36,35 +35,46 @@ The code that determines the correct `at (file):(line)` to output is currently a
 
 :::
 
-### Filtering by Entity
+### Filtering Shorthand
 
-If you want to log only sets for a specific entity type, you can pass a `watches` argument to the `FieldLogger` constructor:
+If you want to quickly setup field logging, we support a string "spec" shorthand:
 
 ```ts
-em.setFieldLogging(new FieldLogger(
-  [{ entity: "Author" }],
-));
+// Single entity, multiple fields
+em.setFieldLogging("Author.firstName,lastName");
+// Multiple entities, breakpoints enabled
+em.setFieldLogging(["Author.lastName", "Book.title!"]);
 ```
 
-### Filtering by Entity and Field
+### Filtering by Entity & Fields
 
-If you want to log only sets for a specific entity *and* field name, you can pass a `watches` argument to the `FieldLogger` constructor:
+If you want to log only sets for a specific entity, or certain fields, you can pass a `watches` argument to the `FieldLogger` constructor:
 
 ```ts
-em.setFieldLogging(new FieldLogger(
-  [{ entity: "Author", fieldNames: ["firstName"] }],
-));
+em.setFieldLogging(new FieldLogger([
+  // Log all field sets for Authors
+  { entity: "Author" },
+  // Log only title changes to Books
+  { entity: "Book", fieldNames: ["title"] },
+]));
 ```
 
 ### Enabling Breakpoints
 
-If you're running code in debug mode, you can also tell Joist to trigger a breakpoint, whenever a field is set:
+If you're running in debug mode, you can tell Joist to trigger a breakpoint on the field set:
 
 ```ts
+// Use a ! shorthand in the spec string
+em.setFieldLogging("Author.firstName!");
+// Or pass `breakpoint: true` to the FieldLogger constructor
 em.setFieldLogging(new FieldLogger(
   [{ entity: "Author", fieldNames: ["firstName"], breakpoint: true }],
 ));
 ```
+
+And your debugger will stop anytime the `firstName` field is mutated.
+
+This can be extremely useful for finding "who" is setting/changing a field in more complex/multi-step scenarios.
 
 ## Colorized Output
 

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -29,6 +29,7 @@ import {
   EnumField,
   ExpressionFilter,
   FieldLogger,
+  FieldLoggerWatch,
   FilterWithAlias,
   GraphQLFilterOf,
   GraphQLFilterWithAlias,
@@ -1642,8 +1643,24 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
     this.#rm.setLogger(typeof arg === "boolean" ? (arg ? new ReactionLogger() : undefined) : arg);
   }
 
-  setFieldLogging(logger: FieldLogger): void {
-    this.#fieldLogger = logger;
+  /** Accepts `Author#firstName,lastName`. */
+  setFieldLogging(spec: string): void;
+  /** Accepts `["Author#firstName,lastName", "Book#title"]`. */
+  setFieldLogging(spec: string[]): void;
+  /** Sets this EntityManager's field logger. */
+  setFieldLogging(logger: FieldLogger): void;
+  setFieldLogging(arg: FieldLogger | string | string[]): void {
+    if (typeof arg === "string" || Array.isArray(arg)) {
+      const specs = Array.isArray(arg) ? arg : [arg];
+      const watching: FieldLoggerWatch[] = specs.map((spec) => {
+        const breakpoint = spec.endsWith("!");
+        const [entity, fields] = spec.replace(/!$/, "").split("#");
+        return { entity, fieldNames: fields.split(","), breakpoint };
+      });
+      this.#fieldLogger = new FieldLogger(watching);
+    } else {
+      this.#fieldLogger = arg;
+    }
   }
 
   async [Symbol.asyncDispose](): Promise<void> {

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1649,12 +1649,16 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
   setFieldLogging(spec: string[]): void;
   /** Sets this EntityManager's field logger. */
   setFieldLogging(logger: FieldLogger): void;
-  setFieldLogging(arg: FieldLogger | string | string[]): void {
-    if (typeof arg === "string" || Array.isArray(arg)) {
+  /** Enables/disables field logging for all fields. */
+  setFieldLogging(enabled: boolean): void;
+  setFieldLogging(arg: FieldLogger | string | string[] | boolean): void {
+    if (typeof arg === "boolean") {
+      this.#fieldLogger = arg ? new FieldLogger([]) : undefined;
+    } else if (typeof arg === "string" || Array.isArray(arg)) {
       const specs = Array.isArray(arg) ? arg : [arg];
       const watching: FieldLoggerWatch[] = specs.map((spec) => {
         const breakpoint = spec.endsWith("!");
-        const [entity, fields] = spec.replace(/!$/, "").split("#");
+        const [entity, fields] = spec.replace(/!$/, "").split(".");
         return { entity, fieldNames: fields.split(","), breakpoint };
       });
       this.#fieldLogger = new FieldLogger(watching);


### PR DESCRIPTION
```ts
em.setFieldLogging("Author.firstName.lastName");
em.setFieldLogging(["Author.firstName", "Book.title!"]);
```

Fixes #1275