### PR TITLE
fix: Add transactionType config to get txn types back.

### DIFF
--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -86,6 +86,14 @@ config.beforeDelete((book, ctx) => {
 
 And the `ctx` param will be correctly typed to your application's specific `Context` type.
 
+### `transactionType`
+
+This optional key specifies your application-specific `Transaction` type, which is usually based on which database client library you're using.
+
+I.e. for Knex this would be `Knex.Transaction@knex`, for Bun it would be `TransactionSQL@bun`.
+
+Setting this value will ensure the correct typing for `EntityManager.transaction`, `afterTransaction`, and `beforeTransaction` methods.
+
 ### `entitiesDirectory`
 
 This controls whether Joist outputs the entity, codegen, and metadata files.
@@ -128,18 +136,18 @@ Allows ignoring tables, i.e. not generating TypeScript entities for them.
 
 This setting controls how `joist-codegen` handles non-deferred foreign keys:
 
-* `"error"` will have Joist error out & require the key to be made deferred
-  * This is recommended but not required
-* `"warn"` will have Joist report any non-deferred keys, but still generate the output
-  * This is the default, to encourage users to convert their FKs to deferred
-* `"ignore"` will have Joist ignore any non-deferred keys
-  * If you don't want to use deferred FKs, this setting will have Joist just ignore them
+- `"error"` will have Joist error out & require the key to be made deferred
+  - This is recommended but not required
+- `"warn"` will have Joist report any non-deferred keys, but still generate the output
+  - This is the default, to encourage users to convert their FKs to deferred
+- `"ignore"` will have Joist ignore any non-deferred keys
+  - If you don't want to use deferred FKs, this setting will have Joist just ignore them
 
 Note that, without deferred FKs, Joist will still behave correctly, i.e. if calling `em.flush` with both a new `Author` and a new `Book`, both with FKs that point to the other not-yet-inserted entity, then Joist will:
 
-* Insert the `authors` row with `book_id=NULL` to let the `INSERT` succeed
-* Insert the `books` rows with `author_id=1` for the book `INSERT`
-* Update the `authors` row to set `book_id=1` now that the `books` rows is available
+- Insert the `authors` row with `book_id=NULL` to let the `INSERT` succeed
+- Insert the `books` rows with `author_id=1` for the book `INSERT`
+- Update the `authors` row to set `book_id=1` now that the `books` rows is available
 
 This approach works, but requires the extra "fixup" `UPDATE` after the two `INSERT`s, which is why we recommend using deferred FKs.
 
@@ -294,16 +302,16 @@ export interface FieldConfig {
 
 Where:
 
-* `derived` controls whether this field is derived from business logic (...link to docs...)
-* `protected` controls whether this is field is `protected` and so can only be accessed internally by the domain model code
-* `ignore` controls whether to ignore the field
-* `superstruct` links to the superstruct type to use for [`jsonb` columns](../modeling/jsonb-fields.md), i.e. `commentStreamReads@src/entities/superstruct`
-* `zodSchema` links to the Zod schema to use for [`jsonb` columns](../modeling/jsonb-fields.md), i.e. `CommentStreamReads@src/entities/schemas` 
-* `type` links to an TypeScript type to use instead of the schema derived one
+- `derived` controls whether this field is derived from business logic (...link to docs...)
+- `protected` controls whether this is field is `protected` and so can only be accessed internally by the domain model code
+- `ignore` controls whether to ignore the field
+- `superstruct` links to the superstruct type to use for [`jsonb` columns](../modeling/jsonb-fields.md), i.e. `commentStreamReads@src/entities/superstruct`
+- `zodSchema` links to the Zod schema to use for [`jsonb` columns](../modeling/jsonb-fields.md), i.e. `CommentStreamReads@src/entities/schemas`
+- `type` links to an TypeScript type to use instead of the schema derived one
 
-   Currently, the `type` must be a [branded type](https://typescript.tv/best-practices/improve-your-type-safety-with-branded-types/) of the runtime type, b/c Joist will still instantiate the value with whatever it's schema-derived value is.
+  Currently, the `type` must be a [branded type](https://typescript.tv/best-practices/improve-your-type-safety-with-branded-types/) of the runtime type, b/c Joist will still instantiate the value with whatever it's schema-derived value is.
 
-   See [this discussion](https://github.com/joist-orm/joist-orm/discussions/674#discussioncomment-6092907) for a future `serde` feature that would allow you to instantiate custom runtime values.
+  See [this discussion](https://github.com/joist-orm/joist-orm/discussions/674#discussioncomment-6092907) for a future `serde` feature that would allow you to instantiate custom runtime values.
 
 ### `entities.relations`
 
@@ -319,17 +327,17 @@ export interface RelationConfig {
 
 The supported values are:
 
-* `polymorphic` creates this relation as a [polymorphic relation](/docs/modeling/relations#polymorphic-references), which logical combines several physical foreign keys into a single field
-* `large` indicates that a collection is too big to be fully loaded into memory and changes the generated type to `LargeCollection`  
-* `orderBy` allows setting an order specific to this collection, the value must be a primitive, synchronous field on the entities within the collection
+- `polymorphic` creates this relation as a [polymorphic relation](/docs/modeling/relations#polymorphic-references), which logical combines several physical foreign keys into a single field
+- `large` indicates that a collection is too big to be fully loaded into memory and changes the generated type to `LargeCollection`
+- `orderBy` allows setting an order specific to this collection, the value must be a primitive, synchronous field on the entities within the collection
 
 ## Runtime Configuration
 
 There are three main things to configure at runtime:
 
-* Connection pool
-* Driver
-* EntityManager
+- Connection pool
+- Driver
+- EntityManager
 
 ### Connection Pool
 
@@ -362,9 +370,9 @@ const driver = new PostgresDriver(knex);
 
 When creating the `PostgresDriver`, you can pass an `IdAssigner` instance, which currently has three implementations:
 
-* `SequenceIdAssigner` assigns numeric ids from each entity's `SEQUENCE`
-* `RandomUuidAssigner` assigns random UUIDs if you're using UUID columns
-* `TestUuidAssigner` assigns deterministic UUIDs for unit testing
+- `SequenceIdAssigner` assigns numeric ids from each entity's `SEQUENCE`
+- `RandomUuidAssigner` assigns random UUIDs if you're using UUID columns
+- `TestUuidAssigner` assigns deterministic UUIDs for unit testing
 
 ### EntityManager
 

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -32,7 +32,7 @@
     "pg-structure": "^7.15.3",
     "pluralize": "^8.0.0",
     "semver": "^7.6.3",
-    "ts-poet": "^6.9.0",
+    "ts-poet": "^6.10.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -86,6 +86,8 @@ export const config = z
     databaseUrl: z.optional(z.string()),
     /** Your application's request-level `Context` type. */
     contextType: z.optional(z.string()),
+    /** Your application's database client's `Transaction` type. */
+    transactionType: z.optional(z.string()),
     /**
      * Allows the user to specify the `updated_at` / `created_at` column names to look up, and if they're optional.
      *

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -75,6 +75,7 @@ export async function generateFiles(config: Config, dbMeta: DbMetadata): Promise
     .reduce(merge, []);
 
   const contextType = config.contextType ? imp(`t:${config.contextType}`) : "{}";
+  const txnType = config.transactionType ? imp(`t:${config.transactionType}`) : "unknown";
 
   const metadataFile: CodegenFile = {
     name: "./codegen/metadata.ts",
@@ -83,7 +84,7 @@ export async function generateFiles(config: Config, dbMeta: DbMetadata): Promise
         temporal: ${config.temporal ? { timeZone: typeof config.temporal === "boolean" ? "UTC" : config.temporal.timeZone } : "false"},
       });
       
-      export class ${def("EntityManager")} extends ${JoistEntityManager}<${contextType}, Entity> {}
+      export class ${def("EntityManager")} extends ${JoistEntityManager}<${contextType}, Entity, ${txnType}> {}
 
       export interface ${def("Entity")} extends ${Entity} {
         id: ${getIdType(config)};

--- a/packages/drivers/bun-pg/src/BunPgDriver.ts
+++ b/packages/drivers/bun-pg/src/BunPgDriver.ts
@@ -1,4 +1,4 @@
-import { sql, TransactionSQL } from "bun";
+import { sql, type TransactionSQL } from "bun";
 import { Driver, EntityManager, IdAssigner, ParsedFindQuery, SequenceIdAssigner } from "joist-orm";
 import { JoinRowTodo, Todo } from "joist-orm/build/Todo";
 

--- a/packages/graphql-codegen/package.json
+++ b/packages/graphql-codegen/package.json
@@ -26,7 +26,7 @@
     "joist-utils": "workspace:*",
     "pluralize": "^8.0.0",
     "prettier": "^3.4.1",
-    "ts-poet": "^6.9.0"
+    "ts-poet": "^6.10.0"
   },
   "devDependencies": {
     "@swc/core": "^1.9.3",

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -83,7 +83,7 @@ import { MaybePromise, assertNever, fail, failIfAnyRejected, getOrSet, groupBy, 
  * implement this and instead only have the `AbsEntityConstructor` type.
  */
 export interface EntityConstructor<T> {
-  new (em: EntityManager<any, any>, opts: any): T;
+  new (em: EntityManager<any, any, any>, opts: any): T;
 
   // Use any for now to pass the `.includes` test in `EntityConstructor.test.ts`. We could
   // probably do some sort of `tagOf(T)` look up, similar to filter types, which would return
@@ -129,7 +129,7 @@ export interface FindCountFilterOptions<T extends Entity> {
  *
  * I.e. this is more like "MaybeAbstractEntityConstructor".
  */
-export type MaybeAbstractEntityConstructor<T> = abstract new (em: EntityManager<any, any>, opts: any) => T;
+export type MaybeAbstractEntityConstructor<T> = abstract new (em: EntityManager<any, any, any>, opts: any) => T;
 
 /** Pulls the entity's id type out of a given entity type T. */
 export type IdOf<T> = T extends { id: infer I } ? I : never;

--- a/packages/orm/src/EntityMetadata.ts
+++ b/packages/orm/src/EntityMetadata.ts
@@ -50,7 +50,8 @@ export interface EntityMetadata<T extends Entity = any> {
   config: ConfigApi<any, any>;
   orderBy: string | undefined;
   timestampFields: TimestampFields;
-  factory: (em: EntityManager<any, any>, opts?: any) => DeepNew<T>;
+  // Ideally this would be the application-specific EntityManager (to avoid anys), but it doesn't really matter
+  factory: (em: EntityManager<any, any, any>, opts?: any) => DeepNew<T>;
   /** The list of base types for this subtype, e.g. for Dog it'd be [Animal, Mammal]. */
   baseTypes: EntityMetadata[];
   /** The list of subtypes for this base type, e.g. for Animal it'd be `[Mammal, Dog]`. */

--- a/packages/orm/src/createOrUpdatePartial.ts
+++ b/packages/orm/src/createOrUpdatePartial.ts
@@ -56,7 +56,7 @@ export async function updatePartial<T extends Entity>(entity: T, opts: DeepParti
  * A utility function to create-or-update entities coming from a partial-update style API.
  */
 export async function createOrUpdatePartial<T extends Entity>(
-  em: EntityManager<any, any>,
+  em: EntityManager<any, any, any>,
   constructor: MaybeAbstractEntityConstructor<T>,
   opts: DeepPartialOrNull<T>,
 ): Promise<T> {

--- a/packages/tests/bun-sql-pg/src/entities/codegen/metadata.ts
+++ b/packages/tests/bun-sql-pg/src/entities/codegen/metadata.ts
@@ -6,7 +6,7 @@ import { authorConfig, bookConfig, newAuthor, newBook } from "../entities.js";
 
 setRuntimeConfig({ temporal: false });
 
-export class EntityManager extends EntityManager1<Context, Entity> {}
+export class EntityManager extends EntityManager1<Context, Entity, unknown> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/packages/tests/bun/src/entities/codegen/metadata.ts
+++ b/packages/tests/bun/src/entities/codegen/metadata.ts
@@ -6,7 +6,7 @@ import { authorConfig, bookConfig, newAuthor, newBook } from "../entities.js";
 
 setRuntimeConfig({ temporal: false });
 
-export class EntityManager extends EntityManager1<Context, Entity> {}
+export class EntityManager extends EntityManager1<Context, Entity, unknown> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/packages/tests/esm-misc/src/entities/codegen/metadata.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/metadata.ts
@@ -6,7 +6,7 @@ import { authorConfig, bookConfig, newAuthor, newBook } from "../entities.ts";
 
 setRuntimeConfig({ temporal: false });
 
-export class EntityManager extends EntityManager1<Context, Entity> {}
+export class EntityManager extends EntityManager1<Context, Entity, unknown> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/metadata.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/metadata.ts
@@ -15,7 +15,7 @@ import { newT1Author, newT1Book, newT2Author, newT2Book, newT3Author, newT3Book,
 
 setRuntimeConfig({ temporal: false });
 
-export class EntityManager extends EntityManager1<Context, Entity> {}
+export class EntityManager extends EntityManager1<Context, Entity, unknown> {}
 
 export interface Entity extends Entity2 {
   id: number;

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -112,5 +112,6 @@
     }
   },
   "entitiesDirectory": "./src/entities",
+  "transactionType": "Knex.Transaction@knex",
   "version": "0.0.1"
 }

--- a/packages/tests/integration/src/EntityManager.txns.test.ts
+++ b/packages/tests/integration/src/EntityManager.txns.test.ts
@@ -7,6 +7,13 @@ import { Pool } from "pg";
 import { knex, newEntityManager } from "@src/testEm";
 
 describe("EntityManager", () => {
+  it("has a typed txn parameter", async () => {
+    const em = newEntityManager();
+    await em.transaction(async (txn) => {
+      await txn.raw("select 1");
+    });
+  });
+
   it("reproduces anomalies w/o transactions", async () => {
     const steps = new Stepper();
 

--- a/packages/tests/integration/src/entities/codegen/metadata.ts
+++ b/packages/tests/integration/src/entities/codegen/metadata.ts
@@ -1,4 +1,5 @@
 import { BigIntSerde, configureMetadata, CustomSerdeAdapter, DateSerde, DecimalToNumberSerde, type Entity as Entity2, EntityManager as EntityManager1, type EntityMetadata, EnumArrayFieldSerde, EnumFieldSerde, JsonSerde, KeySerde, PolymorphicKeySerde, PrimitiveSerde, setRuntimeConfig, SuperstructSerde, ZodSerde } from "joist-orm";
+import { type Knex } from "knex";
 import { type Context } from "src/context";
 import { address, AddressSchema, PasswordValueSerde, quotes } from "src/entities/types";
 import { AdminUser } from "../AdminUser";
@@ -94,7 +95,7 @@ import {
 
 setRuntimeConfig({ temporal: false });
 
-export class EntityManager extends EntityManager1<Context, Entity> {}
+export class EntityManager extends EntityManager1<Context, Entity, Knex.Transaction> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/packages/tests/integration/src/testEm.ts
+++ b/packages/tests/integration/src/testEm.ts
@@ -16,7 +16,7 @@ let makeApiCall: Function = null!;
 
 export function newEntityManager(): EntityManager {
   const ctx = { knex };
-  const opts: EntityManagerOpts = {
+  const opts: EntityManagerOpts<any> = {
     driver: testDriver.driver,
     preloadPlugin: isPreloadingEnabled ? new JsonAggregatePreloader() : undefined,
   };

--- a/packages/tests/number-ids/src/entities/codegen/metadata.ts
+++ b/packages/tests/number-ids/src/entities/codegen/metadata.ts
@@ -6,7 +6,7 @@ import { authorConfig, bookConfig, newAuthor, newBook } from "../entities";
 
 setRuntimeConfig({ temporal: false });
 
-export class EntityManager extends EntityManager1<Context, Entity> {}
+export class EntityManager extends EntityManager1<Context, Entity, unknown> {}
 
 export interface Entity extends Entity2 {
   id: number;

--- a/packages/tests/schema-misc/src/entities/codegen/metadata.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/metadata.ts
@@ -9,7 +9,7 @@ import { artistConfig, authorConfig, bookConfig, databaseOwnerConfig, newArtist,
 
 setRuntimeConfig({ temporal: false });
 
-export class EntityManager extends EntityManager1<Context, Entity> {}
+export class EntityManager extends EntityManager1<Context, Entity, unknown> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/packages/tests/temporal/src/entities/codegen/metadata.ts
+++ b/packages/tests/temporal/src/entities/codegen/metadata.ts
@@ -7,7 +7,7 @@ import { authorConfig, bookConfig, newAuthor, newBook } from "../entities";
 
 setRuntimeConfig({ temporal: { "timeZone": "America/Los_Angeles" } });
 
-export class EntityManager extends EntityManager1<Context, Entity> {}
+export class EntityManager extends EntityManager1<Context, Entity, unknown> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/packages/tests/untagged-ids/src/entities/codegen/metadata.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/metadata.ts
@@ -8,7 +8,7 @@ import { authorConfig, bookConfig, bookReviewConfig, commentConfig, newAuthor, n
 
 setRuntimeConfig({ temporal: false });
 
-export class EntityManager extends EntityManager1<Context, Entity> {}
+export class EntityManager extends EntityManager1<Context, Entity, unknown> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/packages/tests/uuid-ids/src/entities/codegen/metadata.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/metadata.ts
@@ -6,7 +6,7 @@ import { authorConfig, bookConfig, BookStatuses, newAuthor, newBook } from "../e
 
 setRuntimeConfig({ temporal: false });
 
-export class EntityManager extends EntityManager1<Context, Entity> {}
+export class EntityManager extends EntityManager1<Context, Entity, unknown> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11001,7 +11001,7 @@ __metadata:
     prettier-plugin-organize-imports: "npm:^4.1.0"
     semver: "npm:^7.6.3"
     ts-node-dev: "npm:^2.0.0"
-    ts-poet: "npm:^6.9.0"
+    ts-poet: "npm:^6.10.0"
     tsconfig-paths: "npm:^4.2.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:5.7.2"
@@ -11042,7 +11042,7 @@ __metadata:
     pluralize: "npm:^8.0.0"
     prettier: "npm:^3.4.1"
     prettier-plugin-organize-imports: "npm:^4.1.0"
-    ts-poet: "npm:^6.9.0"
+    ts-poet: "npm:^6.10.0"
     tsconfig-paths: "npm:^4.2.0"
     typescript: "npm:5.7.2"
   languageName: unknown
@@ -17998,12 +17998,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-poet@npm:^6.9.0":
-  version: 6.9.0
-  resolution: "ts-poet@npm:6.9.0"
+"ts-poet@npm:^6.10.0":
+  version: 6.10.0
+  resolution: "ts-poet@npm:6.10.0"
   dependencies:
     dprint-node: "npm:^1.0.8"
-  checksum: 10/104a76f67c646aaafb74269299bd2356cd6f8c4d58a857b5833a8e90e531dee530c29a11c40233828e8a12f6c3af76859e0039287e3a8ee61adcf30f4634acfd
+  checksum: 10/35bf96d9efb76d3a60217057b8ccfdfe40cd2d3204e0cb91bd3d3c76923c2ced48d841b88287dfe2e91ca40d720536e0e2ba2a4547f3d76db0fc9abdc5664c18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Setting `transactionType: "Knex.Transaction@knex"` in joist-config.json will restore the `txn: Knex.Transaction` typing in methods like `em.transaction` / `afterTransaction` / etc.