### PR TITLE
fix: findOrCreate should reject collections

### DIFF
--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -145,6 +145,7 @@ export function findDataLoader<T extends Entity>(
 }
 
 const Temporal = maybeRequireTemporal()?.Temporal;
+
 // If a where clause includes an entity, object-hash cannot hash it, so just use the id.
 function replacer(v: any) {
   if (isEntity(v)) {

--- a/packages/tests/integration/src/EntityManager.test.ts
+++ b/packages/tests/integration/src/EntityManager.test.ts
@@ -1089,6 +1089,13 @@ describe("EntityManager", () => {
     expect(b1.author.get).toEqual(a1);
   });
 
+  it("cannot findOrCreate with o2ms", async () => {
+    const em = newEntityManager();
+    const b1 = newBook(em);
+    const promise = em.findOrCreate(Author, { firstName: "a2", books: [b1] }, {}, {});
+    await expect(promise).rejects.toThrow("findOrCreate only supports");
+  });
+
   it("can set derived values", async () => {
     const em = newEntityManager();
     const a1 = new Author(em, { firstName: "a1", lastName: "last" });


### PR DESCRIPTION
findOrCreate fundamentally assumes it can "eval the `where` clause against all in-memory entities", so that we don't dup against a just-created entity.

Currently we don't assume that entity has non-primitive relations loaded into memory, and even if we did `populate` those into memory, the concept of "this entity is unique based on (...)" really is meant to match "basically what a database constraint" can eval, i.e. just fields/columns directly owned on the entity.

Fixes #1375