### PR TITLE
fix: Better error message for unsupported reactivity.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1801,7 +1801,7 @@ async function validateReactiveRules(
   // From the given triggered entities, follow the entity's ReactiveRule back
   // to the reactive rules that need ran, and queue them in the `fn` map
   async function followAndQueue(triggered: Entity[], rule: ReactiveRule): Promise<void> {
-    (await followReverseHint(triggered, rule.path))
+    (await followReverseHint(rule.name, triggered, rule.path))
       .filter((entity) => !entity.isDeletedEntity)
       .filter((e) => e instanceof rule.cstr)
       .forEach((entity) => {

--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -161,7 +161,7 @@ export class ReactionsManager {
           pending.todo.clear();
           for (const doing of todo) pending.done.add(doing);
           // Walk back from the source to any downstream fields
-          const relations = (await followReverseHint(todo, rf.path))
+          const relations = (await followReverseHint(rf.name, todo, rf.path))
             .filter((entity) => !entity.isDeletedEntity)
             .filter((e) => e instanceof rf.cstr)
             .map((entity) => (entity as any)[rf.name]);


### PR DESCRIPTION
Currently we don't support reacting to ReactiveReferences, because they don't have an in-memory "other side" of their relation.

I.e. with a ReactiveReference of Author.favoriteBook, a rule like:

```ts
authorConfig.addRule({ favoriteBook: "title", firstName: {} }, a => {
  return a.firstName === a.favoriteBook.get.title ? "bad" : undefined;
});
```

When `Book.title` changes, our reaction logic would try to:

"Look for author's that I'm the favorite book of", which would be the relation `book.favoritedByAuthors` and "follow" that relation to say "tell those authors to rerun their validation rule".

This reactivity leverages the "other side" relation, i.e. `book.favoritedByAuthors`, however we currently do not codegen the "other side" collection for ReactiveReferences because it's difficult to keep "in-sync" (which we do for o2m relations) because:

a) there could be many different writes that invalidate a RR and need "the other side" to be recalcd, and

b) the recalc would likely need to be async

We might be able to solve this someday, but for now just error out with a better message.