### PR TITLE
chore: add repo link to joist-utils package.json

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,6 +2,11 @@
   "name": "joist-utils",
   "version": "1.222.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joist-orm/joist-orm.git",
+    "directory": "packages/utils"
+  },
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
The one sad non-link in Dependabot! 😅 

![Screenshot 2025-01-08 at 15 27 35](https://github.com/user-attachments/assets/81e61734-2225-438a-ba0e-ba793306c50a)
