### PR TITLE
fix: Improve post-dataloader stack traces.

### DIFF
--- a/packages/orm/src/loadLens.ts
+++ b/packages/orm/src/loadLens.ts
@@ -1,4 +1,5 @@
 import { Entity, isEntity } from "./Entity";
+import { appendStack } from "./EntityManager";
 import {
   EntityMetadata,
   Field,
@@ -111,10 +112,18 @@ export async function loadLens<T extends Entity, U, V>(
       // TODO We can only do this is _none_ of the paths are loaded, otherwise we'll miss WIP mutations
       if (Array.isArray(start)) {
         const em = start[0].em;
-        return (await lensDataLoader(em, meta.cstr, true, paths).loadMany(start.map((e) => e.idTagged))) as V;
+        return (await lensDataLoader(em, meta.cstr, true, paths)
+          .loadMany(start.map((e) => e.idTagged))
+          .catch(function loadLens(err) {
+            throw appendStack(err, new Error());
+          })) as V;
       } else {
         const em = start.em;
-        return (await lensDataLoader(em, meta.cstr, false, paths).load(start.idTagged)) as V;
+        return (await lensDataLoader(em, meta.cstr, false, paths)
+          .load(start.idTagged)
+          .catch(function loadLens(err) {
+            throw appendStack(err, new Error());
+          })) as V;
       }
     }
   }

--- a/packages/orm/src/relations/ManyToManyLargeCollection.ts
+++ b/packages/orm/src/relations/ManyToManyLargeCollection.ts
@@ -1,6 +1,6 @@
 import { manyToManyFindDataLoader } from "../dataloaders/manyToManyFindDataLoader";
 import { Entity } from "../Entity";
-import { IdOf } from "../EntityManager";
+import { appendStack, IdOf } from "../EntityManager";
 import { EntityMetadata } from "../EntityMetadata";
 import { ensureNotDeleted, getMetadata, ManyToManyCollection, toTaggedId } from "../index";
 import { remove } from "../utils";
@@ -70,7 +70,11 @@ export class ManyToManyLargeCollection<T extends Entity, U extends Entity> imple
 
     // Make a cacheable tuple to look up this specific m2m row
     const key = `${this.columnName}=${this.entity.id},${this.otherColumnName}=${id}`;
-    const includes = await manyToManyFindDataLoader(this.entity.em, this).load(key);
+    const includes = await manyToManyFindDataLoader(this.entity.em, this)
+      .load(key)
+      .catch(function find(err) {
+        throw appendStack(err, new Error());
+      });
     const taggedId = toTaggedId(this.otherMeta, id);
     return includes ? (this.entity.em.load(taggedId) as Promise<U>) : undefined;
   }
@@ -92,7 +96,11 @@ export class ManyToManyLargeCollection<T extends Entity, U extends Entity> imple
 
     // Make a cacheable tuple to look up this specific m2m row
     const key = `${this.columnName}=${this.entity.id},${this.otherColumnName}=${other.id}`;
-    return manyToManyFindDataLoader(this.entity.em, this).load(key);
+    return manyToManyFindDataLoader(this.entity.em, this)
+      .load(key)
+      .catch(function includes(err) {
+        throw appendStack(err, new Error());
+      });
   }
 
   add(other: U): void {

--- a/packages/orm/src/relations/OneToManyLargeCollection.ts
+++ b/packages/orm/src/relations/OneToManyLargeCollection.ts
@@ -1,6 +1,6 @@
 import { oneToManyFindDataLoader } from "../dataloaders/oneToManyFindDataLoader";
 import { Entity } from "../Entity";
-import { IdOf, sameEntity } from "../EntityManager";
+import { appendStack, IdOf, sameEntity } from "../EntityManager";
 import { EntityMetadata } from "../EntityMetadata";
 import { ensureNotDeleted, getMetadata, ManyToOneReferenceImpl } from "../index";
 import { remove } from "../utils";
@@ -54,7 +54,11 @@ export class OneToManyLargeCollection<T extends Entity, U extends Entity> implem
 
     // Make a cacheable tuple to look up this specific o2m row
     const key = `id=${id},${this.otherColumnName}=${this.entity.id}`;
-    return oneToManyFindDataLoader(this.entity.em, this).load(key);
+    return oneToManyFindDataLoader(this.entity.em, this)
+      .load(key)
+      .catch(function find(err) {
+        throw appendStack(err, new Error());
+      });
   }
 
   async includes(other: U): Promise<boolean> {

--- a/packages/orm/src/relations/OneToOneReference.ts
+++ b/packages/orm/src/relations/OneToOneReference.ts
@@ -1,4 +1,13 @@
-import { deTagId, ensureNotDeleted, getEmInternalApi, getInstanceData, IdOf, LoadedReference, TaggedId } from "../";
+import {
+  appendStack,
+  deTagId,
+  ensureNotDeleted,
+  getEmInternalApi,
+  getInstanceData,
+  IdOf,
+  LoadedReference,
+  TaggedId,
+} from "../";
 import { oneToOneDataLoader } from "../dataloaders/oneToOneDataLoader";
 import { Entity } from "../Entity";
 import { EntityMetadata } from "../EntityMetadata";
@@ -157,7 +166,11 @@ export class OneToOneReferenceImpl<T extends Entity, U extends Entity>
         const joinLoaded = this.getPreloaded();
         this.loaded = joinLoaded
           ? joinLoaded[0]
-          : await oneToOneDataLoader(this.entity.em, this).load(this.entity.idTagged);
+          : await oneToOneDataLoader(this.entity.em, this)
+              .load(this.entity.idTagged)
+              .catch(function load(err) {
+                throw appendStack(err, new Error());
+              });
       }
       this._isLoaded = true;
     }


### PR DESCRIPTION
Any time a batched operation fails, it will fail in "the other context" / the dataloader's setTimeout-d callback, where the error.stack doesn't know about the caller-who-is-blocking's context/stack.

And so it's error.stack will not include the caller's own stack:

```
error: SELECT a.* FROM authors AS a WHERE a.id = $1 ORDER BY a.id ASC LIMIT $2 - invalid input syntax for type integer: "0.6931471805599453"
    at Object.raw (/home/stephen/other/joist-orm/node_modules/knex/lib/knex-builder/make-knex.js:116:30)
    at Function.value (/home/stephen/other/joist-orm/node_modules/knex/lib/knex-builder/make-knex.js:92:29)
    at PostgresDriver.executeQuery (/home/stephen/other/joist-orm/packages/orm/src/drivers/PostgresDriver.ts:69:8)
    at PostgresDriver.executeFind (/home/stephen/other/joist-orm/packages/orm/src/drivers/PostgresDriver.ts:63:17)
    at DataLoader.em.getLoader.cacheKeyFn [as _batchLoadFn] (/home/stephen/other/joist-orm/packages/orm/src/dataloaders/findDataLoader.ts:61:38)
    at dispatchBatch (/home/stephen/other/joist-orm/node_modules/dataloader/index.js:288:27)
    at /home/stephen/other/joist-orm/node_modules/dataloader/index.js:268:5
    at processTicksAndRejections (node:internal/process/task_queues:85:11)
```

We can only tell "someone asked the dataloader to batch this".

With the appendStack, we see who the caller was:

```
error: SELECT a.* FROM authors AS a WHERE a.id = $1 ORDER BY a.id ASC LIMIT $2 - invalid input syntax for type integer: "0.6931471805599453"
    at Object.raw (/home/stephen/other/joist-orm/node_modules/knex/lib/knex-builder/make-knex.js:116:30)
    at Function.value (/home/stephen/other/joist-orm/node_modules/knex/lib/knex-builder/make-knex.js:92:29)
    at PostgresDriver.executeQuery (/home/stephen/other/joist-orm/packages/orm/src/drivers/PostgresDriver.ts:69:8)
    at PostgresDriver.executeFind (/home/stephen/other/joist-orm/packages/orm/src/drivers/PostgresDriver.ts:63:17)
    at DataLoader.em.getLoader.cacheKeyFn [as _batchLoadFn] (/home/stephen/other/joist-orm/packages/orm/src/dataloaders/findDataLoader.ts:61:38)
    at dispatchBatch (/home/stephen/other/joist-orm/node_modules/dataloader/index.js:288:27)
    at /home/stephen/other/joist-orm/node_modules/dataloader/index.js:268:5
    at processTicksAndRejections (node:internal/process/task_queues:85:11)
    at find (/home/stephen/other/joist-orm/packages/orm/src/EntityManager.ts:331:32) <== new lines
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at EntityManager.find (/home/stephen/other/joist-orm/packages/orm/src/EntityManager.ts:328:20)
    at Object.<anonymous> (/home/stephen/other/joist-orm/packages/tests/integration/src/EntityManager.queries.test.ts:76:21)
```

Fixes #1383 