### PR TITLE
fix: Add m2m.changes.hasChanged

### DIFF
--- a/packages/orm/src/changes.ts
+++ b/packages/orm/src/changes.ts
@@ -59,8 +59,12 @@ export class ManyToManyFieldStatus<T extends Entity, U extends Entity> {
     );
   }
 
-  get hasUpdated(): boolean {
+  get hasChanged(): boolean {
     return this.#joinRows.hasChanges;
+  }
+
+  get hasUpdated(): boolean {
+    return !this.#entity.isNewEntity && this.#joinRows.hasChanges;
   }
 }
 

--- a/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
+++ b/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
@@ -606,8 +606,10 @@ describe("ManyToManyCollection", () => {
       const t = newTag(em, { authors: [a] });
       expect(await t.changes.authors.added).toMatchEntity([a]);
       expect(await a.changes.tags.added).toMatchEntity([t]);
-      expect(t.changes.authors.hasUpdated).toBe(true);
-      expect(a.changes.tags.hasUpdated).toBe(true);
+      expect(t.changes.authors.hasChanged).toBe(true);
+      expect(t.changes.authors.hasUpdated).toBe(false);
+      expect(a.changes.tags.hasChanged).toBe(true);
+      expect(a.changes.tags.hasUpdated).toBe(false);
     });
 
     it("detects removes", async () => {


### PR DESCRIPTION
In addition to the `hasUpdated`, this makes it match the FieldStatus interface.