### PR TITLE
feat: Allow factories to set derived values.

### DIFF
--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -69,7 +69,7 @@ export function newTestInstance<T extends Entity>(
   em: EntityManager,
   cstr: EntityConstructor<T>,
   /** The test's test-specific override opts. */
-  testOpts: FactoryOpts<T> = {} as FactoryOpts<T>,
+  testOpts: FactoryOpts<T> = {},
   /** The factory file's default opts. */
   factoryOpts: FactoryOpts<T> & {
     useExisting?: (opts: OptsOf<T>, existing: DeepNew<T>) => boolean;

--- a/packages/orm/src/typeMap.ts
+++ b/packages/orm/src/typeMap.ts
@@ -49,6 +49,9 @@ export type GraphQLFilterOf<T> = TypeMapEntry<T, "gqlFilterType">;
 /** Pulls the entity order type out of a given entity type T. */
 export type OrderOf<T> = TypeMapEntry<T, "orderType">;
 
+/** Returns the factory "extras" type, like `withDerivedField`. */
+export type FactoryExtrasOf<T> = TypeMapEntry<T, "factoryExtrasType">;
+
 /**
  * Returns the opts of the entity's `newEntity` factory method, as exists in the actual file.
  *

--- a/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
@@ -91,6 +91,9 @@ export interface AuthorOrder {
   updatedAt?: OrderBy;
 }
 
+export interface AuthorFactoryExtras {
+}
+
 export const authorConfig = new ConfigApi<Author, Context>();
 
 authorConfig.addRule(newRequiredRule("firstName"));
@@ -107,6 +110,7 @@ declare module "joist-orm" {
       optsType: AuthorOpts;
       fieldsType: AuthorFields;
       optIdsType: AuthorIdsOpts;
+      factoryExtrasType: AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newAuthor>[1];
     };
   }

--- a/packages/tests/esm-misc/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/BookCodegen.ts
@@ -83,6 +83,9 @@ export interface BookOrder {
   author?: AuthorOrder;
 }
 
+export interface BookFactoryExtras {
+}
+
 export const bookConfig = new ConfigApi<Book, Context>();
 
 bookConfig.addRule(newRequiredRule("title"));
@@ -98,6 +101,7 @@ declare module "joist-orm" {
       optsType: BookOpts;
       fieldsType: BookFields;
       optIdsType: BookIdsOpts;
+      factoryExtrasType: BookFactoryExtras;
       factoryOptsType: Parameters<typeof newBook>[1];
     };
   }

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
@@ -80,6 +80,9 @@ export interface T1AuthorOrder {
   firstName?: OrderBy;
 }
 
+export interface T1AuthorFactoryExtras {
+}
+
 export const t1AuthorConfig = new ConfigApi<T1Author, Context>();
 
 t1AuthorConfig.addRule(newRequiredRule("firstName"));
@@ -94,6 +97,7 @@ declare module "joist-orm" {
       optsType: T1AuthorOpts;
       fieldsType: T1AuthorFields;
       optIdsType: T1AuthorIdsOpts;
+      factoryExtrasType: T1AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newT1Author>[1];
     };
   }

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T1BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T1BookCodegen.ts
@@ -83,6 +83,9 @@ export interface T1BookOrder {
   author?: T1AuthorOrder;
 }
 
+export interface T1BookFactoryExtras {
+}
+
 export const t1BookConfig = new ConfigApi<T1Book, Context>();
 
 t1BookConfig.addRule(newRequiredRule("title"));
@@ -98,6 +101,7 @@ declare module "joist-orm" {
       optsType: T1BookOpts;
       fieldsType: T1BookFields;
       optIdsType: T1BookIdsOpts;
+      factoryExtrasType: T1BookFactoryExtras;
       factoryOptsType: Parameters<typeof newT1Book>[1];
     };
   }

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
@@ -89,6 +89,9 @@ export interface T2AuthorOrder {
   favoriteBook?: T2BookOrder;
 }
 
+export interface T2AuthorFactoryExtras {
+}
+
 export const t2AuthorConfig = new ConfigApi<T2Author, Context>();
 
 t2AuthorConfig.addRule(newRequiredRule("firstName"));
@@ -103,6 +106,7 @@ declare module "joist-orm" {
       optsType: T2AuthorOpts;
       fieldsType: T2AuthorFields;
       optIdsType: T2AuthorIdsOpts;
+      factoryExtrasType: T2AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newT2Author>[1];
     };
   }

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
@@ -89,6 +89,9 @@ export interface T2BookOrder {
   author?: T2AuthorOrder;
 }
 
+export interface T2BookFactoryExtras {
+}
+
 export const t2BookConfig = new ConfigApi<T2Book, Context>();
 
 t2BookConfig.addRule(newRequiredRule("title"));
@@ -104,6 +107,7 @@ declare module "joist-orm" {
       optsType: T2BookOpts;
       fieldsType: T2BookFields;
       optIdsType: T2BookIdsOpts;
+      factoryExtrasType: T2BookFactoryExtras;
       factoryOptsType: Parameters<typeof newT2Book>[1];
     };
   }

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
@@ -89,6 +89,9 @@ export interface T3AuthorOrder {
   favoriteBook?: T3BookOrder;
 }
 
+export interface T3AuthorFactoryExtras {
+}
+
 export const t3AuthorConfig = new ConfigApi<T3Author, Context>();
 
 t3AuthorConfig.addRule(newRequiredRule("firstName"));
@@ -104,6 +107,7 @@ declare module "joist-orm" {
       optsType: T3AuthorOpts;
       fieldsType: T3AuthorFields;
       optIdsType: T3AuthorIdsOpts;
+      factoryExtrasType: T3AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newT3Author>[1];
     };
   }

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
@@ -89,6 +89,9 @@ export interface T3BookOrder {
   author?: T3AuthorOrder;
 }
 
+export interface T3BookFactoryExtras {
+}
+
 export const t3BookConfig = new ConfigApi<T3Book, Context>();
 
 t3BookConfig.addRule(newRequiredRule("title"));
@@ -104,6 +107,7 @@ declare module "joist-orm" {
       optsType: T3BookOpts;
       fieldsType: T3BookFields;
       optIdsType: T3BookIdsOpts;
+      factoryExtrasType: T3BookFactoryExtras;
       factoryOptsType: Parameters<typeof newT3Book>[1];
     };
   }

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
@@ -89,6 +89,9 @@ export interface T4AuthorOrder {
   favoriteBook?: T4BookOrder;
 }
 
+export interface T4AuthorFactoryExtras {
+}
+
 export const t4AuthorConfig = new ConfigApi<T4Author, Context>();
 
 t4AuthorConfig.addRule(newRequiredRule("firstName"));
@@ -104,6 +107,7 @@ declare module "joist-orm" {
       optsType: T4AuthorOpts;
       fieldsType: T4AuthorFields;
       optIdsType: T4AuthorIdsOpts;
+      factoryExtrasType: T4AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newT4Author>[1];
     };
   }

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
@@ -89,6 +89,9 @@ export interface T4BookOrder {
   author?: T4AuthorOrder;
 }
 
+export interface T4BookFactoryExtras {
+}
+
 export const t4BookConfig = new ConfigApi<T4Book, Context>();
 
 t4BookConfig.addRule(newRequiredRule("title"));
@@ -104,6 +107,7 @@ declare module "joist-orm" {
       optsType: T4BookOpts;
       fieldsType: T4BookFields;
       optIdsType: T4BookIdsOpts;
+      factoryExtrasType: T4BookFactoryExtras;
       factoryOptsType: Parameters<typeof newT4Book>[1];
     };
   }

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
@@ -80,6 +80,9 @@ export interface T5AuthorOrder {
   firstName?: OrderBy;
 }
 
+export interface T5AuthorFactoryExtras {
+}
+
 export const t5AuthorConfig = new ConfigApi<T5Author, Context>();
 
 t5AuthorConfig.addRule(newRequiredRule("firstName"));
@@ -94,6 +97,7 @@ declare module "joist-orm" {
       optsType: T5AuthorOpts;
       fieldsType: T5AuthorFields;
       optIdsType: T5AuthorIdsOpts;
+      factoryExtrasType: T5AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newT5Author>[1];
     };
   }

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
@@ -92,6 +92,9 @@ export interface T5BookOrder {
   author?: T5AuthorOrder;
 }
 
+export interface T5BookFactoryExtras {
+}
+
 export const t5BookConfig = new ConfigApi<T5Book, Context>();
 
 t5BookConfig.addRule(newRequiredRule("title"));
@@ -107,6 +110,7 @@ declare module "joist-orm" {
       optsType: T5BookOpts;
       fieldsType: T5BookFields;
       optIdsType: T5BookIdsOpts;
+      factoryExtrasType: T5BookFactoryExtras;
       factoryOptsType: Parameters<typeof newT5Book>[1];
     };
   }

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookReviewCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookReviewCodegen.ts
@@ -83,6 +83,9 @@ export interface T5BookReviewOrder {
   book?: T5BookOrder;
 }
 
+export interface T5BookReviewFactoryExtras {
+}
+
 export const t5BookReviewConfig = new ConfigApi<T5BookReview, Context>();
 
 t5BookReviewConfig.addRule(newRequiredRule("title"));
@@ -97,6 +100,7 @@ declare module "joist-orm" {
       optsType: T5BookReviewOpts;
       fieldsType: T5BookReviewFields;
       optIdsType: T5BookReviewIdsOpts;
+      factoryExtrasType: T5BookReviewFactoryExtras;
       factoryOptsType: Parameters<typeof newT5BookReview>[1];
     };
   }

--- a/packages/tests/integration/src/entities/Publisher.ts
+++ b/packages/tests/integration/src/entities/Publisher.ts
@@ -29,6 +29,7 @@ const allImagesHint = { images: [], authors: { image: [], books: "image" } } as 
 export abstract class Publisher extends PublisherCodegen {
   transientFields = {
     numberOfBookReviewEvals: 0,
+    numberOfBookReviewCalcs: 0,
     wasNewInBeforeCommit: undefined as boolean | undefined,
     changedInBeforeCommit: [] as string[],
   };
@@ -43,7 +44,10 @@ export abstract class Publisher extends PublisherCodegen {
     // this hint will recalc + not be available on `p`
     { authors: { books: "reviews" } },
     // findCount is N+1 safe
-    (p) => p.em.findCount(BookReview, { book: { author: { publisher: p.id } } }),
+    (p) => {
+      p.transientFields.numberOfBookReviewCalcs++;
+      return p.em.findCount(BookReview, { book: { author: { publisher: p.id } } });
+    },
   );
 
   /** Example of a ReactiveField reacting to ReactiveReferences. */

--- a/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AdminUserCodegen.ts
@@ -74,6 +74,9 @@ export interface AdminUserOrder extends UserOrder {
   role?: OrderBy;
 }
 
+export interface AdminUserFactoryExtras {
+}
+
 export const adminUserConfig = new ConfigApi<AdminUser, Context>();
 
 adminUserConfig.addRule(newRequiredRule("role"));
@@ -88,6 +91,7 @@ declare module "joist-orm" {
       optsType: AdminUserOpts;
       fieldsType: AdminUserFields;
       optIdsType: AdminUserIdsOpts;
+      factoryExtrasType: AdminUserFactoryExtras;
       factoryOptsType: Parameters<typeof newAdminUser>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
@@ -361,6 +361,18 @@ export interface AuthorOrder {
   publisher?: PublisherOrder;
 }
 
+export interface AuthorFactoryExtras {
+  withNumberOfBooks?: number;
+  withBookComments?: string | null;
+  withNickNamesUpper?: string[] | null;
+  withMentorNames?: string | null;
+  withNumberOfPublicReviews?: number | null;
+  withNumberOfPublicReviews2?: number | null;
+  withTagsOfAllBooks?: string | null;
+  withSearch?: string | null;
+  withRangeOfBooks?: BookRange | null;
+}
+
 export const authorConfig = new ConfigApi<Author, Context>();
 
 authorConfig.addRule(newRequiredRule("firstName"));
@@ -381,6 +393,7 @@ declare module "joist-orm" {
       optsType: AuthorOpts;
       fieldsType: AuthorFields;
       optIdsType: AuthorIdsOpts;
+      factoryExtrasType: AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newAuthor>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorScheduleCodegen.ts
@@ -91,6 +91,9 @@ export interface AuthorScheduleOrder {
   author?: AuthorOrder;
 }
 
+export interface AuthorScheduleFactoryExtras {
+}
+
 export const authorScheduleConfig = new ConfigApi<AuthorSchedule, Context>();
 
 authorScheduleConfig.addRule(newRequiredRule("createdAt"));
@@ -107,6 +110,7 @@ declare module "joist-orm" {
       optsType: AuthorScheduleOpts;
       fieldsType: AuthorScheduleFields;
       optIdsType: AuthorScheduleIdsOpts;
+      factoryExtrasType: AuthorScheduleFactoryExtras;
       factoryOptsType: Parameters<typeof newAuthorSchedule>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorStatCodegen.ts
@@ -124,6 +124,9 @@ export interface AuthorStatOrder {
   updatedAt?: OrderBy;
 }
 
+export interface AuthorStatFactoryExtras {
+}
+
 export const authorStatConfig = new ConfigApi<AuthorStat, Context>();
 
 authorStatConfig.addRule(newRequiredRule("smallint"));
@@ -148,6 +151,7 @@ declare module "joist-orm" {
       optsType: AuthorStatOpts;
       fieldsType: AuthorStatFields;
       optIdsType: AuthorStatIdsOpts;
+      factoryExtrasType: AuthorStatFactoryExtras;
       factoryOptsType: Parameters<typeof newAuthorStat>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookAdvanceCodegen.ts
@@ -121,6 +121,9 @@ export interface BookAdvanceOrder {
   publisher?: PublisherOrder;
 }
 
+export interface BookAdvanceFactoryExtras {
+}
+
 export const bookAdvanceConfig = new ConfigApi<BookAdvance, Context>();
 
 bookAdvanceConfig.addRule(newRequiredRule("createdAt"));
@@ -139,6 +142,7 @@ declare module "joist-orm" {
       optsType: BookAdvanceOpts;
       fieldsType: BookAdvanceFields;
       optIdsType: BookAdvanceIdsOpts;
+      factoryExtrasType: BookAdvanceFactoryExtras;
       factoryOptsType: Parameters<typeof newBookAdvance>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookCodegen.ts
@@ -195,6 +195,10 @@ export interface BookOrder {
   randomComment?: CommentOrder;
 }
 
+export interface BookFactoryExtras {
+  withSearch?: string | null;
+}
+
 export const bookConfig = new ConfigApi<Book, Context>();
 
 bookConfig.addRule(newRequiredRule("title"));
@@ -215,6 +219,7 @@ declare module "joist-orm" {
       optsType: BookOpts;
       fieldsType: BookFields;
       optIdsType: BookIdsOpts;
+      factoryExtrasType: BookFactoryExtras;
       factoryOptsType: Parameters<typeof newBook>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
@@ -129,6 +129,11 @@ export interface BookReviewOrder {
   critic?: CriticOrder;
 }
 
+export interface BookReviewFactoryExtras {
+  withIsPublic?: boolean;
+  withIsTest?: boolean;
+}
+
 export const bookReviewConfig = new ConfigApi<BookReview, Context>();
 
 bookReviewConfig.addRule(newRequiredRule("rating"));
@@ -148,6 +153,7 @@ declare module "joist-orm" {
       optsType: BookReviewOpts;
       fieldsType: BookReviewFields;
       optIdsType: BookReviewIdsOpts;
+      factoryExtrasType: BookReviewFactoryExtras;
       factoryOptsType: Parameters<typeof newBookReview>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
@@ -88,6 +88,9 @@ export interface ChildOrder {
   updatedAt?: OrderBy;
 }
 
+export interface ChildFactoryExtras {
+}
+
 export const childConfig = new ConfigApi<Child, Context>();
 
 childConfig.addRule(newRequiredRule("createdAt"));
@@ -103,6 +106,7 @@ declare module "joist-orm" {
       optsType: ChildOpts;
       fieldsType: ChildFields;
       optIdsType: ChildIdsOpts;
+      factoryExtrasType: ChildFactoryExtras;
       factoryOptsType: Parameters<typeof newChild>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
@@ -110,6 +110,9 @@ export interface ChildGroupOrder {
   parentGroup?: ParentGroupOrder;
 }
 
+export interface ChildGroupFactoryExtras {
+}
+
 export const childGroupConfig = new ConfigApi<ChildGroup, Context>();
 
 childGroupConfig.addRule(newRequiredRule("createdAt"));
@@ -127,6 +130,7 @@ declare module "joist-orm" {
       optsType: ChildGroupOpts;
       fieldsType: ChildGroupFields;
       optIdsType: ChildGroupIdsOpts;
+      factoryExtrasType: ChildGroupFactoryExtras;
       factoryOptsType: Parameters<typeof newChildGroup>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildItemCodegen.ts
@@ -101,6 +101,9 @@ export interface ChildItemOrder {
   parentItem?: ParentItemOrder;
 }
 
+export interface ChildItemFactoryExtras {
+}
+
 export const childItemConfig = new ConfigApi<ChildItem, Context>();
 
 childItemConfig.addRule(newRequiredRule("createdAt"));
@@ -118,6 +121,7 @@ declare module "joist-orm" {
       optsType: ChildItemOpts;
       fieldsType: ChildItemFields;
       optIdsType: ChildItemIdsOpts;
+      factoryExtrasType: ChildItemFactoryExtras;
       factoryOptsType: Parameters<typeof newChildItem>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
@@ -150,6 +150,11 @@ export interface CommentOrder {
   user?: UserOrder;
 }
 
+export interface CommentFactoryExtras {
+  withParentTaggedId?: string | null;
+  withParentTags?: string;
+}
+
 export const commentConfig = new ConfigApi<Comment, Context>();
 
 commentConfig.addRule("parentTags", newRequiredRule("parentTags"));
@@ -167,6 +172,7 @@ declare module "joist-orm" {
       optsType: CommentOpts;
       fieldsType: CommentFields;
       optIdsType: CommentIdsOpts;
+      factoryExtrasType: CommentFactoryExtras;
       factoryOptsType: Parameters<typeof newComment>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
@@ -133,6 +133,9 @@ export interface CriticOrder {
   group?: PublisherGroupOrder;
 }
 
+export interface CriticFactoryExtras {
+}
+
 export const criticConfig = new ConfigApi<Critic, Context>();
 
 criticConfig.addRule(newRequiredRule("name"));
@@ -149,6 +152,7 @@ declare module "joist-orm" {
       optsType: CriticOpts;
       fieldsType: CriticFields;
       optIdsType: CriticIdsOpts;
+      factoryExtrasType: CriticFactoryExtras;
       factoryOptsType: Parameters<typeof newCritic>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticColumnCodegen.ts
@@ -91,6 +91,9 @@ export interface CriticColumnOrder {
   critic?: CriticOrder;
 }
 
+export interface CriticColumnFactoryExtras {
+}
+
 export const criticColumnConfig = new ConfigApi<CriticColumn, Context>();
 
 criticColumnConfig.addRule(newRequiredRule("name"));
@@ -108,6 +111,7 @@ declare module "joist-orm" {
       optsType: CriticColumnOpts;
       fieldsType: CriticColumnFields;
       optIdsType: CriticColumnIdsOpts;
+      factoryExtrasType: CriticColumnFactoryExtras;
       factoryOptsType: Parameters<typeof newCriticColumn>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ImageCodegen.ts
@@ -137,6 +137,9 @@ export interface ImageOrder {
   publisher?: PublisherOrder;
 }
 
+export interface ImageFactoryExtras {
+}
+
 export const imageConfig = new ConfigApi<Image, Context>();
 
 imageConfig.addRule(newRequiredRule("fileName"));
@@ -154,6 +157,7 @@ declare module "joist-orm" {
       optsType: ImageOpts;
       fieldsType: ImageFields;
       optIdsType: ImageIdsOpts;
+      factoryExtrasType: ImageFactoryExtras;
       factoryOptsType: Parameters<typeof newImage>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -106,6 +106,9 @@ export interface LargePublisherOrder extends PublisherOrder {
   country?: OrderBy;
 }
 
+export interface LargePublisherFactoryExtras {
+}
+
 export const largePublisherConfig = new ConfigApi<LargePublisher, Context>();
 
 declare module "joist-orm" {
@@ -118,6 +121,7 @@ declare module "joist-orm" {
       optsType: LargePublisherOpts;
       fieldsType: LargePublisherFields;
       optIdsType: LargePublisherIdsOpts;
+      factoryExtrasType: LargePublisherFactoryExtras;
       factoryOptsType: Parameters<typeof newLargePublisher>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
@@ -95,6 +95,9 @@ export interface ParentGroupOrder {
   updatedAt?: OrderBy;
 }
 
+export interface ParentGroupFactoryExtras {
+}
+
 export const parentGroupConfig = new ConfigApi<ParentGroup, Context>();
 
 parentGroupConfig.addRule(newRequiredRule("createdAt"));
@@ -110,6 +113,7 @@ declare module "joist-orm" {
       optsType: ParentGroupOpts;
       fieldsType: ParentGroupFields;
       optIdsType: ParentGroupIdsOpts;
+      factoryExtrasType: ParentGroupFactoryExtras;
       factoryOptsType: Parameters<typeof newParentGroup>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
@@ -100,6 +100,9 @@ export interface ParentItemOrder {
   parentGroup?: ParentGroupOrder;
 }
 
+export interface ParentItemFactoryExtras {
+}
+
 export const parentItemConfig = new ConfigApi<ParentItem, Context>();
 
 parentItemConfig.addRule(newRequiredRule("createdAt"));
@@ -116,6 +119,7 @@ declare module "joist-orm" {
       optsType: ParentItemOpts;
       fieldsType: ParentItemFields;
       optIdsType: ParentItemIdsOpts;
+      factoryExtrasType: ParentItemFactoryExtras;
       factoryOptsType: Parameters<typeof newParentItem>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
@@ -221,6 +221,11 @@ export interface PublisherOrder {
   spotlightAuthor?: AuthorOrder;
 }
 
+export interface PublisherFactoryExtras {
+  withNumberOfBookReviews?: number;
+  withTitlesOfFavoriteBooks?: string | null;
+}
+
 export const publisherConfig = new ConfigApi<Publisher, Context>();
 
 publisherConfig.addRule(newRequiredRule("name"));
@@ -243,6 +248,7 @@ declare module "joist-orm" {
       optsType: PublisherOpts;
       fieldsType: PublisherFields;
       optIdsType: PublisherIdsOpts;
+      factoryExtrasType: PublisherFactoryExtras;
       factoryOptsType: Parameters<typeof newPublisher>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
@@ -118,6 +118,10 @@ export interface PublisherGroupOrder {
   updatedAt?: OrderBy;
 }
 
+export interface PublisherGroupFactoryExtras {
+  withNumberOfBookReviews?: number;
+}
+
 export const publisherGroupConfig = new ConfigApi<PublisherGroup, Context>();
 
 publisherGroupConfig.addRule("numberOfBookReviews", newRequiredRule("numberOfBookReviews"));
@@ -134,6 +138,7 @@ declare module "joist-orm" {
       optsType: PublisherGroupOpts;
       fieldsType: PublisherGroupFields;
       optIdsType: PublisherGroupIdsOpts;
+      factoryExtrasType: PublisherGroupFactoryExtras;
       factoryOptsType: Parameters<typeof newPublisherGroup>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -131,6 +131,10 @@ export interface SmallPublisherOrder extends PublisherOrder {
   group?: SmallPublisherGroupOrder;
 }
 
+export interface SmallPublisherFactoryExtras {
+  withAllAuthorNames?: string | null;
+}
+
 export const smallPublisherConfig = new ConfigApi<SmallPublisher, Context>();
 
 smallPublisherConfig.addRule(newRequiredRule("city"));
@@ -146,6 +150,7 @@ declare module "joist-orm" {
       optsType: SmallPublisherOpts;
       fieldsType: SmallPublisherFields;
       optIdsType: SmallPublisherIdsOpts;
+      factoryExtrasType: SmallPublisherFactoryExtras;
       factoryOptsType: Parameters<typeof newSmallPublisher>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
@@ -82,6 +82,9 @@ export interface SmallPublisherGroupOrder extends PublisherGroupOrder {
   smallName?: OrderBy;
 }
 
+export interface SmallPublisherGroupFactoryExtras {
+}
+
 export const smallPublisherGroupConfig = new ConfigApi<SmallPublisherGroup, Context>();
 
 declare module "joist-orm" {
@@ -94,6 +97,7 @@ declare module "joist-orm" {
       optsType: SmallPublisherGroupOpts;
       fieldsType: SmallPublisherGroupFields;
       optIdsType: SmallPublisherGroupIdsOpts;
+      factoryExtrasType: SmallPublisherGroupFactoryExtras;
       factoryOptsType: Parameters<typeof newSmallPublisherGroup>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TagCodegen.ts
@@ -116,6 +116,9 @@ export interface TagOrder {
   updatedAt?: OrderBy;
 }
 
+export interface TagFactoryExtras {
+}
+
 export const tagConfig = new ConfigApi<Tag, Context>();
 
 tagConfig.addRule(newRequiredRule("name"));
@@ -132,6 +135,7 @@ declare module "joist-orm" {
       optsType: TagOpts;
       fieldsType: TagFields;
       optIdsType: TagIdsOpts;
+      factoryExtrasType: TagFactoryExtras;
       factoryOptsType: Parameters<typeof newTag>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
@@ -162,6 +162,10 @@ export interface TaskOrder {
   copiedFrom?: TaskOrder;
 }
 
+export interface TaskFactoryExtras {
+  withAsyncDerived?: string | null;
+}
+
 export const taskConfig = new ConfigApi<Task, Context>();
 
 taskConfig.addRule(newRequiredRule("durationInDays"));
@@ -179,6 +183,7 @@ declare module "joist-orm" {
       optsType: TaskOpts;
       fieldsType: TaskFields;
       optIdsType: TaskIdsOpts;
+      factoryExtrasType: TaskFactoryExtras;
       factoryOptsType: Parameters<typeof newTask>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskItemCodegen.ts
@@ -109,6 +109,9 @@ export interface TaskItemOrder {
   task?: TaskOrder;
 }
 
+export interface TaskItemFactoryExtras {
+}
+
 export const taskItemConfig = new ConfigApi<TaskItem, Context>();
 
 taskItemConfig.addRule(newRequiredRule("createdAt"));
@@ -126,6 +129,7 @@ declare module "joist-orm" {
       optsType: TaskItemOpts;
       fieldsType: TaskItemFields;
       optIdsType: TaskItemIdsOpts;
+      factoryExtrasType: TaskItemFactoryExtras;
       factoryOptsType: Parameters<typeof newTaskItem>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
@@ -118,6 +118,9 @@ export interface TaskNewOrder extends TaskOrder {
   copiedFrom?: TaskNewOrder;
 }
 
+export interface TaskNewFactoryExtras {
+}
+
 export const taskNewConfig = new ConfigApi<TaskNew, Context>();
 
 taskNewConfig.addRule("selfReferential", mustBeSubType("selfReferential"));
@@ -134,6 +137,7 @@ declare module "joist-orm" {
       optsType: TaskNewOpts;
       fieldsType: TaskNewFields;
       optIdsType: TaskNewIdsOpts;
+      factoryExtrasType: TaskNewFactoryExtras;
       factoryOptsType: Parameters<typeof newTaskNew>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -124,6 +124,9 @@ export interface TaskOldOrder extends TaskOrder {
   copiedFrom?: TaskOldOrder;
 }
 
+export interface TaskOldFactoryExtras {
+}
+
 export const taskOldConfig = new ConfigApi<TaskOld, Context>();
 
 taskOldConfig.addRule(newRequiredRule("specialOldField"));
@@ -141,6 +144,7 @@ declare module "joist-orm" {
       optsType: TaskOldOpts;
       fieldsType: TaskOldFields;
       optIdsType: TaskOldIdsOpts;
+      factoryExtrasType: TaskOldFactoryExtras;
       factoryOptsType: Parameters<typeof newTaskOld>[1];
     };
   }

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -188,6 +188,9 @@ export interface UserOrder {
   authorManyToOne?: AuthorOrder;
 }
 
+export interface UserFactoryExtras {
+}
+
 export const userConfig = new ConfigApi<User, Context>();
 
 userConfig.addRule(newRequiredRule("name"));
@@ -208,6 +211,7 @@ declare module "joist-orm" {
       optsType: UserOpts;
       fieldsType: UserFields;
       optIdsType: UserIdsOpts;
+      factoryExtrasType: UserFactoryExtras;
       factoryOptsType: Parameters<typeof newUser>[1];
     };
   }

--- a/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
@@ -84,6 +84,9 @@ export interface AuthorOrder {
   updatedAt?: OrderBy;
 }
 
+export interface AuthorFactoryExtras {
+}
+
 export const authorConfig = new ConfigApi<Author, Context>();
 
 authorConfig.addRule(newRequiredRule("firstName"));
@@ -100,6 +103,7 @@ declare module "joist-orm" {
       optsType: AuthorOpts;
       fieldsType: AuthorFields;
       optIdsType: AuthorIdsOpts;
+      factoryExtrasType: AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newAuthor>[1];
     };
   }

--- a/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/BookCodegen.ts
@@ -91,6 +91,9 @@ export interface BookOrder {
   author?: AuthorOrder;
 }
 
+export interface BookFactoryExtras {
+}
+
 export const bookConfig = new ConfigApi<Book, Context>();
 
 bookConfig.addRule(newRequiredRule("title"));
@@ -108,6 +111,7 @@ declare module "joist-orm" {
       optsType: BookOpts;
       fieldsType: BookFields;
       optIdsType: BookIdsOpts;
+      factoryExtrasType: BookFactoryExtras;
       factoryOptsType: Parameters<typeof newBook>[1];
     };
   }

--- a/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
@@ -93,6 +93,9 @@ export interface ArtistOrder {
   updatedAt?: OrderBy;
 }
 
+export interface ArtistFactoryExtras {
+}
+
 export const artistConfig = new ConfigApi<Artist, Context>();
 
 artistConfig.addRule(newRequiredRule("firstName"));
@@ -110,6 +113,7 @@ declare module "joist-orm" {
       optsType: ArtistOpts;
       fieldsType: ArtistFields;
       optIdsType: ArtistIdsOpts;
+      factoryExtrasType: ArtistFactoryExtras;
       factoryOptsType: Parameters<typeof newArtist>[1];
     };
   }

--- a/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
@@ -91,6 +91,9 @@ export interface AuthorOrder {
   updatedAt?: OrderBy;
 }
 
+export interface AuthorFactoryExtras {
+}
+
 export const authorConfig = new ConfigApi<Author, Context>();
 
 authorConfig.addRule(newRequiredRule("firstName"));
@@ -107,6 +110,7 @@ declare module "joist-orm" {
       optsType: AuthorOpts;
       fieldsType: AuthorFields;
       optIdsType: AuthorIdsOpts;
+      factoryExtrasType: AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newAuthor>[1];
     };
   }

--- a/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/BookCodegen.ts
@@ -83,6 +83,9 @@ export interface BookOrder {
   author?: AuthorOrder;
 }
 
+export interface BookFactoryExtras {
+}
+
 export const bookConfig = new ConfigApi<Book, Context>();
 
 bookConfig.addRule(newRequiredRule("title"));
@@ -98,6 +101,7 @@ declare module "joist-orm" {
       optsType: BookOpts;
       fieldsType: BookFields;
       optIdsType: BookIdsOpts;
+      factoryExtrasType: BookFactoryExtras;
       factoryOptsType: Parameters<typeof newBook>[1];
     };
   }

--- a/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/DatabaseOwnerCodegen.ts
@@ -61,6 +61,9 @@ export interface DatabaseOwnerOrder {
   name?: OrderBy;
 }
 
+export interface DatabaseOwnerFactoryExtras {
+}
+
 export const databaseOwnerConfig = new ConfigApi<DatabaseOwner, Context>();
 
 databaseOwnerConfig.addRule(newRequiredRule("name"));
@@ -75,6 +78,7 @@ declare module "joist-orm" {
       optsType: DatabaseOwnerOpts;
       fieldsType: DatabaseOwnerFields;
       optIdsType: DatabaseOwnerIdsOpts;
+      factoryExtrasType: DatabaseOwnerFactoryExtras;
       factoryOptsType: Parameters<typeof newDatabaseOwner>[1];
     };
   }

--- a/packages/tests/schema-misc/src/entities/codegen/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/PaintingCodegen.ts
@@ -91,6 +91,9 @@ export interface PaintingOrder {
   artist?: ArtistOrder;
 }
 
+export interface PaintingFactoryExtras {
+}
+
 export const paintingConfig = new ConfigApi<Painting, Context>();
 
 paintingConfig.addRule(newRequiredRule("title"));
@@ -108,6 +111,7 @@ declare module "joist-orm" {
       optsType: PaintingOpts;
       fieldsType: PaintingFields;
       optIdsType: PaintingIdsOpts;
+      factoryExtrasType: PaintingFactoryExtras;
       factoryOptsType: Parameters<typeof newPainting>[1];
     };
   }

--- a/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
@@ -120,6 +120,9 @@ export interface AuthorOrder {
   updatedAt?: OrderBy;
 }
 
+export interface AuthorFactoryExtras {
+}
+
 export const authorConfig = new ConfigApi<Author, Context>();
 
 authorConfig.addRule(newRequiredRule("firstName"));
@@ -141,6 +144,7 @@ declare module "joist-orm" {
       optsType: AuthorOpts;
       fieldsType: AuthorFields;
       optIdsType: AuthorIdsOpts;
+      factoryExtrasType: AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newAuthor>[1];
     };
   }

--- a/packages/tests/temporal/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/temporal/src/entities/codegen/BookCodegen.ts
@@ -102,6 +102,9 @@ export interface BookOrder {
   author?: AuthorOrder;
 }
 
+export interface BookFactoryExtras {
+}
+
 export const bookConfig = new ConfigApi<Book, Context>();
 
 bookConfig.addRule(newRequiredRule("title"));
@@ -121,6 +124,7 @@ declare module "joist-orm" {
       optsType: BookOpts;
       fieldsType: BookFields;
       optIdsType: BookIdsOpts;
+      factoryExtrasType: BookFactoryExtras;
       factoryOptsType: Parameters<typeof newBook>[1];
     };
   }

--- a/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
@@ -107,6 +107,9 @@ export interface AuthorOrder {
   updatedAt?: OrderBy;
 }
 
+export interface AuthorFactoryExtras {
+}
+
 export const authorConfig = new ConfigApi<Author, Context>();
 
 authorConfig.addRule(newRequiredRule("firstName"));
@@ -123,6 +126,7 @@ declare module "joist-orm" {
       optsType: AuthorOpts;
       fieldsType: AuthorFields;
       optIdsType: AuthorIdsOpts;
+      factoryExtrasType: AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newAuthor>[1];
     };
   }

--- a/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
@@ -100,6 +100,9 @@ export interface BookOrder {
   author?: AuthorOrder;
 }
 
+export interface BookFactoryExtras {
+}
+
 export const bookConfig = new ConfigApi<Book, Context>();
 
 bookConfig.addRule(newRequiredRule("title"));
@@ -117,6 +120,7 @@ declare module "joist-orm" {
       optsType: BookOpts;
       fieldsType: BookFields;
       optIdsType: BookIdsOpts;
+      factoryExtrasType: BookFactoryExtras;
       factoryOptsType: Parameters<typeof newBook>[1];
     };
   }

--- a/packages/tests/untagged-ids/src/entities/codegen/BookReviewCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/BookReviewCodegen.ts
@@ -82,6 +82,9 @@ export interface BookReviewOrder {
   book?: AuthorOrder;
 }
 
+export interface BookReviewFactoryExtras {
+}
+
 export const bookReviewConfig = new ConfigApi<BookReview, Context>();
 
 bookReviewConfig.addRule(newRequiredRule("rating"));
@@ -97,6 +100,7 @@ declare module "joist-orm" {
       optsType: BookReviewOpts;
       fieldsType: BookReviewFields;
       optIdsType: BookReviewIdsOpts;
+      factoryExtrasType: BookReviewFactoryExtras;
       factoryOptsType: Parameters<typeof newBookReview>[1];
     };
   }

--- a/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/CommentCodegen.ts
@@ -94,6 +94,9 @@ export interface CommentOrder {
   updatedAt?: OrderBy;
 }
 
+export interface CommentFactoryExtras {
+}
+
 export const commentConfig = new ConfigApi<Comment, Context>();
 
 commentConfig.addRule(newRequiredRule("text"));
@@ -111,6 +114,7 @@ declare module "joist-orm" {
       optsType: CommentOpts;
       fieldsType: CommentFields;
       optIdsType: CommentIdsOpts;
+      factoryExtrasType: CommentFactoryExtras;
       factoryOptsType: Parameters<typeof newComment>[1];
     };
   }

--- a/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
@@ -84,6 +84,9 @@ export interface AuthorOrder {
   updatedAt?: OrderBy;
 }
 
+export interface AuthorFactoryExtras {
+}
+
 export const authorConfig = new ConfigApi<Author, Context>();
 
 authorConfig.addRule(newRequiredRule("firstName"));
@@ -100,6 +103,7 @@ declare module "joist-orm" {
       optsType: AuthorOpts;
       fieldsType: AuthorFields;
       optIdsType: AuthorIdsOpts;
+      factoryExtrasType: AuthorFactoryExtras;
       factoryOptsType: Parameters<typeof newAuthor>[1];
     };
   }

--- a/packages/tests/uuid-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/BookCodegen.ts
@@ -99,6 +99,9 @@ export interface BookOrder {
   author?: AuthorOrder;
 }
 
+export interface BookFactoryExtras {
+}
+
 export const bookConfig = new ConfigApi<Book, Context>();
 
 bookConfig.addRule(newRequiredRule("title"));
@@ -117,6 +120,7 @@ declare module "joist-orm" {
       optsType: BookOpts;
       fieldsType: BookFields;
       optIdsType: BookIdsOpts;
+      factoryExtrasType: BookFactoryExtras;
       factoryOptsType: Parameters<typeof newBook>[1];
     };
   }


### PR DESCRIPTION
Normally business logic is prevented from setting ReactiveFields and ReactiveQueryFields.

However, for unit tests, it can be useful to set a RF/RFQ to a specific value, as part of test setup, without fully re-creating the data necessary to get that value calculated by the RF/RFQ logic.

So now any RF/RFQ will have a `with${fieldName}` factory option that, when provided, will be used/get stored in the db, instead of the RF/RFQs canonical operation.

Note that this only applies to the factory-created instance, i.e. if code-under-test happens to load the RF/RFQ on a new entity, and cause it to be re-calculated, then it will be recalculated, i.e. we don't "remember" that it should have a pinned value.