### PR TITLE
feat: Basic toMatchEntity working in Bun.

### DIFF
--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -5,11 +5,22 @@ export { ContextFn, makeRun, makeRunEach, newContext, run, runEach } from "./run
 export { seed } from "./seed";
 export { toMatchEntity } from "./toMatchEntity";
 
+export interface CustomMatcherResult {
+  pass: boolean;
+  message: () => string;
+}
+
 declare global {
   namespace jest {
     interface Matchers<R, T = {}> {
       toMatchEntity(expected: MatchedEntity<T>): CustomMatcherResult;
     }
+  }
+}
+// @ts-ignore
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchEntity(expected: MatchedEntity<T>): CustomMatcherResult;
   }
 }
 

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -56,10 +56,7 @@ export function toMatchEntity<T>(this: any, actual: unknown, expected: MatchedEn
     // this is bun--it's matcherHint actually seems to do `toMatchObject` already?
     return {
       pass: this.equals(cleanActual, cleanExpected),
-      message: () =>
-        this.utils.matcherHint("toMatchEntity", cleanActual, cleanExpected, {
-          comment: "asdf",
-        }),
+      message: () => this.utils.matcherHint("toMatchEntity", cleanActual, cleanExpected),
     };
   }
 }

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -1,4 +1,3 @@
-import CustomMatcherResult = jest.CustomMatcherResult;
 import {
   AsyncProperty,
   BaseEntity,
@@ -14,6 +13,7 @@ import {
   Reference,
 } from "joist-orm";
 import { isPlainObject } from "joist-utils";
+import { CustomMatcherResult } from "./index";
 
 // This might be undefined if running outside of jest
 const jestMatchers = (globalThis as any)[Symbol.for("$$jest-matchers-object")];
@@ -29,7 +29,7 @@ const matchers = jestMatchers?.matchers;
  * - We prune the expected/actual values to be as minimal as possible, to avoid Jest
  *   recursively crawling into connection pools or other misc non-useful things in the diffs
  */
-export function toMatchEntity<T extends object>(actual: T, expected: MatchedEntity<T>): CustomMatcherResult {
+export function toMatchEntity<T>(this: any, actual: unknown, expected: MatchedEntity<T>): CustomMatcherResult {
   // We're given expected, which is an object literal of what the user wants to match
   // against (some intermixed POJOs & entities) and actual (which similarly could be
   // intermixed POJOs & entities, but will likely be more sprawling because it's the
@@ -40,14 +40,27 @@ export function toMatchEntity<T extends object>(actual: T, expected: MatchedEnti
   // same "clean clone" of actual, and compare the two.
   const cleanExpected = deepClone(expected);
   const cleanActual = deepClone(deepMirror(cleanExpected, actual));
+
   // Watch for `expect(someAuthor).toMatchEntity(a1)` as we'll turn `someAuthor` into "a:1",
   // so can't use toMatchObject anymore.
-  if (typeof cleanActual !== "object") {
-    // @ts-ignore
-    return matchers.toEqual.call(this, cleanActual, cleanExpected);
+  if (matchers) {
+    // this is jest
+    if (typeof cleanActual !== "object") {
+      // @ts-ignore
+      return matchers.toEqual.call(this, cleanActual, cleanExpected);
+    } else {
+      // @ts-ignore
+      return matchers.toMatchObject.call(this, cleanActual, cleanExpected);
+    }
   } else {
-    // @ts-ignore
-    return matchers.toMatchObject.call(this, cleanActual, cleanExpected);
+    // this is bun--it's matcherHint actually seems to do `toMatchObject` already?
+    return {
+      pass: this.equals(cleanActual, cleanExpected),
+      message: () =>
+        this.utils.matcherHint("toMatchEntity", cleanActual, cleanExpected, {
+          comment: "asdf",
+        }),
+    };
   }
 }
 

--- a/packages/tests/bun/bunfig.toml
+++ b/packages/tests/bun/bunfig.toml
@@ -1,2 +1,3 @@
 [test]
 preload = ["./src/setupDbTests.ts"]
+root = "./src"

--- a/packages/tests/bun/src/entities/Author.test.ts
+++ b/packages/tests/bun/src/entities/Author.test.ts
@@ -1,11 +1,14 @@
-import { describe, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { newAuthor } from "src/entities/index.js";
 import { newEntityManager } from "src/setupDbTests.js";
 
 describe("Author", () => {
   test("works", async () => {
     const em = newEntityManager();
-    newAuthor(em);
+    const a = newAuthor(em);
     await em.flush();
+    expect(a).toMatchEntity({
+      firstName: "firstName",
+    });
   });
 });

--- a/packages/tests/bun/src/setupDbTests.ts
+++ b/packages/tests/bun/src/setupDbTests.ts
@@ -1,9 +1,10 @@
-import { afterAll, beforeEach } from "bun:test";
+import { afterAll, beforeEach, expect } from "bun:test";
 import { newPgConnectionConfig, PostgresDriver } from "joist-orm";
+import { toMatchEntity } from "joist-test-utils";
 import { knex as createKnex, Knex } from "knex";
 import { EntityManager } from "src/entities";
 
-// expect.extend({ toMatchEntity });
+expect.extend({ toMatchEntity });
 
 export let knex: Knex = createKnex({
   client: "pg",


### PR DESCRIPTION
Pretty surprised, but bun's clone of the Jest/expect `utils.matcherHint` is basically what `toMatchObject` does, and is much more straight-forward to call, so we get pretty diffs (same as Jest, but easier to achieve/less hacky in bun): 

![image](https://github.com/user-attachments/assets/89ee297b-2354-480d-a282-8e9b7c5479f8)
