### PR TITLE
feat: Add m2m added/removed/changed to changes.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -529,7 +529,10 @@ function generateFieldsType(meta: EntityDbMetadata, idType: "string" | "number")
   const polys = meta.polymorphics.map(({ fieldName, notNull, fieldType }) => {
     return code`${fieldName}: { kind: "poly"; type: ${fieldType}; nullable: ${undefinedOrNever(notNull)} };`;
   });
-  return [id, ...primitives, ...enums, ...pgEnums, ...m2o, ...polys];
+  const m2m = meta.manyToManys.map(({ fieldName, otherEntity }) => {
+    return code`${fieldName}: { kind: "m2m"; type: ${otherEntity.type} };`;
+  });
+  return [id, ...primitives, ...enums, ...pgEnums, ...m2o, ...polys, ...m2m];
 }
 
 // We know the OptIds types are only used in partials, so we make everything optional.

--- a/packages/orm/src/JoinRows.ts
+++ b/packages/orm/src/JoinRows.ts
@@ -12,6 +12,8 @@ export class JoinRows {
   private readonly rows: JoinRow[] = [];
 
   constructor(
+    // This could be either side of the m2m relation, depending on which is accessed first.
+    // Regardless of which m2m side, we still have a single `JoinRows` instance in memory per m2m table.
     readonly m2m: ManyToManyCollection<any, any>,
     private rm: ReactionsManager,
   ) {}
@@ -78,6 +80,14 @@ export class JoinRows {
     // `tag_id=t1`, are marked for deletion, and then `.map` them to the removed book.
     const rows = this.rows.filter((r) => r[columnName] === e1 && r.deleted);
     return rows.map((r) => r[otherColumnName] as Entity);
+  }
+
+  addedFor(m2m: ManyToManyCollection<any, any>, e1: Entity): Entity[] {
+    const { columnName, otherColumnName } = m2m;
+    const newRows = this.rows.filter(
+      (r) => r.id === undefined && r.deleted !== true && r.op === "pending" && r[columnName] === e1,
+    );
+    return newRows.map((r) => r[otherColumnName] as Entity);
   }
 
   /** Adds an existing join row to this table. */

--- a/packages/orm/src/changes.ts
+++ b/packages/orm/src/changes.ts
@@ -28,6 +28,45 @@ export interface ManyToOneFieldStatus<T extends Entity> extends FieldStatus<IdOf
   originalEntity: Promise<T | undefined>;
 }
 
+/** Provides access to a m2m relation's added/removed/changed/original values. */
+export class ManyToManyFieldStatus<T extends Entity, U extends Entity> {
+  #entity: T;
+  #fieldName: keyof T;
+
+  constructor(entity: T, fieldName: keyof T) {
+    this.#entity = entity;
+    this.#fieldName = fieldName;
+  }
+
+  get added(): Promise<U[]> {
+    const m2m = this.#entity[this.#fieldName] as ManyToManyCollection<T, any>;
+    const joinRow = getEmInternalApi(this.#entity.em).joinRows(m2m);
+    return Promise.resolve(joinRow.addedFor(m2m, this.#entity) as U[]);
+  }
+
+  get removed(): Promise<U[]> {
+    const m2m = this.#entity[this.#fieldName] as ManyToManyCollection<T, any>;
+    const joinRow = getEmInternalApi(this.#entity.em).joinRows(m2m);
+    return Promise.resolve(joinRow.removedFor(m2m, this.#entity) as U[]);
+  }
+
+  get changed(): Promise<U[]> {
+    const m2m = this.#entity[this.#fieldName] as ManyToManyCollection<T, any>;
+    const joinRow = getEmInternalApi(this.#entity.em).joinRows(m2m);
+    return Promise.resolve(
+      [...(joinRow.addedFor(m2m, this.#entity) as U[]), ...(joinRow.removedFor(m2m, this.#entity) as U[])].sort(
+        (a, b) => a.toString().localeCompare(b.toString()),
+      ),
+    );
+  }
+
+  get hasUpdated(): boolean {
+    const m2m = this.#entity[this.#fieldName] as ManyToManyCollection<T, any>;
+    const joinRow = getEmInternalApi(this.#entity.em).joinRows(m2m);
+    return joinRow.hasChanges;
+  }
+}
+
 /**
  * Creates the `this.changes.firstName` changes API for a given entity `T`.
  *
@@ -35,18 +74,21 @@ export interface ManyToOneFieldStatus<T extends Entity> extends FieldStatus<IdOf
  * convert reference fields to `ManyToOneFieldStatus` to be the id type
  * because the reference may not be loaded.
  *
- * @type K The fields of the entity, or potentially the union of the entity and its subtypes,
+ * @typeParam K The fields of the entity, or potentially the union of the entity and its subtypes,
  *    i.e. `Publisher.changes` is typed as `Changes<Publisher, keyof Publisher | keyof SmallPub | keyof LargePub>`
- * @type R An optional list of restrictions, i.e for `Reacted` for to provide `changes` to its subset of fields.
+ * @typeParam R An optional list of restrictions, i.e for `Reacted` for to provide `changes` to its subset of fields.
  */
 export type Changes<T extends Entity, K = keyof (FieldsOf<T> & RelationsOf<T>), R = K> = {
+  /** Array of changed field names. */
   fields: NonNullable<K>[];
 } & {
-  [P in keyof FieldsOf<T> & R]: FieldsOf<T>[P] extends { type: infer U | undefined }
-    ? U extends Entity
-      ? ManyToOneFieldStatus<U>
-      : FieldStatus<U>
-    : never;
+  [P in keyof FieldsOf<T> & R]: FieldsOf<T>[P] extends { kind: "m2m"; type: infer U extends Entity }
+    ? ManyToManyFieldStatus<T, U>
+    : FieldsOf<T>[P] extends { type: infer U | undefined }
+      ? U extends Entity
+        ? ManyToOneFieldStatus<U>
+        : FieldStatus<U>
+      : never;
 };
 
 // type A1 = never extends string ? 1 : 2;
@@ -66,36 +108,17 @@ export interface EntityChanges<T extends Entity> {
 
 export function newChangesProxy<T extends Entity>(entity: T): Changes<T> {
   return new Proxy(entity, {
-    get(target, p: PropertyKey): FieldStatus<any> | ManyToOneFieldStatus<any> | (keyof OptsOf<T>)[] {
+    get(
+      target,
+      p: PropertyKey,
+    ): FieldStatus<any> | ManyToOneFieldStatus<any> | ManyToManyFieldStatus<any, any> | (keyof OptsOf<T>)[] {
       if (p === "fields") {
-        const fieldsChanged = (
-          entity.isNewEntity
-            ? // Cloning sometimes leaves unset keys in data as undefined, so drop them
-              Object.entries(getInstanceData(entity).data)
-                .filter(([, value]) => value !== undefined)
-                .map(([key]) => key)
-            : Object.keys(getInstanceData(entity).originalData)
-        ) as (keyof OptsOf<T>)[];
-
-        // scan the join rows to get if the relation has any rows
-        const m2mFieldsChanged: (keyof RelationsOf<T>)[] = [];
-        const emApi = getEmInternalApi(entity.em);
-        // we will report changes only on the many to many relations for now
-        const m2mFields = Object.values(getMetadata(entity).allFields).filter((f) => f.kind === "m2m");
-        for (const field of m2mFields) {
-          const m2m = entity[field.fieldName as keyof T] as ManyToManyCollection<any, any>;
-          const joinRow = emApi.joinRows(m2m);
-          if (joinRow.hasChanges) {
-            m2mFieldsChanged.push(field.fieldName as keyof RelationsOf<T>);
-          }
-        }
-
-        return [...fieldsChanged, ...m2mFieldsChanged];
+        return getChangedFieldNames(entity);
       } else if (typeof p === "symbol") {
         throw new Error(`Unsupported call to ${String(p)}`);
-      }
-
-      if (!isChangeableField(entity, p as any)) {
+      } else if (getMetadata(entity).allFields[p]?.kind === "m2m") {
+        return new ManyToManyFieldStatus(entity, p as keyof T);
+      } else if (!isChangeableField(entity, p as any)) {
         throw new Error(`Invalid changes field ${p}`);
       }
 
@@ -150,3 +173,28 @@ const addOriginalEntity: Record<Field["kind"], boolean> = {
   primaryKey: false,
   primitive: false,
 };
+
+/** Scans `entity` for changes primitive + m2m fields. */
+function getChangedFieldNames<T extends Entity>(entity: T): (keyof OptsOf<T>)[] {
+  const fieldsChanged = entity.isNewEntity
+    ? // Cloning sometimes leaves unset keys in data as undefined, so drop them
+      Object.entries(getInstanceData(entity).data)
+        .filter(([, value]) => value !== undefined)
+        .map(([key]) => key)
+    : Object.keys(getInstanceData(entity).originalData);
+
+  // scan the join rows to get if the relation has any rows
+  const m2mFieldsChanged: (keyof RelationsOf<T>)[] = [];
+  const emApi = getEmInternalApi(entity.em);
+  // we will report changes only on the m2m relations for now
+  const m2mFields = Object.values(getMetadata(entity).allFields).filter((f) => f.kind === "m2m");
+  for (const field of m2mFields) {
+    const m2m = (entity as any)[field.fieldName as keyof T] as ManyToManyCollection<any, any>;
+    const joinRow = emApi.joinRows(m2m);
+    if (joinRow.hasChanges) {
+      m2mFieldsChanged.push(field.fieldName as keyof RelationsOf<T>);
+    }
+  }
+
+  return [...fieldsChanged, ...m2mFieldsChanged] as any;
+}

--- a/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
@@ -138,6 +138,7 @@ export interface AuthorFields {
   currentDraftBook: { kind: "m2o"; type: Book; nullable: undefined; derived: false };
   favoriteBook: { kind: "m2o"; type: Book; nullable: undefined; derived: true };
   publisher: { kind: "m2o"; type: Publisher; nullable: undefined; derived: false };
+  tags: { kind: "m2m"; type: Tag };
 }
 
 export interface AuthorOpts {

--- a/packages/tests/integration/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookCodegen.ts
@@ -90,6 +90,7 @@ export interface BookFields {
   author: { kind: "m2o"; type: Author; nullable: never; derived: false };
   reviewer: { kind: "m2o"; type: Author; nullable: undefined; derived: false };
   randomComment: { kind: "m2o"; type: Comment; nullable: undefined; derived: false };
+  tags: { kind: "m2m"; type: Tag };
 }
 
 export interface BookOpts {

--- a/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookReviewCodegen.ts
@@ -75,6 +75,7 @@ export interface BookReviewFields {
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   book: { kind: "m2o"; type: Book; nullable: never; derived: false };
   critic: { kind: "m2o"; type: Critic; nullable: undefined; derived: false };
+  tags: { kind: "m2m"; type: Tag };
 }
 
 export interface BookReviewOpts {

--- a/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
@@ -85,6 +85,7 @@ export interface CommentFields {
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   user: { kind: "m2o"; type: User; nullable: undefined; derived: false };
   parent: { kind: "poly"; type: CommentParent; nullable: never };
+  likedByUsers: { kind: "m2m"; type: User };
 }
 
 export interface CommentOpts {

--- a/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
@@ -105,6 +105,8 @@ export interface PublisherFields {
   favoriteAuthor: { kind: "m2o"; type: Author; nullable: undefined; derived: true };
   group: { kind: "m2o"; type: PublisherGroup; nullable: undefined; derived: false };
   spotlightAuthor: { kind: "m2o"; type: Author; nullable: undefined; derived: false };
+  tags: { kind: "m2m"; type: Tag };
+  tasks: { kind: "m2m"; type: TaskOld };
 }
 
 export interface PublisherOpts {

--- a/packages/tests/integration/src/entities/codegen/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TagCodegen.ts
@@ -66,6 +66,11 @@ export interface TagFields {
   name: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  authors: { kind: "m2m"; type: Author };
+  books: { kind: "m2m"; type: Book };
+  bookReviews: { kind: "m2m"; type: BookReview };
+  publishers: { kind: "m2m"; type: Publisher };
+  tasks: { kind: "m2m"; type: Task };
 }
 
 export interface TagOpts {

--- a/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
@@ -82,6 +82,7 @@ export interface TaskFields {
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   type: { kind: "enum"; type: TaskType; nullable: undefined };
   copiedFrom: { kind: "m2o"; type: Task; nullable: undefined; derived: false };
+  tags: { kind: "m2m"; type: Tag };
 }
 
 export interface TaskOpts {

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -73,6 +73,7 @@ export interface TaskOldFields extends TaskFields {
   specialOldField: { kind: "primitive"; type: number; unique: false; nullable: never; derived: false };
   parentOldTask: { kind: "m2o"; type: TaskOld; nullable: undefined; derived: false };
   copiedFrom: { kind: "m2o"; type: TaskOld; nullable: undefined; derived: false };
+  publishers: { kind: "m2m"; type: Publisher };
 }
 
 export interface TaskOldOpts extends TaskOpts {

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -90,6 +90,7 @@ export interface UserFields {
   manager: { kind: "m2o"; type: User; nullable: undefined; derived: false };
   authorManyToOne: { kind: "m2o"; type: Author; nullable: undefined; derived: false };
   favoritePublisher: { kind: "poly"; type: UserFavoritePublisher; nullable: undefined };
+  likedComments: { kind: "m2m"; type: Comment };
 }
 
 export interface UserOpts {


### PR DESCRIPTION
```ts
      // When we remove a1 from t1
      t1.authors.remove(a1);
      // And add a1 to t2
      t2.authors.add(a1);
      // Then a1.changed shows both added/removed
      expect(await a1.changes.tags.changed).toMatchEntity([t1, t2]);
      // And t1/t2.changed reflect show the same change
      expect(await t1.changes.authors.changed).toMatchEntity([a1]);
      expect(await t2.changes.authors.changed).toMatchEntity([a1]);
```

Fixes #1386