### PR TITLE
feat: Revert using lateral joins for o2m/m2m finds

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -678,10 +678,7 @@ function generateOrderFields(meta: EntityDbMetadata): Code[] {
   const m2o = meta.manyToOnes.map(({ fieldName, otherEntity }) => {
     return code`${fieldName}?: ${otherEntity.orderType};`;
   });
-  const o2m = meta.oneToManys.map(({ fieldName, otherEntity }) => {
-    return code`${fieldName}?: ${otherEntity.orderType};`;
-  });
-  return [...maybeId, ...primitives, ...enums, ...pgEnums, ...m2o, ...o2m];
+  return [...maybeId, ...primitives, ...enums, ...pgEnums, ...m2o];
 }
 
 function createPrimitives(meta: EntityDbMetadata, entity: Entity) {

--- a/packages/orm/src/AliasAssigner.ts
+++ b/packages/orm/src/AliasAssigner.ts
@@ -8,19 +8,13 @@ export class AliasAssigner {
     this.getAlias = this.getAlias.bind(this);
     // If we're assigning aliases into an existing query, get the current assignments
     if (query) {
-      const todo = [query];
-      while (todo.length > 0) {
-        const query = todo.pop()!;
-        for (const table of query.tables) {
-          // Ignore CTI base/sub aliases
-          if (table.alias.includes("_")) continue;
-          if (table.join === "lateral") {
-            this.maybeBumpIndex(table.table, table.alias);
-            todo.push(table.query);
-          } else {
-            this.maybeBumpIndex(table.table, table.alias);
-          }
-        }
+      for (const table of query.tables) {
+        // Ignore CTI base/sub aliases
+        if (table.alias.includes("_")) continue;
+        const abbrev = abbreviation(table.table);
+        const i = this.#aliases[abbrev] || 0;
+        const j = Number(table.alias.replace(abbrev, "")) + 1;
+        this.#aliases[abbrev] = Math.max(i, j);
       }
     }
   }
@@ -30,14 +24,5 @@ export class AliasAssigner {
     const i = this.#aliases[abbrev] || 0;
     this.#aliases[abbrev] = i + 1;
     return i === 0 ? abbrev : `${abbrev}${i}`;
-  }
-
-  /** Given an existing alias, like `a5`, make sure our internal `a = N` is at least 5 or higher. */
-  private maybeBumpIndex(tableName: string, alias: string): void {
-    const tag = abbreviation(tableName);
-    const ourN = this.#aliases[tag] || 0;
-    // Recover the `5` out of `pi5` by stripping the `pi` prefix
-    const newN = Number(alias.replace(tag, "")) + 1;
-    this.#aliases[tag] = Math.max(ourN, newN);
   }
 }

--- a/packages/orm/src/Aliases.ts
+++ b/packages/orm/src/Aliases.ts
@@ -37,9 +37,6 @@ export type Alias<T extends Entity> = {
         : FieldsOf<T>[P] extends { kind: "poly"; type: infer U extends Entity }
           ? PolyReferenceAlias<U>
           : never;
-} & {
-  /** Allow querying on "a parent that has no children". This is only valid when bound to child/collection relations. */
-  $count: CountAlias;
 };
 
 export interface PrimitiveAlias<V, N extends null | never> {
@@ -70,22 +67,6 @@ export interface EntityAlias<T> {
   gte(value: IdOf<T> | null | undefined): ExpressionCondition;
   lt(value: IdOf<T> | null | undefined): ExpressionCondition;
   lte(value: IdOf<T> | null | undefined): ExpressionCondition;
-}
-
-/**
- * Allows complex conditions on the number of matching children.
- *
- * Note that `$count` value will only count children that match *inline* conditions,
- * i.e. a query like:
- *
- * ```ts
- * await em.find(Author, { books: { $count: 1, status: BookStatus.Draft } });
- * ```
- *
- * Will find Author's that have a single book in Draft status.
- */
-export interface CountAlias {
-  eq(count: number | undefined | null): ExpressionCondition;
 }
 
 export const aliasMgmt = Symbol("aliasMgmt");
@@ -119,9 +100,6 @@ export function newAliasProxy<T extends Entity>(cstr: MaybeAbstractEntityConstru
     get(target, key: PropertyKey): any {
       if (key === aliasMgmt) {
         return mgmt;
-      }
-      if (key === "$count") {
-        return new CountAliasImpl(callbacks);
       }
       const field = meta.allFields[key as string] ?? fail(`No field ${String(key)} on ${cstr.name}`);
       switch (field.kind) {
@@ -445,24 +423,6 @@ class PolyReferenceAlias<T extends Entity> {
     // Track the conditions we've created to re-write the alias when we're bound
     this.callbacks.push((newMeta, newAlias) => {
       cond.alias = getMaybeCtiAlias(this.meta, this.field, newMeta, newAlias);
-    });
-    return cond;
-  }
-}
-
-class CountAliasImpl implements CountAlias {
-  constructor(protected callbacks: BindCallback[]) {}
-  eq(count: number | undefined | null): ExpressionCondition {
-    if (count === undefined) return skipCondition;
-    const cond: ColumnCondition = {
-      kind: "column",
-      alias: "unset",
-      column: "$count",
-      dbType: "int",
-      cond: { kind: "eq", value: count },
-    };
-    this.callbacks.push((_, newAlias) => {
-      cond.alias = newAlias;
     });
     return cond;
   }

--- a/packages/orm/src/EntityFilter.ts
+++ b/packages/orm/src/EntityFilter.ts
@@ -33,7 +33,7 @@ export type EntityFilter<T extends Entity, I = IdOf<T>, F = FilterOf<T>, N = nev
   | I
   | readonly I[]
   // Note that this is a weak type (all optional keys) but TS still enforces at least one overlap
-  | ({ as?: Alias<T>; $count?: number } & F)
+  | ({ as?: Alias<T> } & F)
   // Always allow `undefined` for condition pruning
   | undefined
   // But only allow `null` for `nullable` relations

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -189,12 +189,10 @@ export function parseFindQuery(
     condition: RawCondition,
     // If we're a m2m, the join table to inject (which will use the outer table)
     joinTable: JoinTable | undefined,
-    // Allow addOrderBy to do its own post-addTable lateral join building
-    orderByTables: ParsedTable[] | undefined = undefined,
-  ): LateralJoinTable | undefined {
+  ) {
     const ef = parseEntityFilter(meta, filter);
     // Maybe skip
-    if (!ef && !isAlias(filter) && !orderByTables) return;
+    if (!ef && !isAlias(filter)) return;
 
     bindAlias(filter, meta, alias);
 
@@ -250,8 +248,7 @@ export function parseFindQuery(
     );
     subQuery.orderBys = [];
     if (joinTable) subQuery.tables.unshift(joinTable);
-    const join: LateralJoinTable = { join: "lateral", table: meta.tableName, query: subQuery, alias, fromAlias };
-    (orderByTables ?? tables).push(join);
+    tables.push({ join: "lateral", table: meta.tableName, query: subQuery, alias, fromAlias });
 
     // Look for complex conditions...
     const topLevelAlias = opts.outerLateralJoins?.[opts.outerLateralJoins?.length - 1]?.alias;
@@ -303,8 +300,6 @@ export function parseFindQuery(
         });
       });
     }
-
-    return join;
   }
 
   /** Adds `meta` to the query, i.e. for m2o/o2o joins into parents. */
@@ -533,94 +528,38 @@ export function parseFindQuery(
     }
   }
 
-  function addOrderBy(
-    meta: EntityMetadata,
-    alias: string,
-    orderBy: Record<string, any>,
-    lateralJoins: LateralJoinTable[],
-  ): void {
+  function addOrderBy(meta: EntityMetadata, alias: string, orderBy: Record<string, any>): void {
     const entries = Object.entries(orderBy);
-    // If we're recursing for lateral joins, look in the local query's tables,
-    const tables = (lateralJoins[lateralJoins.length - 1]?.query ?? query).tables;
     if (entries.length === 0) return;
     for (const [key, value] of entries) {
       if (!value) continue; // prune undefined
       const field = meta.allFields[key] ?? fail(`${key} not found on ${meta.tableName}`);
       if (field.kind === "primitive" || field.kind === "primaryKey" || field.kind === "enum") {
         const column = field.serde.columns[0];
-        if (lateralJoins.length === 0) {
-          // We can add the orderBy directly against the column
-          orderBys.push({
-            alias: `${alias}${field.aliasSuffix}`,
-            column: column.columnName,
-            order: value as OrderBy,
-          });
-        } else {
-          // We need to orderBy the summed column
-          const [topJoin, ...rest] = lateralJoins;
-          const lastJoin = rest[rest.length - 1] ?? topJoin;
-          const as = `_${alias}_${column.columnName}_sum`;
-          lastJoin.query.selects.push({
-            sql: `SUM(${alias}${field.aliasSuffix}.${column.columnName}) AS ${as}`,
-            aliases: [alias],
-            bindings: [],
-          });
-          for (const join of lateralJoins) {
-            if (join !== lastJoin) {
-              join.query.selects.push({
-                sql: `SUM(${alias}.${as}) AS ${as}`,
-                aliases: [join.alias],
-                bindings: [],
-              });
-            }
-          }
-          orderBys.push({ alias: `${topJoin.alias}`, column: as, order: value as OrderBy });
-        }
+        orderBys.push({
+          alias: `${alias}${field.aliasSuffix ?? ""}`,
+          column: column.columnName,
+          order: value as OrderBy,
+        });
       } else if (field.kind === "m2o") {
         // Do we already this table joined in?
         let table = tables.find((t) => t.table === field.otherMetadata().tableName);
-        if (!table) {
-          const { tableName } = field.otherMetadata();
-          const a = getAlias(tableName);
+        if (table) {
+          addOrderBy(field.otherMetadata(), table.alias, value);
+        } else {
+          const table = field.otherMetadata().tableName;
+          const a = getAlias(table);
           const column = field.serde.columns[0].columnName;
-          table = {
+          // If we don't have a join, don't force this to be an inner join
+          tables.push({
             alias: a,
-            table: tableName,
-            // If we don't have a join, don't force this to be an inner join
+            table,
             join: "outer", // don't drop the entity just b/c of a missing order by
             col1: kqDot(alias, column),
             col2: kqDot(a, "id"),
-          } satisfies JoinTable;
-          tables.push(table);
+          });
+          addOrderBy(field.otherMetadata(), a, value);
         }
-        addOrderBy(field.otherMetadata(), table.alias, value, lateralJoins);
-      } else if (field.kind === "o2m") {
-        let table = tables.filter((t) => t.join === "lateral").find((t) => t.table === field.otherMetadata().tableName);
-        if (!table) {
-          // ...big copy/paste from up above...
-          const a = getAlias(field.otherMetadata().tableName);
-          const otherField = field.otherMetadata().allFields[field.otherFieldName];
-          let otherColumn = otherField.serde!.columns[0].columnName;
-          // If the other field is a poly, we need to find the right column
-          if (otherField.kind === "poly") {
-            // For a subcomponent that matches field's metadata
-            const otherComponent =
-              otherField.components.find((c) => c.otherMetadata() === meta) ??
-              fail(`No poly component found for ${otherField.fieldName}`);
-            otherColumn = otherComponent.columnName;
-          }
-          const condition = `${kqDot(alias, "id")} = ${kqDot(a + otherField.aliasSuffix, otherColumn)}`;
-          table = addLateralJoin(
-            field.otherMetadata(),
-            alias,
-            a,
-            undefined,
-            { kind: "raw", aliases: [a, alias], condition, pruneable: true, bindings: [] },
-            undefined,
-            tables,
-          )!;
-        }
-        addOrderBy(field.otherMetadata(), table.alias, value, [...lateralJoins, table]);
       } else {
         throw new Error(`Unsupported field ${key}`);
       }
@@ -646,9 +585,9 @@ export function parseFindQuery(
 
   if (orderBy) {
     if (Array.isArray(orderBy)) {
-      for (const ob of orderBy) addOrderBy(meta, alias, ob, []);
+      for (const ob of orderBy) addOrderBy(meta, alias, ob);
     } else {
-      addOrderBy(meta, alias, orderBy, []);
+      addOrderBy(meta, alias, orderBy);
     }
   }
   maybeAddOrderBy(query, meta, alias);

--- a/packages/orm/src/QueryVisitor.ts
+++ b/packages/orm/src/QueryVisitor.ts
@@ -4,7 +4,7 @@ import { ColumnCondition, ParsedExpressionFilter, ParsedFindQuery, RawCondition 
 interface Visitor {
   visitExp?(c: ParsedExpressionFilter): ParsedExpressionFilter | void;
   visitRaw?(c: RawCondition): RawCondition | ParsedExpressionFilter | void;
-  visitCond(c: ColumnCondition): ColumnCondition | ParsedExpressionFilter | RawCondition | void;
+  visitCond(c: ColumnCondition): ColumnCondition | ParsedExpressionFilter | void;
 }
 
 /**
@@ -35,14 +35,5 @@ export function visitConditions(query: ParsedFindQuery, visitor: Visitor): void 
       }
     });
   }
-  const todo = [query];
-  while (todo.length > 0) {
-    const query = todo.pop()!;
-    if (query.condition) visit(query.condition);
-    for (const table of query.tables) {
-      if (table.join === "lateral") {
-        todo.push(table.query);
-      }
-    }
-  }
+  if (query.condition) visit(query.condition);
 }

--- a/packages/orm/src/dataloaders/findByUniqueDataLoader.ts
+++ b/packages/orm/src/dataloaders/findByUniqueDataLoader.ts
@@ -32,7 +32,7 @@ export function findByUniqueDataLoader<T extends Entity>(
     };
 
     addTablePerClassJoinsAndClassTag(query, meta, alias, true);
-    maybeAddNotSoftDeleted(conditions, softDeletes, meta, alias);
+    maybeAddNotSoftDeleted(conditions, meta, alias, softDeletes);
 
     let column: Column;
     switch (field.kind) {

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -9,15 +9,14 @@ import { EntityMetadata, getMetadata } from "../EntityMetadata";
 import { buildHintTree } from "../HintTree";
 import {
   ColumnCondition,
+  ParsedExpressionFilter,
   ParsedFindQuery,
   ParsedValueFilter,
-  RawCondition,
   getTables,
-  parseAlias,
+  joinKeywords,
   parseFindQuery,
 } from "../QueryParser";
 import { visitConditions } from "../QueryVisitor";
-import { buildRawQuery } from "../drivers/buildRawQuery";
 import { kq, kqDot } from "../keywords";
 import { LoadHint } from "../loadHints";
 import { maybeRequireTemporal } from "../temporal";
@@ -66,62 +65,64 @@ export function findDataLoader<T extends Entity>(
         return [entities];
       }
 
-      // WITH _find (tag, arg1, arg2) AS (VALUES
+      // WITH data(tag, arg1, arg2) AS (VALUES
       //   (0::int, 'a'::varchar, 'a'::varchar),
       //   (1, 'b', 'b'),
       //   (2, 'c', 'c')
       // )
-      // SELECT a.*, array_agg(_find.tag) AS _tags
+      // SELECT array_agg(d.tag), a.*
       // FROM authors a
-      // CROSS JOIN _find AS _find
-      // WHERE a.first_name = _find.arg0 OR a.last_name = _find.arg1
-      // GROUP BY a.id
+      // JOIN data d ON (d.arg1 = a.first_name OR d.arg2 = a.last_name)
+      // group by a.id;
 
       // Build the list of 'arg1', 'arg2', ... strings
-      const { where, ...options } = queries[0];
-      const query = parseFindQuery(getMetadata(type), where, options);
-      const args = collectAndReplaceArgs(query);
+      const args = collectArgs(query);
       args.unshift({ columnName: "tag", dbType: "int" });
 
-      query.selects.unshift("array_agg(_find.tag) as _tags");
-      // Inject a cross join into the query
-      query.tables.unshift({ join: "cross", table: "_find", alias: "_find" });
-      query.cte = {
-        sql: buildValuesCte("_find", args, queries),
-        bindings: createBindings(meta, queries),
-      };
+      const selects = ["array_agg(_find.tag) as _tags", ...query.selects];
+      const [primary, joins] = getTables(query);
+
+      // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
+      const bindings = createBindings(meta, queries);
+      // Create the JOIN clause, i.e. ON a.firstName = _find.arg0
+      const [conditions] = buildConditions(query.condition!);
+
       // Because we want to use `array_agg(tag)`, add `GROUP BY`s to the values we're selecting
-      query.groupBys = query.selects
-        .filter((s) => typeof s === "string")
+      const groupBys = selects
         .filter((s) => !s.includes("array_agg") && !s.includes("CASE") && !s.includes(" as "))
-        .map((s) => {
-          // Make a liberal assumption that this is a `a.id` or `a_st0.id` string
-          const alias = parseAlias(s);
-          return { alias, column: "id" };
-        });
+        .map((s) => s.replace("*", "id"));
 
       // Also because of our `array_agg` group by, add any order bys to the group by
-      const [primary] = getTables(query);
-      for (const { alias, column } of query.orderBys) {
-        if (alias !== primary.alias) {
-          query.groupBys.push({ alias, column });
+      for (const o of query.orderBys) {
+        if (o.alias !== primary.alias) {
+          groupBys.push(kqDot(o.alias, o.column));
         }
       }
 
       const { preloader } = getEmInternalApi(em);
       const preloadJoins = preloader && hint && preloader.getPreloadJoins(em, meta, buildHintTree(hint), query);
       if (preloadJoins) {
-        query.selects.push(
+        selects.push(
           ...preloadJoins.flatMap((j) =>
             // Because we 'group by primary.id' to collapse the "a1 matched multiple finds" into
             // a single row, we also need to pick just the first value of each preload column
             j.selects.map((s) => `(array_agg(${s.value}))[1] AS ${s.as}`),
           ),
         );
-        query.tables.push(...preloadJoins.map((j) => j.join));
       }
 
-      const { sql, bindings } = buildRawQuery(query, { limit: em.entityLimit });
+      const sql = `
+        ${buildValuesCte("_find", args, queries)}
+        SELECT ${selects.join(", ")}
+        FROM ${primary.table} as ${kq(primary.alias)}
+        ${joins.map((j) => `${joinKeywords(j)} ${j.table} ${kq(j.alias)} ON ${j.col1} = ${j.col2}`).join(" ")}
+        JOIN _find ON ${conditions}
+        ${preloadJoins?.map((j) => j.join).join(" ") ?? ""}
+        GROUP BY ${groupBys.join(", ")}
+        ORDER BY ${query.orderBys.map((o) => `${kq(o.alias)}.${o.column} ${o.order}`).join(", ")}
+        LIMIT ${em.entityLimit};
+      `;
+
       const rows = await em.driver.executeQuery(em, cleanSql(sql), bindings);
       ensureUnderLimit(em, rows);
 
@@ -170,56 +171,26 @@ export function whereFilterHash(where: FilterAndSettings<any>): any {
   return hash(where, { replacer, algorithm: "md5" });
 }
 
-class ArgCounter {
-  private index = 0;
-  next(): number {
-    return this.index++;
-  }
-}
-
-/**
- * Recursively finds args in `query` and replaces them with `_find.argX` placeholders.
- *
- * We also return the name/type of each found/rewritten arg so we can build the `_find` CTE table.
- */
-export function collectAndReplaceArgs(query: ParsedFindQuery): { columnName: string; dbType: string }[] {
+/** Collects & names all the args in a query, i.e. `['arg1', 'arg2']`--not the actual values. */
+export function collectArgs(query: ParsedFindQuery): { columnName: string; dbType: string }[] {
   const args: { columnName: string; dbType: string }[] = [];
-  const argsIndex = new ArgCounter();
   visitConditions(query, {
     visitCond(c: ColumnCondition) {
       if ("value" in c.cond) {
         const { kind } = c.cond;
         if (kind === "in" || kind === "nin") {
           args.push({ columnName: `arg${args.length}`, dbType: `${c.dbType}[]` });
-          return rewriteToRawCondition(c, argsIndex);
         } else if (kind === "between") {
           // between has two values
           args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
           args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
-          return rewriteToRawCondition(c, argsIndex);
         } else {
           args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
-          return rewriteToRawCondition(c, argsIndex);
         }
-      } else if (c.cond.kind === "is-null" || c.cond.kind === "not-null") {
-        // leave it alone
-      } else {
-        throw new Error("Unsupported");
       }
     },
   });
   return args;
-}
-
-function rewriteToRawCondition(c: ColumnCondition, argsIndex: ArgCounter): RawCondition {
-  const [op, negate] = makeOp(c.cond, argsIndex);
-  return {
-    kind: "raw",
-    aliases: [c.alias],
-    condition: `${negate ? "NOT " : ""}${kqDot(c.alias, c.column)} ${op}`,
-    pruneable: c.pruneable ?? false,
-    bindings: [],
-  };
 }
 
 export function createBindings(meta: EntityMetadata, queries: readonly FilterAndSettings<any>[]): any[] {
@@ -261,8 +232,51 @@ function stripValues(query: ParsedFindQuery): void {
   });
 }
 
-/** Returns [operator, argsTaken, negate], i.e. `["=", 1, false]`. */
-function makeOp(cond: ParsedValueFilter<any>, argsIndex: ArgCounter): [string, boolean] {
+/**
+ * Creates the `a1.firstName = _find.args1` AND a2.lastName = _find.args2` condition
+ * that joins our `_find` CTE (1 row per query that's getting auto-joined together)
+ * into the main table.
+ *
+ * We return a tuple for `[SQL, argsTaken]`, but `argsTaken` is only used for recursive
+ * calls to know which `_find.argsX` they should use, as we match up columns of the `_find`
+ * CTE (`args0`, `args1`, `args2`, ...) to positions in the `JOIN ON (...)` "batched where"
+ * clause.
+ */
+export function buildConditions(ef: ParsedExpressionFilter, argsIndex: number = 0): [string, number] {
+  const conditions = [] as string[];
+  const originalIndex = argsIndex;
+  ef.conditions.forEach((c) => {
+    if (c.kind === "column") {
+      const [op, argsTaken, negate] = makeOp(c.cond, argsIndex);
+      if (c.alias === "unset") {
+        throw new Error("Alias was not bound in em.find");
+      }
+      if (negate) {
+        conditions.push(`NOT (${kqDot(c.alias, c.column)} ${op})`);
+      } else {
+        conditions.push(`${kqDot(c.alias, c.column)} ${op}`);
+      }
+      argsIndex += argsTaken;
+    } else if (c.kind === "exp") {
+      let [cond, argsTaken] = buildConditions(c, argsIndex);
+      const needsWrap = !("cond" in c);
+      if (needsWrap) cond = `(${cond})`;
+      conditions.push(cond);
+      argsIndex += argsTaken;
+    } else if (c.kind === "raw") {
+      conditions.push(c.condition);
+      if (c.bindings.length > 0) {
+        throw new Error("RawConditions with bindings is not batchable yet");
+      }
+    } else {
+      throw new Error(`Unsupported condition kind ${c}`);
+    }
+  });
+  const argsTaken = argsIndex - originalIndex;
+  return [conditions.join(` ${ef.op.toUpperCase()} `), argsTaken];
+}
+
+function makeOp(cond: ParsedValueFilter<any>, argsIndex: number): [string, number, boolean] {
   switch (cond.kind) {
     case "eq":
     case "ne":
@@ -282,23 +296,23 @@ function makeOp(cond: ParsedValueFilter<any>, argsIndex: ArgCounter): [string, b
     case "overlaps":
     case "containedBy": {
       const fn = opToFn[cond.kind] ?? fail(`Invalid operator ${cond.kind}`);
-      return [`${fn} _find.arg${argsIndex.next()}`, false];
+      return [`${fn} _find.arg${argsIndex}`, 1, false];
     }
     case "noverlaps":
     case "ncontains": {
       const fn = (opToFn as any)[cond.kind.substring(1)] ?? fail(`Invalid operator ${cond.kind}`);
-      return [`${fn} _find.arg${argsIndex.next()}`, true];
+      return [`${fn} _find.arg${argsIndex}`, 1, true];
     }
     case "is-null":
-      return [`IS NULL`, false];
+      return [`IS NULL`, 0, false];
     case "not-null":
-      return [`IS NOT NULL`, false];
+      return [`IS NOT NULL`, 0, false];
     case "in":
-      return [`= ANY(_find.arg${argsIndex.next()})`, false];
+      return [`= ANY(_find.arg${argsIndex})`, 1, false];
     case "nin":
-      return [`!= ALL(_find.arg${argsIndex.next()})`, false];
+      return [`!= ALL(_find.arg${argsIndex})`, 1, false];
     case "between":
-      return [`BETWEEN _find.arg${argsIndex.next()} AND _find.arg${argsIndex.next()}`, false];
+      return [`BETWEEN _find.arg${argsIndex} AND _find.arg${argsIndex + 1}`, 2, false];
     default:
       assertNever(cond);
   }

--- a/packages/orm/src/drivers/Driver.ts
+++ b/packages/orm/src/drivers/Driver.ts
@@ -13,7 +13,7 @@ export interface Driver {
   ): Promise<any[]>;
 
   /** Executes a raw SQL query with bindings. */
-  executeQuery(em: EntityManager, sql: string, bindings: readonly any[]): Promise<any[]>;
+  executeQuery(em: EntityManager, sql: string, bindings: any[]): Promise<any[]>;
 
   transaction<T>(em: EntityManager, fn: (txn: Knex.Transaction) => Promise<T>): Promise<T>;
 

--- a/packages/orm/src/drivers/buildKnexQuery.ts
+++ b/packages/orm/src/drivers/buildKnexQuery.ts
@@ -22,19 +22,19 @@ export function buildKnexQuery(
 ): QueryBuilder<{}, unknown[]> {
   const { limit, offset } = settings;
 
+  // If we're doing o2m joins, add a `DISTINCT` clause to avoid duplicates
+  const needsDistinct = parsed.tables.some((t) => t.join === "outer" && t.distinct !== false);
+
   // We need the `knex` param to call `knex.raw`
   const asRaw = (t: ParsedTable) => knex.raw(`${kq(t.table)} as ${kq(t.alias)}`);
 
   const primary = parsed.tables.find((t) => t.join === "primary")!;
 
-  let query: Knex.QueryBuilder = knex.from(asRaw(primary));
+  let query: Knex.QueryBuilder<any, any> = knex.from(asRaw(primary));
 
-  parsed.selects.forEach((s) => {
-    if (typeof s === "string") {
-      query.select(knex.raw(s));
-    } else {
-      query.select(knex.raw(s.sql, s.bindings));
-    }
+  parsed.selects.forEach((s, i) => {
+    const maybeDistinct = i === 0 && needsDistinct ? "distinct " : "";
+    query.select(knex.raw(`${maybeDistinct}${s}`));
   });
 
   parsed.tables.forEach((t) => {
@@ -48,17 +48,14 @@ export function buildKnexQuery(
       case "primary":
         // ignore
         break;
-      case "lateral":
-        const { sql, bindings } = buildKnexQuery(knex, t.query, {}).toSQL();
-        query.crossJoin(knex.raw(`lateral (${sql}) as ${kq(t.alias)}`, bindings));
-        break;
-      case "cross":
-        query.crossJoin(asRaw(t));
-        break;
       default:
         assertNever(t);
     }
   });
+
+  if (parsed.lateralJoins) {
+    query.joinRaw(parsed.lateralJoins.joins.join("\n"), parsed.lateralJoins.bindings);
+  }
 
   if (parsed.condition) {
     const where = buildWhereClause(parsed.condition, true);
@@ -70,6 +67,10 @@ export function buildKnexQuery(
 
   parsed.orderBys &&
     parsed.orderBys.forEach(({ alias, column, order }) => {
+      // If we're doing "select distinct" for o2m joins, then all order bys must be selects
+      if (needsDistinct) {
+        query.select(knex.raw(kqDot(alias, column)));
+      }
       query.orderBy(knex.raw(kqDot(alias, column)) as any, order);
     });
 

--- a/packages/orm/src/drivers/buildRawQuery.ts
+++ b/packages/orm/src/drivers/buildRawQuery.ts
@@ -1,7 +1,9 @@
+import { Knex } from "knex";
 import { ParsedFindQuery, ParsedTable } from "../QueryParser";
 import { kq, kqDot } from "../keywords";
 import { assertNever } from "../utils";
 import { buildWhereClause } from "./buildUtils";
+import QueryBuilder = Knex.QueryBuilder;
 
 /**
  * Transforms `ParsedFindQuery` into a raw SQL string.
@@ -15,6 +17,9 @@ export function buildRawQuery(
 ): { sql: string; bindings: readonly any[] } {
   const { limit, offset } = settings;
 
+  // If we're doing o2m joins, add a `DISTINCT` clause to avoid duplicates
+  const needsDistinct = parsed.tables.some((t) => t.join === "outer" && t.distinct !== false);
+
   let sql = "";
   const bindings: any[] = [];
 
@@ -25,14 +30,17 @@ export function buildRawQuery(
 
   sql += "SELECT ";
   parsed.selects.forEach((s, i) => {
+    const maybeDistinct = i === 0 && needsDistinct ? "DISTINCT " : "";
     const maybeComma = i === parsed.selects.length - 1 ? "" : ", ";
-    if (typeof s === "string") {
-      sql += s + maybeComma;
-    } else {
-      sql += s.sql + maybeComma;
-      bindings.push(...s.bindings);
-    }
+    sql += maybeDistinct + s + maybeComma;
   });
+
+  // If we're doing "select distinct" for o2m joins, then all order bys must be selects
+  if (needsDistinct && parsed.orderBys.length > 0) {
+    for (const { alias, column } of parsed.orderBys) {
+      sql += `, ${kqDot(alias, column)}`;
+    }
+  }
 
   // Make sure the primary is first
   const primary = parsed.tables.find((t) => t.join === "primary")!;
@@ -46,15 +54,14 @@ export function buildRawQuery(
       sql += ` LEFT OUTER JOIN ${as(t)} ON ${t.col1} = ${t.col2}`;
     } else if (t.join === "primary") {
       // handled above
-    } else if (t.join === "lateral") {
-      const { sql: subQ, bindings: subB } = buildRawQuery(t.query, {});
-      sql += ` CROSS JOIN LATERAL (${subQ}) AS ${kq(t.alias)}`;
-      bindings.push(...subB);
-    } else if (t.join === "cross") {
-      sql += ` CROSS JOIN ${as(t)}`;
     } else {
       assertNever(t.join);
     }
+  }
+
+  if (parsed.lateralJoins) {
+    sql += " " + parsed.lateralJoins.joins.join("\n");
+    bindings.push(...parsed.lateralJoins.bindings);
   }
 
   if (parsed.condition) {
@@ -63,10 +70,6 @@ export function buildRawQuery(
       sql += " WHERE " + where[0];
       bindings.push(...where[1]);
     }
-  }
-
-  if (parsed.groupBys && parsed.groupBys.length > 0) {
-    sql += " GROUP BY " + parsed.groupBys.map((ob) => kqDot(ob.alias, ob.column)).join(", ");
   }
 
   if (parsed.orderBys.length > 0) {

--- a/packages/orm/src/drivers/buildUtils.ts
+++ b/packages/orm/src/drivers/buildUtils.ts
@@ -25,13 +25,15 @@ export function buildWhereClause(exp: ParsedExpressionFilter, topLevel = false):
   return [sql, tuples.flatMap(([, bindings]) => bindings)];
 }
 
-/** Returns a tuple of `["column op ?"`, bindings]`. */
 function buildRawCondition(raw: RawCondition): [string, any[]] {
-  return [raw.condition, raw.bindings];
+  if (raw.bindings.length > 0) {
+    throw new Error("Not implemented");
+  }
+  return [raw.condition, []];
 }
 
 /** Returns a tuple of `["column op ?"`, bindings]`. */
-export function buildCondition(cc: ColumnCondition): [string, any[]] {
+function buildCondition(cc: ColumnCondition): [string, any[]] {
   const { alias, column, cond } = cc;
   const columnName = kqDot(alias, column);
   switch (cond.kind) {

--- a/packages/orm/src/plugins/PreloadPlugin.ts
+++ b/packages/orm/src/plugins/PreloadPlugin.ts
@@ -3,7 +3,7 @@ import { EntityManager } from "../EntityManager";
 import { EntityMetadata } from "../EntityMetadata";
 import { EntityOrId, HintNode } from "../HintTree";
 import { LoadHint, NestedLoadHint } from "../loadHints";
-import { LateralJoinTable, ParsedFindQuery } from "../QueryParser";
+import { ParsedFindQuery } from "../QueryParser";
 
 /**
  * This is a plugin API dedicated to preloading data for subtrees of entities.
@@ -78,7 +78,9 @@ export type JoinResult = {
   /** The select clause(s) for this join, i.e. `b._ as _b` or `c._ as _c`. */
   selects: { value: string; as: string }[];
   /** The SQL for this child's lateral join, which itself might have recursive lateral joins. */
-  join: LateralJoinTable;
+  join: string;
   /** The processor for this child's lateral join, which itself might recursively processor subjoins. */
   hydrator: PreloadHydrator;
+  /** Any bindings for filtering subjoins by a subset of the root entities, to avoid over-fetching. */
+  bindings: any[];
 };

--- a/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
@@ -38,17 +38,7 @@ import {
   type ValueGraphQLFilter,
 } from "joist-orm";
 import { type Context } from "../../context.js";
-import {
-  Author,
-  authorMeta,
-  Book,
-  type BookId,
-  bookMeta,
-  type BookOrder,
-  type Entity,
-  EntityManager,
-  newAuthor,
-} from "../entities.js";
+import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities.js";
 
 export type AuthorId = Flavor<string, "Author">;
 
@@ -99,7 +89,6 @@ export interface AuthorOrder {
   delete?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
-  books?: BookOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
@@ -45,7 +45,6 @@ import {
   T1Book,
   type T1BookId,
   t1BookMeta,
-  type T1BookOrder,
 } from "../entities";
 
 export type T1AuthorId = Flavor<number, "T1Author">;
@@ -79,7 +78,6 @@ export interface T1AuthorGraphQLFilter {
 export interface T1AuthorOrder {
   id?: OrderBy;
   firstName?: OrderBy;
-  t1Books?: T1BookOrder;
 }
 
 export const t1AuthorConfig = new ConfigApi<T1Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
@@ -87,7 +87,6 @@ export interface T2AuthorOrder {
   id?: OrderBy;
   firstName?: OrderBy;
   favoriteBook?: T2BookOrder;
-  t2Books?: T2BookOrder;
 }
 
 export const t2AuthorConfig = new ConfigApi<T2Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
@@ -87,7 +87,6 @@ export interface T2BookOrder {
   id?: OrderBy;
   title?: OrderBy;
   author?: T2AuthorOrder;
-  t2Authors?: T2AuthorOrder;
 }
 
 export const t2BookConfig = new ConfigApi<T2Book, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
@@ -87,7 +87,6 @@ export interface T3AuthorOrder {
   id?: OrderBy;
   firstName?: OrderBy;
   favoriteBook?: T3BookOrder;
-  t3Books?: T3BookOrder;
 }
 
 export const t3AuthorConfig = new ConfigApi<T3Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
@@ -87,7 +87,6 @@ export interface T3BookOrder {
   id?: OrderBy;
   title?: OrderBy;
   author?: T3AuthorOrder;
-  t3Authors?: T3AuthorOrder;
 }
 
 export const t3BookConfig = new ConfigApi<T3Book, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
@@ -87,7 +87,6 @@ export interface T4AuthorOrder {
   id?: OrderBy;
   firstName?: OrderBy;
   favoriteBook?: T4BookOrder;
-  t4Books?: T4BookOrder;
 }
 
 export const t4AuthorConfig = new ConfigApi<T4Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
@@ -87,7 +87,6 @@ export interface T4BookOrder {
   id?: OrderBy;
   title?: OrderBy;
   author?: T4AuthorOrder;
-  t4Authors?: T4AuthorOrder;
 }
 
 export const t4BookConfig = new ConfigApi<T4Book, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
@@ -45,7 +45,6 @@ import {
   T5Book,
   type T5BookId,
   t5BookMeta,
-  type T5BookOrder,
 } from "../entities";
 
 export type T5AuthorId = Flavor<number, "T5Author">;
@@ -79,7 +78,6 @@ export interface T5AuthorGraphQLFilter {
 export interface T5AuthorOrder {
   id?: OrderBy;
   firstName?: OrderBy;
-  t5Books?: T5BookOrder;
 }
 
 export const t5AuthorConfig = new ConfigApi<T5Author, Context>();

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
@@ -51,7 +51,6 @@ import {
   T5BookReview,
   type T5BookReviewId,
   t5BookReviewMeta,
-  type T5BookReviewOrder,
 } from "../entities";
 
 export type T5BookId = Flavor<number, "T5Book">;
@@ -91,7 +90,6 @@ export interface T5BookOrder {
   id?: OrderBy;
   title?: OrderBy;
   author?: T5AuthorOrder;
-  reviews?: T5BookReviewOrder;
 }
 
 export const t5BookConfig = new ConfigApi<T5Book, Context>();

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -8,7 +8,6 @@ import {
   insertImage,
   insertLargePublisher,
   insertPublisher,
-  insertSmallPublisherGroup,
   insertTag,
   insertUser,
   update,
@@ -22,7 +21,6 @@ import {
   UniqueFilter,
   alias,
   aliases,
-  buildQuery,
   getMetadata,
   parseFindQuery,
 } from "joist-orm";
@@ -49,7 +47,6 @@ import {
   PublisherId,
   PublisherSize,
   SmallPublisher,
-  SmallPublisherGroup,
   Tag,
   TaskItem,
   TaskItemFilter,
@@ -718,107 +715,6 @@ describe("EntityManager.queries", () => {
     });
   });
 
-  it("can find by o2m is null", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertAuthor({ first_name: "a2" });
-    await insertBook({ title: "b1", author_id: 1 });
-
-    const em = newEntityManager();
-    const where = { books: null } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
-    expect(authors).toMatchEntity([{ firstName: "a2" }]);
-  });
-
-  it("can find by o2m is ne null", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertAuthor({ first_name: "a2" });
-    await insertBook({ title: "b1", author_id: 1 });
-
-    const em = newEntityManager();
-    const where = { books: { ne: null } } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
-    expect(authors).toMatchEntity([{ firstName: "a1" }]);
-  });
-
-  it("can find by o2m has list of ids", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertAuthor({ first_name: "a2" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertBook({ title: "b2", author_id: 1 });
-
-    const em = newEntityManager();
-    const where = { books: ["b:1"] } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
-    expect(authors).toMatchEntity([{ firstName: "a1" }]);
-  });
-
-  it("can find by o2m is an id", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertAuthor({ first_name: "a2" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertBook({ title: "b2", author_id: 1 });
-
-    const em = newEntityManager();
-    const where = { books: { id: "b:1" } } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
-    expect(authors).toMatchEntity([{ firstName: "a1" }]);
-  });
-
-  it("can find by nested o2m is an id", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertAuthor({ first_name: "a2" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertBookReview({ book_id: 1, rating: 1 });
-    const em = newEntityManager();
-    const where = { books: { reviews: { id: "br:1" } } } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
-    expect(authors).toMatchEntity([{ firstName: "a1" }]);
-  });
-
-  it("can find by o2m in ids", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertAuthor({ first_name: "a2" });
-    await insertBook({ title: "b1", author_id: 1 });
-    await insertBook({ title: "b2", author_id: 1 });
-
-    const em = newEntityManager();
-    const where = { books: { id: { in: ["b:1", "b:3"] } } } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
-    expect(authors).toMatchEntity([{ firstName: "a1" }]);
-  });
-
-  it("can find by o2m that is empty", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertAuthor({ first_name: "a2" });
-    await insertBook({ title: "b1", author_id: 1 });
-    const em = newEntityManager();
-    // Given a `where` that will pull in the joins, but get pruned away
-    const where = { publisher: { authors: { firstName: undefined } } } satisfies AuthorFilter;
-    const authors = await em.find(Author, where, opts);
-    // Then we find all authors
-    expect(authors.length).toBe(2);
-    // And the query didn't have the extra joins or extra conditions
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
-      selects: [`a.*`],
-      tables: [{ alias: "a", table: "authors", join: "primary" }],
-      condition: undefined,
-      orderBys: [{ alias: "a", column: "id", order: "ASC" }],
-    });
-    // And if we ask for pruneJoins: false
-    expect(parseFindQuery(am, where, { ...opts, pruneJoins: false })).toMatchObject({
-      selects: [`a.*`],
-      tables: [
-        { alias: "a", table: "authors", join: "primary" },
-        // Then the joins themselves stay
-        { alias: "p", table: "publishers", join: "outer" },
-        { alias: "a1", table: "authors", join: "lateral" },
-      ],
-      // But the "at least 1 child" condition was not added
-      condition: undefined,
-      orderBys: [{ alias: "a", column: "id", order: "ASC" }],
-    });
-  });
-
   it("can find through a o2o entity", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertAuthor({ first_name: "a2" });
@@ -994,8 +890,8 @@ describe("EntityManager.queries", () => {
       ],
       tables: [
         { alias: "p", table: "publishers", join: "primary" },
-        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id" },
-        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id" },
+        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id", distinct: false },
+        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id", distinct: false },
       ],
       condition: {
         op: "and",
@@ -1054,8 +950,8 @@ describe("EntityManager.queries", () => {
       ],
       tables: [
         { alias: "p", table: "publishers", join: "primary" },
-        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id" },
-        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id" },
+        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id", distinct: false },
+        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id", distinct: false },
       ],
       condition: {
         op: "and",
@@ -1086,8 +982,8 @@ describe("EntityManager.queries", () => {
       ],
       tables: [
         { alias: "p", table: "publishers", join: "primary" },
-        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id" },
-        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id" },
+        { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id", distinct: false },
+        { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id", distinct: false },
       ],
       condition: {
         op: "and",
@@ -1729,8 +1625,8 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        { alias: "b", table: "books", join: "outer", col1: "a.current_draft_book_id", col2: "b.id" },
-        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id" },
+        { alias: "b", table: "books", join: "outer", col1: "a.current_draft_book_id", col2: "b.id", distinct: false },
+        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id", distinct: false },
       ],
       orderBys: [
         { alias: "b", column: "title", order: "ASC" },
@@ -1758,8 +1654,8 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id" },
-        { alias: "b", table: "books", join: "outer", col1: "a.current_draft_book_id", col2: "b.id" },
+        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id", distinct: false },
+        { alias: "b", table: "books", join: "outer", col1: "a.current_draft_book_id", col2: "b.id", distinct: false },
       ],
       orderBys: [
         { alias: "p", column: "name", order: "ASC" },
@@ -1786,7 +1682,7 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id" },
+        { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id", distinct: false },
       ],
       orderBys: [
         { alias: "p", column: "name", order: "ASC" },
@@ -2188,7 +2084,7 @@ describe("EntityManager.queries", () => {
       selects: [`u.*`, "u_s0.*", "u.id as id", expect.anything()],
       tables: [
         { alias: "u", table: "users", join: "primary" },
-        { alias: "u_s0", table: "admin_users", join: "outer", col1: "u.id", col2: "u_s0.id" },
+        { alias: "u_s0", table: "admin_users", join: "outer", col1: "u.id", col2: "u_s0.id", distinct: false },
       ],
       condition: {
         op: "or",
@@ -2238,19 +2134,18 @@ describe("EntityManager.queries", () => {
     const authors = await em.find(Author, where);
     expect(authors.length).toEqual(1);
 
-    // We used to only join into the `author_to_tags`, but for now we lateral join into tags itself
-    // expect(parseFindQuery(am, where, opts)).toMatchObject({
-    //   selects: [`a.*`],
-    //   tables: [
-    //     { alias: "a", table: "authors", join: "primary" },
-    //     { alias: "att", table: "authors_to_tags", join: "outer", col1: "a.id", col2: "att.author_id" },
-    //   ],
-    //   condition: {
-    //     op: "and",
-    //     conditions: [{ alias: "att", column: "tag_id", dbType: "int", cond: { kind: "eq", value: 1 } }],
-    //   },
-    //   orderBys: [expect.anything()],
-    // });
+    expect(parseFindQuery(am, where, opts)).toMatchObject({
+      selects: [`a.*`],
+      tables: [
+        { alias: "a", table: "authors", join: "primary" },
+        { alias: "att", table: "authors_to_tags", join: "outer", col1: "a.id", col2: "att.author_id" },
+      ],
+      condition: {
+        op: "and",
+        conditions: [{ alias: "att", column: "tag_id", dbType: "int", cond: { kind: "eq", value: 1 } }],
+      },
+      orderBys: [expect.anything()],
+    });
   });
 
   it("can find through m2m matching on new values and not fail", async () => {
@@ -2266,22 +2161,11 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        {
-          alias: "t",
-          table: "tags",
-          query: {
-            condition: {
-              conditions: [
-                { aliases: ["att", "t"], condition: "att.tag_id = t.id", bindings: [] },
-                { alias: "t", column: "id", dbType: "int", cond: { kind: "in", value: [-1] } },
-              ],
-            },
-          },
-        },
+        { alias: "att", table: "authors_to_tags", join: "outer", col1: "a.id", col2: "att.author_id" },
       ],
       condition: {
         op: "and",
-        conditions: [{ alias: "t", column: "_", dbType: "int", cond: { kind: "gt", value: 0 } }],
+        conditions: [{ alias: "att", column: "tag_id", dbType: "int", cond: { kind: "in", value: [-1] } }],
       },
       orderBys: [expect.anything()],
     });
@@ -2302,77 +2186,12 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        {
-          alias: "t",
-          table: "tags",
-          join: "lateral",
-          fromAlias: "a",
-          query: {
-            selects: ["count(*) as _"],
-            orderBys: [],
-            tables: [
-              { alias: "att", table: "authors_to_tags", join: "inner", col1: "a.id", col2: "att.author_id" },
-              { alias: "t", table: "tags", join: "primary" },
-            ],
-            condition: {
-              op: "and",
-              conditions: [
-                { aliases: ["att", "t"], condition: "att.tag_id = t.id", bindings: [] },
-                { alias: "t", column: "name", dbType: "citext", cond: { kind: "eq", value: "t1" } },
-              ],
-            },
-          },
-        },
+        { alias: "att", table: "authors_to_tags", join: "outer", col1: "a.id", col2: "att.author_id" },
+        { alias: "t", table: "tags", join: "outer", col1: "att.tag_id", col2: "t.id" },
       ],
       condition: {
         op: "and",
-        conditions: [{ alias: "t", column: "_", dbType: "int", cond: { kind: "gt", value: 0 } }],
-      },
-      orderBys: [expect.anything()],
-    });
-  });
-
-  it("can find through m2m matching multiple m2m children", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertTag({ name: "t1" });
-    await insertAuthorToTag({ author_id: 1, tag_id: 1 });
-    await insertTag({ name: "t2" });
-    await insertAuthorToTag({ author_id: 1, tag_id: 2 });
-
-    const em = newEntityManager();
-    const where = { tags: { name: ["t1", "t2"] } } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
-    expect(authors.length).toEqual(1);
-
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
-      selects: [`a.*`],
-      tables: [
-        { alias: "a", table: "authors", join: "primary" },
-        {
-          alias: "t",
-          table: "tags",
-          join: "lateral",
-          fromAlias: "a",
-          query: {
-            selects: ["count(*) as _"],
-            orderBys: [],
-            tables: [
-              { alias: "att", table: "authors_to_tags", join: "inner", col1: "a.id", col2: "att.author_id" },
-              { alias: "t", table: "tags", join: "primary" },
-            ],
-            condition: {
-              op: "and",
-              conditions: [
-                { aliases: ["att", "t"], condition: "att.tag_id = t.id", bindings: [] },
-                { alias: "t", column: "name", dbType: "citext", cond: { kind: "in", value: ["t1", "t2"] } },
-              ],
-            },
-          },
-        },
-      ],
-      condition: {
-        op: "and",
-        conditions: [{ alias: "t", column: "_", dbType: "int", cond: { kind: "gt", value: 0 } }],
+        conditions: [{ alias: "t", column: "name", dbType: "citext", cond: { kind: "eq", value: "t1" } }],
       },
       orderBys: [expect.anything()],
     });
@@ -2392,7 +2211,6 @@ describe("EntityManager.queries", () => {
   it("can find through o2m with all children matching", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertAuthor({ first_name: "a2" });
-    await insertAuthor({ first_name: "a3" });
     await insertBook({ title: "b10", author_id: 1 });
     await insertBook({ title: "b11", author_id: 1 });
     await insertBook({ title: "b2", author_id: 2 });
@@ -2407,26 +2225,13 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        {
-          alias: "b",
-          table: "books",
-          query: {
-            selects: [`count(*) as _`],
-            tables: [{ alias: "b", table: "books", join: "primary" }],
-            condition: {
-              op: "and",
-              conditions: [
-                { kind: "raw", condition: "a.id = b.author_id" },
-                { alias: "b", column: "title", dbType: "character varying", cond: { kind: "like", value: "b1%" } },
-              ],
-            },
-          },
-          join: "lateral",
-        },
+        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
       ],
       condition: {
         op: "and",
-        conditions: [{ alias: "b", column: "_", dbType: "int", cond: { kind: "gt", value: 0 } }],
+        conditions: [
+          { alias: "b", column: "title", dbType: "character varying", cond: { kind: "like", value: "b1%" } },
+        ],
       },
       orderBys: [expect.anything()],
     });
@@ -2448,24 +2253,11 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        {
-          alias: "b",
-          table: "books",
-          join: "lateral",
-          query: {
-            condition: {
-              op: "and",
-              conditions: [
-                { kind: "raw", condition: "a.id = b.author_id" },
-                { alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b3" } },
-              ],
-            },
-          },
-        },
+        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
       ],
       condition: {
         op: "and",
-        conditions: [{ alias: "b", column: "_", dbType: "int", cond: { kind: "gt", value: 0 } }],
+        conditions: [{ alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b3" } }],
       },
       orderBys: [expect.anything()],
     });
@@ -2485,24 +2277,11 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        {
-          alias: "b",
-          table: "books",
-          join: "lateral",
-          query: {
-            condition: {
-              op: "and",
-              conditions: [
-                { condition: "a.id = b.author_id" },
-                { alias: "b", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } },
-              ],
-            },
-          },
-        },
+        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
       ],
       condition: {
         op: "and",
-        conditions: [{ alias: "b", column: "_", dbType: "int", cond: { kind: "gt", value: 0 } }],
+        conditions: [{ alias: "b", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } }],
       },
       orderBys: [expect.anything()],
     });
@@ -2524,21 +2303,7 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        {
-          alias: "b",
-          table: "books",
-          join: "lateral",
-          query: {
-            condition: {
-              op: "and",
-              conditions: [
-                { kind: "raw", condition: "a.id = b.author_id" },
-                { alias: "b", column: "deleted_at", dbType: "timestamp with time zone", cond: { kind: "is-null" } },
-                { alias: "b", column: "acknowledgements", dbType: "text", cond: { kind: "is-null" } },
-              ],
-            },
-          },
-        },
+        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
       ],
       condition: {
         op: "and",
@@ -2548,8 +2313,22 @@ describe("EntityManager.queries", () => {
             column: "deleted_at",
             dbType: "timestamp with time zone",
             cond: { kind: "is-null" },
+            pruneable: true,
           },
-          { alias: "b", column: "_", dbType: "int", cond: { kind: "gt", value: 0 } },
+          {
+            alias: "b",
+            column: "deleted_at",
+            dbType: "timestamp with time zone",
+            cond: { kind: "is-null" },
+            pruneable: true,
+          },
+          {
+            op: "and",
+            conditions: [
+              { alias: "b", column: "acknowledgements", dbType: "text", cond: { kind: "is-null" } },
+              { alias: "b", column: "id", dbType: "int", cond: { kind: "not-null" } },
+            ],
+          },
         ],
       },
       orderBys: [expect.anything()],
@@ -2563,8 +2342,8 @@ describe("EntityManager.queries", () => {
     // And only the 1st author has a book
     await insertBook({ title: "b1", author_id: 1 });
     const em = newEntityManager();
-    // When we query for books with no books
-    const where = { books: { $count: 0 } } satisfies AuthorFilter;
+    // When we query for books with a null book.id column
+    const where = { books: { id: null } } satisfies AuthorFilter;
     const authors = await em.find(Author, where);
     // Then we only get back 2nd author
     expect(authors).toMatchEntity([{ firstName: "a2" }]);
@@ -2572,12 +2351,9 @@ describe("EntityManager.queries", () => {
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },
-        { alias: "b", table: "books", join: "lateral" },
+        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
       ],
-      condition: {
-        op: "and",
-        conditions: [{ alias: "b", column: "_", dbType: "int", cond: { kind: "eq", value: 0 } }],
-      },
+      condition: { op: "and", conditions: [{ alias: "b", column: "id", dbType: "int", cond: { kind: "is-null" } }] },
       orderBys: [expect.anything()],
     });
   });
@@ -2598,24 +2374,13 @@ describe("EntityManager.queries", () => {
         { alias: "c", table: "critics", join: "primary" },
         { alias: "lp", table: "large_publishers", join: "outer", col1: "c.favorite_large_publisher_id", col2: "lp.id" },
         // Perhaps ideally the `col1` would be `lp_b0.id` but it doesn't matter
-        {
-          alias: "a",
-          table: "authors",
-          join: "lateral",
-          query: {
-            condition: {
-              op: "and",
-              conditions: [
-                { kind: "raw", condition: "lp.id = a.publisher_id" },
-                { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
-              ],
-            },
-          },
-        },
+        { alias: "a", table: "authors", join: "outer", col1: "lp.id", col2: "a.publisher_id" },
       ],
       condition: {
         op: "and",
-        conditions: [{ alias: "a", column: "_", dbType: "int", cond: { kind: "gt", value: 0 } }],
+        conditions: [
+          { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
+        ],
       },
       orderBys: [expect.anything()],
     });
@@ -2745,42 +2510,8 @@ describe("EntityManager.queries", () => {
       await insertBook({ title: "b1", author_id: 1 });
       const em = newEntityManager();
       const b = alias(Book);
-      const authors = await em.find(Author, { books: b }, { conditions: { and: [b.$count.eq(0)] } });
+      const authors = await em.find(Author, { books: b }, { conditions: { and: [b.id.eq(null)] } });
       expect(authors.length).toEqual(1);
-    });
-
-    it("can use aliases as an o2m entity filter with zero or some children", async () => {
-      await insertAuthor({ first_name: "a1" });
-      await insertAuthor({ first_name: "a2" });
-      await insertBook({ title: "b1", author_id: 1 });
-      await insertBook({ title: "b2", author_id: 1 });
-      const em = newEntityManager();
-      const b = alias(Book);
-      const authors = await em.find(
-        Author,
-        { books: b },
-        {
-          conditions: {
-            or: [b.$count.eq(0), b.id.in(["b:1"])],
-          },
-        },
-      );
-      expect(authors.length).toEqual(2);
-    });
-
-    it("can use aliases as an o2m entity filter against a base type", async () => {
-      await insertSmallPublisherGroup({ id: 1, name: "pg1" });
-      await insertPublisher({ name: "p1", group_id: 1 });
-      const em = newEntityManager();
-      const p = alias(SmallPublisher);
-      const pgs = await em.find(
-        SmallPublisherGroup,
-        { publishers: p },
-        {
-          conditions: { and: [p.name.eq("p1")] },
-        },
-      );
-      expect(pgs.length).toEqual(1);
     });
 
     it("can use aliases as an o2m entity filter with primary key in tagged ids", async () => {
@@ -3015,29 +2746,12 @@ describe("EntityManager.queries", () => {
         tables: [
           { alias: "b", table: "books", join: "primary" },
           { alias: "a", table: "authors", join: "inner", col1: "b.author_id", col2: "a.id" },
-          {
-            alias: "t",
-            table: "tags",
-            join: "lateral",
-            fromAlias: "a",
-            query: {
-              selects: ["count(*) as _", { sql: "BOOL_OR(t.id = ?) as _t_id_0", bindings: [1], aliases: ["t"] }],
-              orderBys: [],
-              tables: [
-                { alias: "att", table: "authors_to_tags", join: "inner", col1: "a.id", col2: "att.author_id" },
-                { alias: "t", table: "tags", join: "primary" },
-              ],
-              condition: {
-                op: "and",
-                conditions: [{ aliases: ["att", "t"], condition: "att.tag_id = t.id", bindings: [] }],
-              },
-            },
-          },
+          { alias: "att", table: "authors_to_tags", join: "outer", col1: "a.id", col2: "att.author_id" },
+          { alias: "t", table: "tags", join: "outer", col1: "att.tag_id", col2: "t.id" },
         ],
         condition: {
           op: "or",
-          // conditions: [{ alias: "t", column: "id", dbType: "int", cond: { kind: "eq", value: 1 } }],
-          conditions: [{ aliases: ["t"], condition: "t._t_id_0" }],
+          conditions: [{ alias: "t", column: "id", dbType: "int", cond: { kind: "eq", value: 1 } }],
         },
         orderBys: expect.anything(),
       });
@@ -3059,26 +2773,8 @@ describe("EntityManager.queries", () => {
         tables: [
           { alias: "a", table: "authors", join: "primary" },
           { alias: "p", table: "publishers", join: "outer", col1: "a.publisher_id", col2: "p.id" },
-          {
-            alias: "b",
-            fromAlias: "a",
-            table: "books",
-            join: "lateral",
-            query: {
-              selects: ["count(*) as _"],
-              tables: [{ alias: "b", table: "books", join: "primary" }],
-              condition: {
-                kind: "exp",
-                op: "and",
-                conditions: [
-                  { kind: "raw", aliases: ["b", "a"], condition: "a.id = b.author_id", bindings: [], pruneable: true },
-                ],
-              },
-              orderBys: [],
-            },
-          },
+          { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
         ],
-        condition: undefined,
         orderBys: [expect.anything()],
       });
     });
@@ -3089,9 +2785,8 @@ describe("EntityManager.queries", () => {
         selects: [`a.*`],
         tables: [
           { alias: "a", table: "authors", join: "primary" },
-          { alias: "b", table: "books", join: "lateral", fromAlias: "a", query: expect.anything() },
+          { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
         ],
-        condition: undefined,
         orderBys: [expect.anything()],
       });
     });
@@ -3108,31 +2803,13 @@ describe("EntityManager.queries", () => {
         selects: [`a.*`],
         tables: [
           { alias: "a", table: "authors", join: "primary" },
-          {
-            alias: "b",
-            table: "books",
-            join: "lateral",
-            query: {
-              selects: ["count(*) as _", { sql: "BOOL_OR(b.title = ?) as _b_title_0", bindings: ["b1"] }],
-              tables: [{ table: "books", join: "primary" }],
-              condition: {
-                conditions: [{ kind: "raw", condition: "a.id = b.author_id" }],
-              },
-            },
-          },
+          { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
         ],
         condition: {
           op: "and",
-          conditions: [
-            {
-              kind: "raw",
-              aliases: ["b"],
-              condition: "b._b_title_0",
-              bindings: [],
-              pruneable: false,
-            },
-          ],
+          conditions: [{ alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b1" } }],
         },
+
         orderBys: [expect.anything()],
       });
     });
@@ -3295,7 +2972,7 @@ describe("EntityManager.queries", () => {
       const conditionalFilter: ExpressionFilter | undefined = undefined;
       expect(
         parseFindQuery(am, where, {
-          conditions: { and: [a.firstName.eq("a"), conditionalFilter] },
+          conditions: { and: [a.firstName.eq("a"), undefined] },
         }),
       ).toMatchObject({
         selects: [`a.*`],
@@ -3310,7 +2987,12 @@ describe("EntityManager.queries", () => {
               cond: { kind: "is-null" },
               pruneable: true,
             },
-            { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a" } },
+            {
+              conditions: [
+                { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a" } },
+              ],
+              op: "and",
+            },
           ],
         },
         orderBys: [expect.anything()],
@@ -3702,17 +3384,6 @@ describe("EntityManager.queries", () => {
     const em = newEntityManager();
     const users = await em.find(User, { password });
     expect(users.length).toBe(1);
-  });
-
-  it("supports buildKnexQuery", async () => {
-    const em = newEntityManager();
-    const where = { books: { title: "b1" } } satisfies AuthorFilter;
-    const q = buildQuery(em.ctx.knex, Author, { where });
-    expect(q.toSQL().sql).toMatchInlineSnapshot(
-      `"select a.* from authors as a cross join lateral (select count(*) as _ from books as b where a.id = b.author_id AND b.deleted_at IS NULL AND b.title = ?) as b where a.deleted_at IS NULL AND b._ > ? order by a.id ASC"`,
-    );
-    const rows = await q;
-    expect(rows.length).toBe(0);
   });
 });
 

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -3567,33 +3567,6 @@ describe("EntityManager.queries", () => {
     });
   });
 
-  describe("orderBy", () => {
-    it("can order by child m2o", async () => {
-      await insertAuthor({ first_name: "a1" });
-      await insertBook({ author_id: 1, title: "b1" });
-      await insertBook({ author_id: 1, title: "b2" });
-      await insertBookReview({ book_id: 1, rating: 1 });
-      await insertBookReview({ book_id: 2, rating: 1 });
-      await insertBookReview({ book_id: 2, rating: 1 });
-      const em = newEntityManager();
-      const books = await em.find(Book, {}, { orderBy: { reviews: { rating: "DESC" } } });
-      expect(books).toMatchEntity([{ title: "b2" }, { title: "b1" }]);
-    });
-
-    it("can order by nested child m2o", async () => {
-      await insertAuthor({ first_name: "a1" });
-      await insertAuthor({ first_name: "a2" });
-      await insertBook({ author_id: 1, title: "b1" });
-      await insertBook({ author_id: 2, title: "b2" });
-      await insertBookReview({ book_id: 1, rating: 1 });
-      await insertBookReview({ book_id: 2, rating: 1 });
-      await insertBookReview({ book_id: 2, rating: 1 });
-      const em = newEntityManager();
-      const authors = await em.find(Author, {}, { orderBy: { books: { reviews: { rating: "DESC" } } } });
-      expect(authors).toMatchEntity([{ firstName: "a2" }, { firstName: "a1" }]);
-    });
-  });
-
   describe("count", () => {
     it("can count", async () => {
       await insertAuthor({ first_name: "a1" });

--- a/packages/tests/integration/src/EntityManager.softDeletes.test.ts
+++ b/packages/tests/integration/src/EntityManager.softDeletes.test.ts
@@ -1,7 +1,8 @@
 import { insertAuthor, insertBook, insertBookToTag, insertPublisher, insertTag } from "@src/entities/inserts";
-import { newEntityManager } from "@src/testEm";
 import { Author, Book, Publisher, Tag } from "./entities";
 import { jan1 } from "./testDates";
+
+import { newEntityManager } from "@src/testEm";
 
 describe("EntityManager.softDeletes", () => {
   it("o2m.get skips soft deleted entities", async () => {

--- a/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
@@ -57,7 +57,6 @@ import {
   AuthorSchedule,
   type AuthorScheduleId,
   authorScheduleMeta,
-  type AuthorScheduleOrder,
   Book,
   type BookId,
   bookMeta,
@@ -69,7 +68,6 @@ import {
   Comment,
   type CommentId,
   commentMeta,
-  type CommentOrder,
   type Entity,
   EntityManager,
   FavoriteShape,
@@ -91,7 +89,6 @@ import {
   TaskNew,
   type TaskNewId,
   taskNewMeta,
-  type TaskNewOrder,
   User,
   type UserId,
   userMeta,
@@ -362,13 +359,6 @@ export interface AuthorOrder {
   currentDraftBook?: BookOrder;
   favoriteBook?: BookOrder;
   publisher?: PublisherOrder;
-  mentees?: AuthorOrder;
-  books?: BookOrder;
-  reviewerBooks?: BookOrder;
-  schedules?: AuthorScheduleOrder;
-  comments?: CommentOrder;
-  spotlightAuthorPublishers?: PublisherOrder;
-  tasks?: TaskNewOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/integration/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookCodegen.ts
@@ -54,12 +54,10 @@ import {
   BookAdvance,
   type BookAdvanceId,
   bookAdvanceMeta,
-  type BookAdvanceOrder,
   bookMeta,
   BookReview,
   type BookReviewId,
   bookReviewMeta,
-  type BookReviewOrder,
   Comment,
   type CommentId,
   commentMeta,
@@ -195,9 +193,6 @@ export interface BookOrder {
   author?: AuthorOrder;
   reviewer?: AuthorOrder;
   randomComment?: CommentOrder;
-  advances?: BookAdvanceOrder;
-  reviews?: BookReviewOrder;
-  comments?: CommentOrder;
 }
 
 export const bookConfig = new ConfigApi<Book, Context>();

--- a/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
@@ -41,7 +41,6 @@ import {
   ChildGroup,
   type ChildGroupId,
   childGroupMeta,
-  type ChildGroupOrder,
   childMeta,
   type Entity,
   EntityManager,
@@ -87,7 +86,6 @@ export interface ChildOrder {
   name?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
-  groups?: ChildGroupOrder;
 }
 
 export const childConfig = new ConfigApi<Child, Context>();

--- a/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
@@ -46,7 +46,6 @@ import {
   ChildItem,
   type ChildItemId,
   childItemMeta,
-  type ChildItemOrder,
   childMeta,
   type ChildOrder,
   type Entity,
@@ -109,7 +108,6 @@ export interface ChildGroupOrder {
   updatedAt?: OrderBy;
   childGroupId?: ChildOrder;
   parentGroup?: ParentGroupOrder;
-  childItems?: ChildItemOrder;
 }
 
 export const childGroupConfig = new ConfigApi<ChildGroup, Context>();

--- a/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
@@ -52,7 +52,6 @@ import {
   Book,
   type BookId,
   bookMeta,
-  type BookOrder,
   BookReview,
   Comment,
   commentMeta,
@@ -149,7 +148,6 @@ export interface CommentOrder {
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
   user?: UserOrder;
-  books?: BookOrder;
 }
 
 export const commentConfig = new ConfigApi<Comment, Context>();

--- a/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
@@ -44,7 +44,6 @@ import {
   BookReview,
   type BookReviewId,
   bookReviewMeta,
-  type BookReviewOrder,
   Critic,
   CriticColumn,
   type CriticColumnId,
@@ -132,7 +131,6 @@ export interface CriticOrder {
   updatedAt?: OrderBy;
   favoriteLargePublisher?: LargePublisherOrder;
   group?: PublisherGroupOrder;
-  bookReviews?: BookReviewOrder;
 }
 
 export const criticConfig = new ConfigApi<Critic, Context>();

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -44,7 +44,6 @@ import {
   Critic,
   type CriticId,
   criticMeta,
-  type CriticOrder,
   type Entity,
   EntityManager,
   Image,
@@ -64,7 +63,6 @@ import {
   User,
   type UserId,
   userMeta,
-  type UserOrder,
 } from "../entities";
 
 export type LargePublisherId = Flavor<string, "Publisher">;
@@ -106,8 +104,6 @@ export interface LargePublisherGraphQLFilter extends PublisherGraphQLFilter {
 export interface LargePublisherOrder extends PublisherOrder {
   sharedColumn?: OrderBy;
   country?: OrderBy;
-  critics?: CriticOrder;
-  users?: UserOrder;
 }
 
 export const largePublisherConfig = new ConfigApi<LargePublisher, Context>();

--- a/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
@@ -40,7 +40,6 @@ import {
   ChildGroup,
   type ChildGroupId,
   childGroupMeta,
-  type ChildGroupOrder,
   type Entity,
   EntityManager,
   newParentGroup,
@@ -49,7 +48,6 @@ import {
   ParentItem,
   type ParentItemId,
   parentItemMeta,
-  type ParentItemOrder,
 } from "../entities";
 
 export type ParentGroupId = Flavor<string, "ParentGroup">;
@@ -95,8 +93,6 @@ export interface ParentGroupOrder {
   name?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
-  childGroups?: ChildGroupOrder;
-  parentItems?: ParentItemOrder;
 }
 
 export const parentGroupConfig = new ConfigApi<ParentGroup, Context>();

--- a/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
@@ -42,7 +42,6 @@ import {
   ChildItem,
   type ChildItemId,
   childItemMeta,
-  type ChildItemOrder,
   type Entity,
   EntityManager,
   newParentItem,
@@ -99,7 +98,6 @@ export interface ParentItemOrder {
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
   parentGroup?: ParentGroupOrder;
-  childItems?: ChildItemOrder;
 }
 
 export const parentItemConfig = new ConfigApi<ParentItem, Context>();

--- a/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
@@ -51,17 +51,14 @@ import {
   BookAdvance,
   type BookAdvanceId,
   bookAdvanceMeta,
-  type BookAdvanceOrder,
   Comment,
   type CommentId,
   commentMeta,
-  type CommentOrder,
   type Entity,
   EntityManager,
   Image,
   type ImageId,
   imageMeta,
-  type ImageOrder,
   LargePublisher,
   newPublisher,
   Publisher,
@@ -222,10 +219,6 @@ export interface PublisherOrder {
   favoriteAuthor?: AuthorOrder;
   group?: PublisherGroupOrder;
   spotlightAuthor?: AuthorOrder;
-  authors?: AuthorOrder;
-  bookAdvances?: BookAdvanceOrder;
-  comments?: CommentOrder;
-  images?: ImageOrder;
 }
 
 export const publisherConfig = new ConfigApi<Publisher, Context>();

--- a/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
@@ -54,7 +54,6 @@ import {
   publisherGroupMeta,
   type PublisherId,
   publisherMeta,
-  type PublisherOrder,
   SmallPublisher,
   SmallPublisherGroup,
   type SmallPublisherId,
@@ -117,7 +116,6 @@ export interface PublisherGroupOrder {
   numberOfBookReviews?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
-  publishers?: PublisherOrder;
 }
 
 export const publisherGroupConfig = new ConfigApi<PublisherGroup, Context>();

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -67,7 +67,6 @@ import {
   User,
   type UserId,
   userMeta,
-  type UserOrder,
 } from "../entities";
 
 export type SmallPublisherId = Flavor<string, "Publisher">;
@@ -130,8 +129,6 @@ export interface SmallPublisherOrder extends PublisherOrder {
   allAuthorNames?: OrderBy;
   selfReferential?: SmallPublisherOrder;
   group?: SmallPublisherGroupOrder;
-  smallPublishers?: SmallPublisherOrder;
-  users?: UserOrder;
 }
 
 export const smallPublisherConfig = new ConfigApi<SmallPublisher, Context>();

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
@@ -50,7 +50,6 @@ import {
   smallPublisherGroupMeta,
   type SmallPublisherId,
   smallPublisherMeta,
-  type SmallPublisherOrder,
 } from "../entities";
 
 export type SmallPublisherGroupId = Flavor<string, "PublisherGroup">;
@@ -81,7 +80,6 @@ export interface SmallPublisherGroupGraphQLFilter extends PublisherGroupGraphQLF
 
 export interface SmallPublisherGroupOrder extends PublisherGroupOrder {
   smallName?: OrderBy;
-  publishers?: SmallPublisherOrder;
 }
 
 export const smallPublisherGroupConfig = new ConfigApi<SmallPublisherGroup, Context>();

--- a/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
@@ -57,7 +57,6 @@ import {
   TaskItem,
   type TaskItemId,
   taskItemMeta,
-  type TaskItemOrder,
   taskMeta,
   TaskNew,
   type TaskNewId,
@@ -161,8 +160,6 @@ export interface TaskOrder {
   updatedAt?: OrderBy;
   type?: OrderBy;
   copiedFrom?: TaskOrder;
-  copiedTo?: TaskOrder;
-  taskTaskItems?: TaskItemOrder;
 }
 
 export const taskConfig = new ConfigApi<Task, Context>();

--- a/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
@@ -56,7 +56,6 @@ import {
   TaskItem,
   type TaskItemId,
   taskItemMeta,
-  type TaskItemOrder,
   TaskNew,
   taskNewMeta,
   type TaskOpts,
@@ -117,9 +116,6 @@ export interface TaskNewOrder extends TaskOrder {
   selfReferential?: TaskNewOrder;
   specialNewAuthor?: AuthorOrder;
   copiedFrom?: TaskNewOrder;
-  newTaskTaskItems?: TaskItemOrder;
-  selfReferentialTasks?: TaskNewOrder;
-  copiedTo?: TaskNewOrder;
 }
 
 export const taskNewConfig = new ConfigApi<TaskNew, Context>();

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -45,7 +45,6 @@ import {
   Comment,
   type CommentId,
   commentMeta,
-  type CommentOrder,
   type Entity,
   EntityManager,
   newTaskOld,
@@ -61,7 +60,6 @@ import {
   TaskItem,
   type TaskItemId,
   taskItemMeta,
-  type TaskItemOrder,
   TaskOld,
   taskOldMeta,
   type TaskOpts,
@@ -124,10 +122,6 @@ export interface TaskOldOrder extends TaskOrder {
   specialOldField?: OrderBy;
   parentOldTask?: TaskOldOrder;
   copiedFrom?: TaskOldOrder;
-  comments?: CommentOrder;
-  oldTaskTaskItems?: TaskItemOrder;
-  tasks?: TaskOldOrder;
-  copiedTo?: TaskOldOrder;
 }
 
 export const taskOldConfig = new ConfigApi<TaskOld, Context>();

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -57,7 +57,6 @@ import {
   Comment,
   type CommentId,
   commentMeta,
-  type CommentOrder,
   type Entity,
   EntityManager,
   LargePublisher,
@@ -187,8 +186,6 @@ export interface UserOrder {
   updatedAt?: OrderBy;
   manager?: UserOrder;
   authorManyToOne?: AuthorOrder;
-  createdComments?: CommentOrder;
-  directs?: UserOrder;
 }
 
 export const userConfig = new ConfigApi<User, Context>();

--- a/packages/tests/integration/src/setupTestEnv.ts
+++ b/packages/tests/integration/src/setupTestEnv.ts
@@ -2,7 +2,7 @@ import { GetEnvVars } from "env-cmd";
 
 export default async function globalSetup() {
   process.env.TZ = "UTC";
-  // process.env.DEBUG = "knex:query,knex:bindings";
+  // process.env.DEBUG = "knex:query,bindings";
   // process.env.DEBUG = "knex:*";
   Object.entries(await GetEnvVars()).forEach(([key, value]) => (process.env[key] = value));
 }

--- a/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
@@ -36,17 +36,7 @@ import {
   type ValueGraphQLFilter,
 } from "joist-orm";
 import { type Context } from "src/context";
-import {
-  Author,
-  authorMeta,
-  Book,
-  type BookId,
-  bookMeta,
-  type BookOrder,
-  type Entity,
-  EntityManager,
-  newAuthor,
-} from "../entities";
+import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
 
 export type AuthorId = Flavor<number, "Author">;
 
@@ -92,7 +82,6 @@ export interface AuthorOrder {
   lastName?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
-  books?: BookOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
@@ -45,7 +45,6 @@ import {
   Painting,
   type PaintingId,
   paintingMeta,
-  type PaintingOrder,
 } from "../entities";
 
 export type ArtistId = Flavor<string, "Artist">;
@@ -92,7 +91,6 @@ export interface ArtistOrder {
   lastName?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
-  paintings?: PaintingOrder;
 }
 
 export const artistConfig = new ConfigApi<Artist, Context>();

--- a/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
@@ -38,17 +38,7 @@ import {
   type ValueGraphQLFilter,
 } from "joist-orm";
 import { type Context } from "src/context";
-import {
-  Author,
-  authorMeta,
-  Book,
-  type BookId,
-  bookMeta,
-  type BookOrder,
-  type Entity,
-  EntityManager,
-  newAuthor,
-} from "../entities";
+import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
 
 export type AuthorId = Flavor<string, "Author">;
 
@@ -99,7 +89,6 @@ export interface AuthorOrder {
   delete?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
-  books?: BookOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
@@ -37,17 +37,7 @@ import {
 } from "joist-orm";
 import { type Context } from "src/context";
 import { Temporal } from "temporal-polyfill";
-import {
-  Author,
-  authorMeta,
-  Book,
-  type BookId,
-  bookMeta,
-  type BookOrder,
-  type Entity,
-  EntityManager,
-  newAuthor,
-} from "../entities";
+import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
 
 export type AuthorId = Flavor<string, "Author">;
 
@@ -128,7 +118,6 @@ export interface AuthorOrder {
   timeToMicros?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
-  books?: BookOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
@@ -42,15 +42,12 @@ import {
   Book,
   type BookId,
   bookMeta,
-  type BookOrder,
   BookReview,
   type BookReviewId,
   bookReviewMeta,
-  type BookReviewOrder,
   Comment,
   type CommentId,
   commentMeta,
-  type CommentOrder,
   type Entity,
   EntityManager,
   newAuthor,
@@ -108,9 +105,6 @@ export interface AuthorOrder {
   lastName?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
-  books?: BookOrder;
-  bookReviews?: BookReviewOrder;
-  comments?: CommentOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();

--- a/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
@@ -48,7 +48,6 @@ import {
   Comment,
   type CommentId,
   commentMeta,
-  type CommentOrder,
   type Entity,
   EntityManager,
   newBook,
@@ -99,7 +98,6 @@ export interface BookOrder {
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
   author?: AuthorOrder;
-  comments?: CommentOrder;
 }
 
 export const bookConfig = new ConfigApi<Book, Context>();

--- a/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
@@ -36,17 +36,7 @@ import {
   type ValueGraphQLFilter,
 } from "joist-orm";
 import { type Context } from "src/context";
-import {
-  Author,
-  authorMeta,
-  Book,
-  type BookId,
-  bookMeta,
-  type BookOrder,
-  type Entity,
-  EntityManager,
-  newAuthor,
-} from "../entities";
+import { Author, authorMeta, Book, type BookId, bookMeta, type Entity, EntityManager, newAuthor } from "../entities";
 
 export type AuthorId = Flavor<string, "Author">;
 
@@ -92,7 +82,6 @@ export interface AuthorOrder {
   lastName?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
-  books?: BookOrder;
 }
 
 export const authorConfig = new ConfigApi<Author, Context>();


### PR DESCRIPTION
We ran into issues rolling this out internally -- despite our entire / non-trivial / usually-a-pedantic-pita test suite passing, we didn't caught that complex conditions against child/o2m relations had a breaking change in semantics.

So reverting back to the `OUTER JOIN`s + `DISTINCT` approach for now.

See #1338 for more on the issue + ideas to fix it.