### PR TITLE
feat: Add o2m.changes.added/removed.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -532,7 +532,13 @@ function generateFieldsType(meta: EntityDbMetadata, idType: "string" | "number")
   const m2m = meta.manyToManys.map(({ fieldName, otherEntity }) => {
     return code`${fieldName}: { kind: "m2m"; type: ${otherEntity.type} };`;
   });
-  return [id, ...primitives, ...enums, ...pgEnums, ...m2o, ...polys, ...m2m];
+  const o2m = meta.oneToManys.map(({ fieldName, otherEntity }) => {
+    return code`${fieldName}: { kind: "o2m"; type: ${otherEntity.type} };`;
+  });
+  const lo2m = meta.largeOneToManys.map(({ fieldName, otherEntity }) => {
+    return code`${fieldName}: { kind: "o2m"; type: ${otherEntity.type} };`;
+  });
+  return [id, ...primitives, ...enums, ...pgEnums, ...m2o, ...polys, ...m2m, ...o2m, ...lo2m];
 }
 
 // We know the OptIds types are only used in partials, so we make everything optional.

--- a/packages/orm/src/changes.ts
+++ b/packages/orm/src/changes.ts
@@ -5,6 +5,7 @@ import { getField, isChangeableField } from "./fields";
 import {
   Field,
   ManyToManyCollection,
+  OneToManyCollection,
   RelationsOf,
   getConstructorFromTaggedId,
   getEmInternalApi,
@@ -64,6 +65,48 @@ export class ManyToManyFieldStatus<T extends Entity, U extends Entity> {
   }
 }
 
+/** Provides access to an o2m relation's added/removed/changed entities. */
+export class OneToManyFieldStatus<T extends Entity, U extends Entity> {
+  readonly #entity: T;
+  readonly #o2m: OneToManyCollection<T, U>;
+
+  constructor(entity: T, fieldName: keyof T) {
+    this.#entity = entity;
+    this.#o2m = entity[fieldName] as OneToManyCollection<T, U>;
+  }
+
+  // This doesn't have to be a promise, b/c even if o2m is unloaded, to mutate
+  // the o2m (calling `add(other)` or `remove(other)` or `other.otherField = me`), all
+  // require having the "other entity" in memory.
+  get added(): U[] {
+    return [
+      ...this.#o2m.added(),
+      ...(this.#entity.isNewEntity
+        ? []
+        : ((getEmInternalApi(this.#entity.em).pendingChildren.get(this.#entity.idTagged)?.get(this.#o2m.fieldName)
+            ?.adds as U[]) ?? [])),
+    ].sort(entityCompare);
+  }
+
+  get removed(): U[] {
+    return [
+      ...this.#o2m.removed(),
+      ...(this.#entity.isNewEntity
+        ? []
+        : ((getEmInternalApi(this.#entity.em).pendingChildren.get(this.#entity.idTagged)?.get(this.#o2m.fieldName)
+            ?.removes as U[]) ?? [])),
+    ].sort(entityCompare);
+  }
+
+  get changed(): U[] {
+    return [...this.added, ...this.removed].sort(entityCompare);
+  }
+
+  get hasUpdated(): boolean {
+    return this.changed.length > 0;
+  }
+}
+
 /**
  * Creates the `this.changes.firstName` changes API for a given entity `T`.
  *
@@ -81,11 +124,13 @@ export type Changes<T extends Entity, K = keyof (FieldsOf<T> & RelationsOf<T>), 
 } & {
   [P in keyof FieldsOf<T> & R]: FieldsOf<T>[P] extends { kind: "m2m"; type: infer U extends Entity }
     ? ManyToManyFieldStatus<T, U>
-    : FieldsOf<T>[P] extends { type: infer U | undefined }
-      ? U extends Entity
-        ? ManyToOneFieldStatus<U>
-        : FieldStatus<U>
-      : never;
+    : FieldsOf<T>[P] extends { kind: "o2m"; type: infer U extends Entity }
+      ? OneToManyFieldStatus<T, U>
+      : FieldsOf<T>[P] extends { type: infer U | undefined }
+        ? U extends Entity
+          ? ManyToOneFieldStatus<U>
+          : FieldStatus<U>
+        : never;
 };
 
 // type A1 = never extends string ? 1 : 2;
@@ -108,13 +153,20 @@ export function newChangesProxy<T extends Entity>(entity: T): Changes<T> {
     get(
       target,
       p: PropertyKey,
-    ): FieldStatus<any> | ManyToOneFieldStatus<any> | ManyToManyFieldStatus<any, any> | (keyof OptsOf<T>)[] {
+    ):
+      | FieldStatus<any>
+      | ManyToOneFieldStatus<any>
+      | ManyToManyFieldStatus<any, any>
+      | OneToManyFieldStatus<any, any>
+      | (keyof OptsOf<T>)[] {
       if (p === "fields") {
         return getChangedFieldNames(entity);
       } else if (typeof p === "symbol") {
         throw new Error(`Unsupported call to ${String(p)}`);
       } else if (getMetadata(entity).allFields[p]?.kind === "m2m") {
         return new ManyToManyFieldStatus(entity, p as keyof T);
+      } else if (getMetadata(entity).allFields[p]?.kind === "o2m") {
+        return new OneToManyFieldStatus(entity, p as keyof T);
       } else if (!isChangeableField(entity, p as any)) {
         throw new Error(`Invalid changes field ${p}`);
       }
@@ -171,7 +223,7 @@ const addOriginalEntity: Record<Field["kind"], boolean> = {
   primitive: false,
 };
 
-/** Scans `entity` for changes primitive + m2m fields. */
+/** Scans `entity` for changes primitive + m2m/o2m fields. */
 function getChangedFieldNames<T extends Entity>(entity: T): (keyof OptsOf<T>)[] {
   const fieldsChanged = entity.isNewEntity
     ? // Cloning sometimes leaves unset keys in data as undefined, so drop them
@@ -183,7 +235,7 @@ function getChangedFieldNames<T extends Entity>(entity: T): (keyof OptsOf<T>)[] 
   // scan the join rows to get if the relation has any rows
   const m2mFieldsChanged: (keyof RelationsOf<T>)[] = [];
   const emApi = getEmInternalApi(entity.em);
-  // we will report changes only on the m2m relations for now
+  // check m2m relations
   const m2mFields = Object.values(getMetadata(entity).allFields).filter((f) => f.kind === "m2m");
   for (const field of m2mFields) {
     const m2m = (entity as any)[field.fieldName as keyof T] as ManyToManyCollection<any, any>;
@@ -193,7 +245,17 @@ function getChangedFieldNames<T extends Entity>(entity: T): (keyof OptsOf<T>)[] 
     }
   }
 
-  return [...fieldsChanged, ...m2mFieldsChanged] as any;
+  // check o2m relations
+  const o2mFieldsChanged: (keyof RelationsOf<T>)[] = [];
+  const o2mFields = Object.values(getMetadata(entity).allFields).filter((f) => f.kind === "o2m");
+  for (const field of o2mFields) {
+    const status = new OneToManyFieldStatus(entity, field.fieldName as keyof T);
+    if (status.hasUpdated) {
+      o2mFieldsChanged.push(field.fieldName as keyof RelationsOf<T>);
+    }
+  }
+
+  return [...fieldsChanged, ...m2mFieldsChanged, ...o2mFieldsChanged] as any;
 }
 
 const entityCompare: (a: Entity, b: Entity) => number = (a, b) => {

--- a/packages/tests/bun-sql-pg/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/bun-sql-pg/src/entities/codegen/AuthorCodegen.ts
@@ -49,6 +49,7 @@ export interface AuthorFields {
   delete: { kind: "primitive"; type: boolean; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  books: { kind: "o2m"; type: Book };
 }
 
 export interface AuthorOpts {

--- a/packages/tests/bun/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/bun/src/entities/codegen/AuthorCodegen.ts
@@ -49,6 +49,7 @@ export interface AuthorFields {
   delete: { kind: "primitive"; type: boolean; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  books: { kind: "o2m"; type: Book };
 }
 
 export interface AuthorOpts {

--- a/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/esm-misc/src/entities/codegen/AuthorCodegen.ts
@@ -49,6 +49,7 @@ export interface AuthorFields {
   delete: { kind: "primitive"; type: boolean; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  books: { kind: "o2m"; type: Book };
 }
 
 export interface AuthorOpts {

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T1AuthorCodegen.ts
@@ -52,6 +52,7 @@ export type T1AuthorId = Flavor<number, "T1Author">;
 export interface T1AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };
   firstName: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
+  t1Books: { kind: "o2m"; type: T1Book };
 }
 
 export interface T1AuthorOpts {

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
@@ -56,6 +56,7 @@ export interface T2AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };
   firstName: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   favoriteBook: { kind: "m2o"; type: T2Book; nullable: undefined; derived: false };
+  t2Books: { kind: "o2m"; type: T2Book };
 }
 
 export interface T2AuthorOpts {

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
@@ -56,6 +56,7 @@ export interface T2BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };
   title: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   author: { kind: "m2o"; type: T2Author; nullable: never; derived: false };
+  t2Authors: { kind: "o2m"; type: T2Author };
 }
 
 export interface T2BookOpts {

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
@@ -56,6 +56,7 @@ export interface T3AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };
   firstName: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   favoriteBook: { kind: "m2o"; type: T3Book; nullable: never; derived: false };
+  t3Books: { kind: "o2m"; type: T3Book };
 }
 
 export interface T3AuthorOpts {

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
@@ -56,6 +56,7 @@ export interface T3BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };
   title: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   author: { kind: "m2o"; type: T3Author; nullable: never; derived: false };
+  t3Authors: { kind: "o2m"; type: T3Author };
 }
 
 export interface T3BookOpts {

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
@@ -56,6 +56,7 @@ export interface T4AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };
   firstName: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   favoriteBook: { kind: "m2o"; type: T4Book; nullable: never; derived: false };
+  t4Books: { kind: "o2m"; type: T4Book };
 }
 
 export interface T4AuthorOpts {

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
@@ -56,6 +56,7 @@ export interface T4BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };
   title: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   author: { kind: "m2o"; type: T4Author; nullable: never; derived: false };
+  t4Authors: { kind: "o2m"; type: T4Author };
 }
 
 export interface T4BookOpts {

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5AuthorCodegen.ts
@@ -52,6 +52,7 @@ export type T5AuthorId = Flavor<number, "T5Author">;
 export interface T5AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };
   firstName: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
+  t5Books: { kind: "o2m"; type: T5Book };
 }
 
 export interface T5AuthorOpts {

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
@@ -59,6 +59,7 @@ export interface T5BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: never };
   title: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   author: { kind: "m2o"; type: T5Author; nullable: never; derived: false };
+  reviews: { kind: "o2m"; type: T5BookReview };
 }
 
 export interface T5BookOpts {

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -307,15 +307,6 @@ describe("Author", () => {
       expect(a1.changes.fields).toEqual([]);
     });
 
-    it("does not have collections", async () => {
-      const em = newEntityManager();
-      const a1 = new Author(em, { firstName: "f1", lastName: "ln" });
-      expect(() => {
-        // @ts-expect-error
-        a1.changes.books;
-      }).toThrow("Invalid changes field books");
-    });
-
     it("has the right type for strings", async () => {
       const em = newEntityManager();
       const a1 = new Author(em, { firstName: "f1", lastName: "ln" });

--- a/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/AuthorCodegen.ts
@@ -139,6 +139,13 @@ export interface AuthorFields {
   favoriteBook: { kind: "m2o"; type: Book; nullable: undefined; derived: true };
   publisher: { kind: "m2o"; type: Publisher; nullable: undefined; derived: false };
   tags: { kind: "m2m"; type: Tag };
+  mentees: { kind: "o2m"; type: Author };
+  books: { kind: "o2m"; type: Book };
+  reviewerBooks: { kind: "o2m"; type: Book };
+  schedules: { kind: "o2m"; type: AuthorSchedule };
+  comments: { kind: "o2m"; type: Comment };
+  spotlightAuthorPublishers: { kind: "o2m"; type: Publisher };
+  tasks: { kind: "o2m"; type: TaskNew };
 }
 
 export interface AuthorOpts {

--- a/packages/tests/integration/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/BookCodegen.ts
@@ -91,6 +91,9 @@ export interface BookFields {
   reviewer: { kind: "m2o"; type: Author; nullable: undefined; derived: false };
   randomComment: { kind: "m2o"; type: Comment; nullable: undefined; derived: false };
   tags: { kind: "m2m"; type: Tag };
+  advances: { kind: "o2m"; type: BookAdvance };
+  reviews: { kind: "o2m"; type: BookReview };
+  comments: { kind: "o2m"; type: Comment };
 }
 
 export interface BookOpts {

--- a/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildCodegen.ts
@@ -54,6 +54,7 @@ export interface ChildFields {
   name: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  groups: { kind: "o2m"; type: ChildGroup };
 }
 
 export interface ChildOpts {

--- a/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ChildGroupCodegen.ts
@@ -66,6 +66,7 @@ export interface ChildGroupFields {
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   childGroupId: { kind: "m2o"; type: Child; nullable: never; derived: false };
   parentGroup: { kind: "m2o"; type: ParentGroup; nullable: never; derived: false };
+  childItems: { kind: "o2m"; type: ChildItem };
 }
 
 export interface ChildGroupOpts {

--- a/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CommentCodegen.ts
@@ -86,6 +86,7 @@ export interface CommentFields {
   user: { kind: "m2o"; type: User; nullable: undefined; derived: false };
   parent: { kind: "poly"; type: CommentParent; nullable: never };
   likedByUsers: { kind: "m2m"; type: User };
+  books: { kind: "o2m"; type: Book };
 }
 
 export interface CommentOpts {

--- a/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/CriticCodegen.ts
@@ -73,6 +73,7 @@ export interface CriticFields {
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   favoriteLargePublisher: { kind: "m2o"; type: LargePublisher; nullable: undefined; derived: false };
   group: { kind: "m2o"; type: PublisherGroup; nullable: undefined; derived: false };
+  bookReviews: { kind: "o2m"; type: BookReview };
 }
 
 export interface CriticOpts {

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -78,6 +78,8 @@ export interface LargePublisherFields extends PublisherFields {
   country: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   rating: { kind: "primitive"; type: number; unique: false; nullable: never; derived: false };
   spotlightAuthor: { kind: "m2o"; type: Author; nullable: never; derived: false };
+  critics: { kind: "o2m"; type: Critic };
+  users: { kind: "o2m"; type: User };
 }
 
 export interface LargePublisherOpts extends PublisherOpts {

--- a/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentGroupCodegen.ts
@@ -57,6 +57,8 @@ export interface ParentGroupFields {
   name: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  childGroups: { kind: "o2m"; type: ChildGroup };
+  parentItems: { kind: "o2m"; type: ParentItem };
 }
 
 export interface ParentGroupOpts {

--- a/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/ParentItemCodegen.ts
@@ -61,6 +61,7 @@ export interface ParentItemFields {
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   parentGroup: { kind: "m2o"; type: ParentGroup; nullable: never; derived: false };
+  childItems: { kind: "o2m"; type: ChildItem };
 }
 
 export interface ParentItemOpts {

--- a/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherCodegen.ts
@@ -107,6 +107,10 @@ export interface PublisherFields {
   spotlightAuthor: { kind: "m2o"; type: Author; nullable: undefined; derived: false };
   tags: { kind: "m2m"; type: Tag };
   tasks: { kind: "m2m"; type: TaskOld };
+  authors: { kind: "o2m"; type: Author };
+  bookAdvances: { kind: "o2m"; type: BookAdvance };
+  comments: { kind: "o2m"; type: Comment };
+  images: { kind: "o2m"; type: Image };
 }
 
 export interface PublisherOpts {

--- a/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/PublisherGroupCodegen.ts
@@ -67,6 +67,8 @@ export interface PublisherGroupFields {
   numberOfBookReviews: { kind: "primitive"; type: number; unique: false; nullable: never; derived: true };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  publishers: { kind: "o2m"; type: Publisher };
+  critics: { kind: "o2m"; type: Critic };
 }
 
 export interface PublisherGroupOpts {

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -78,6 +78,8 @@ export interface SmallPublisherFields extends PublisherFields {
   allAuthorNames: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: true };
   selfReferential: { kind: "m2o"; type: SmallPublisher; nullable: undefined; derived: false };
   group: { kind: "m2o"; type: SmallPublisherGroup; nullable: undefined; derived: false };
+  smallPublishers: { kind: "o2m"; type: SmallPublisher };
+  users: { kind: "o2m"; type: User };
 }
 
 export interface SmallPublisherOpts extends PublisherOpts {

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherGroupCodegen.ts
@@ -57,6 +57,7 @@ export type SmallPublisherGroupId = Flavor<string, "PublisherGroup">;
 export interface SmallPublisherGroupFields extends PublisherGroupFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: never };
   smallName: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
+  publishers: { kind: "o2m"; type: SmallPublisher };
 }
 
 export interface SmallPublisherGroupOpts extends PublisherGroupOpts {

--- a/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskCodegen.ts
@@ -83,6 +83,8 @@ export interface TaskFields {
   type: { kind: "enum"; type: TaskType; nullable: undefined };
   copiedFrom: { kind: "m2o"; type: Task; nullable: undefined; derived: false };
   tags: { kind: "m2m"; type: Tag };
+  copiedTo: { kind: "o2m"; type: Task };
+  taskTaskItems: { kind: "o2m"; type: TaskItem };
 }
 
 export interface TaskOpts {

--- a/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
@@ -70,6 +70,9 @@ export interface TaskNewFields extends TaskFields {
   selfReferential: { kind: "m2o"; type: TaskNew; nullable: undefined; derived: false };
   specialNewAuthor: { kind: "m2o"; type: Author; nullable: undefined; derived: false };
   copiedFrom: { kind: "m2o"; type: TaskNew; nullable: undefined; derived: false };
+  newTaskTaskItems: { kind: "o2m"; type: TaskItem };
+  selfReferentialTasks: { kind: "o2m"; type: TaskNew };
+  copiedTo: { kind: "o2m"; type: TaskNew };
 }
 
 export interface TaskNewOpts extends TaskOpts {

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -74,6 +74,10 @@ export interface TaskOldFields extends TaskFields {
   parentOldTask: { kind: "m2o"; type: TaskOld; nullable: undefined; derived: false };
   copiedFrom: { kind: "m2o"; type: TaskOld; nullable: undefined; derived: false };
   publishers: { kind: "m2m"; type: Publisher };
+  comments: { kind: "o2m"; type: Comment };
+  oldTaskTaskItems: { kind: "o2m"; type: TaskItem };
+  tasks: { kind: "o2m"; type: TaskOld };
+  copiedTo: { kind: "o2m"; type: TaskOld };
 }
 
 export interface TaskOldOpts extends TaskOpts {

--- a/packages/tests/integration/src/entities/codegen/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/UserCodegen.ts
@@ -91,6 +91,8 @@ export interface UserFields {
   authorManyToOne: { kind: "m2o"; type: Author; nullable: undefined; derived: false };
   favoritePublisher: { kind: "poly"; type: UserFavoritePublisher; nullable: undefined };
   likedComments: { kind: "m2m"; type: Comment };
+  createdComments: { kind: "o2m"; type: Comment };
+  directs: { kind: "o2m"; type: User };
 }
 
 export interface UserOpts {

--- a/packages/tests/integration/src/relations/OneToManyCollection.test.ts
+++ b/packages/tests/integration/src/relations/OneToManyCollection.test.ts
@@ -20,14 +20,22 @@ describe("OneToManyCollection", () => {
       const em = newEntityManager();
       // Given an author with no (loaded) books
       const a1 = await em.load(Author, "1", "books");
-      // Add a new book
+      // When we add a new book
       const b1 = em.create(Book, { title: "b1", author: a1 });
-      // Check changes
+      // Then it shows up as added/changed
       expect(a1.changes.books.added).toMatchEntity([b1]);
       expect(a1.changes.books.removed).toMatchEntity([]);
       expect(a1.changes.books.changed).toMatchEntity([b1]);
       expect(a1.changes.books.hasUpdated).toBe(true);
       expect(a1.changes.fields).toContain("books");
+      // And when we flush
+      await em.flush();
+      // Then it's no longer changed
+      expect(a1.changes.books.added).toMatchEntity([]);
+      expect(a1.changes.books.removed).toMatchEntity([]);
+      expect(a1.changes.books.changed).toMatchEntity([]);
+      expect(a1.changes.books.hasUpdated).toBe(false);
+      expect(a1.changes.fields).toEqual([]);
     });
 
     it("tracks added/unloaded entities", async () => {

--- a/packages/tests/integration/src/relations/OneToManyCollection.test.ts
+++ b/packages/tests/integration/src/relations/OneToManyCollection.test.ts
@@ -14,6 +14,115 @@ describe("OneToManyCollection", () => {
     expect(books.length).toEqual(2);
   });
 
+  describe("changes tracking", () => {
+    it("tracks added/loaded entities", async () => {
+      await insertAuthor({ first_name: "a1" });
+      const em = newEntityManager();
+      // Given an author with no (loaded) books
+      const a1 = await em.load(Author, "1", "books");
+      // Add a new book
+      const b1 = em.create(Book, { title: "b1", author: a1 });
+      // Check changes
+      expect(a1.changes.books.added).toMatchEntity([b1]);
+      expect(a1.changes.books.removed).toMatchEntity([]);
+      expect(a1.changes.books.changed).toMatchEntity([b1]);
+      expect(a1.changes.books.hasUpdated).toBe(true);
+      expect(a1.changes.fields).toContain("books");
+    });
+
+    it("tracks added/unloaded entities", async () => {
+      await insertAuthor({ first_name: "a1" });
+      const em = newEntityManager();
+      // Given an author with no (unloaded) books
+      const a1 = await em.load(Author, "1");
+      // Add a new book
+      const b1 = em.create(Book, { title: "b1", author: a1 });
+      // Check changes
+      expect(a1.changes.books.added).toMatchEntity([b1]);
+      expect(a1.changes.books.removed).toMatchEntity([]);
+      expect(a1.changes.books.changed).toMatchEntity([b1]);
+      expect(a1.changes.books.hasUpdated).toBe(true);
+      expect(a1.changes.fields).toContain("books");
+    });
+
+    it("tracks removed/loaded entities", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      const em = newEntityManager();
+      // Given an author with one (loaded) books
+      const a1 = await em.load(Author, "1", "books");
+      const b1 = a1.books.get[0];
+      // When we remove the book
+      b1.author.set(newAuthor(em));
+      // Then we see it removed
+      expect(a1.changes.books.added).toMatchEntity([]);
+      expect(a1.changes.books.removed).toMatchEntity([b1]);
+      expect(a1.changes.books.changed).toMatchEntity([b1]);
+      expect(a1.changes.books.hasUpdated).toBe(true);
+      expect(a1.changes.fields).toContain("books");
+    });
+
+    it("tracks removed/unloaded entities", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      const em = newEntityManager();
+      // Given an author with one (unloaded) books
+      const a1 = await em.load(Author, "a:1");
+      const b1 = await em.load(Book, "b:1");
+      // When we remove the book
+      b1.author.set(newAuthor(em));
+      // Then we see it removed
+      expect(a1.changes.books.added).toMatchEntity([]);
+      expect(a1.changes.books.removed).toMatchEntity([b1]);
+      expect(a1.changes.books.changed).toMatchEntity([b1]);
+      expect(a1.changes.books.hasUpdated).toBe(true);
+      expect(a1.changes.fields).toContain("books");
+    });
+
+    it("tracks both added and removed entities", async () => {
+      // Given an author with one book
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      const em = newEntityManager();
+      const a1 = await em.load(Author, "a:1");
+      const b1 = await em.load(Book, "b:1");
+      // Add a new book
+      const b2 = em.create(Book, { title: "b2", author: a1 });
+      // And remove an existing book
+      b1.author.set(newAuthor(em));
+      // Check changes
+      expect(a1.changes.books.added).toMatchEntity([b2]);
+      expect(a1.changes.books.removed).toMatchEntity([b1]);
+      expect(a1.changes.books.changed).toMatchEntity([b1, b2]);
+      expect(a1.changes.books.hasUpdated).toBe(true);
+      expect(a1.changes.fields).toContain("books");
+    });
+
+    it("tracks when a collection is set", async () => {
+      // Given an author with two books
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBook({ title: "b2", author_id: 1 });
+
+      const em = newEntityManager();
+      const a1 = await em.load(Author, "1", "books");
+      const [b1, b2] = a1.books.get;
+
+      // Create a new book
+      const b3 = em.create(Book, { title: "b3" });
+
+      // Set the collection to a new set of books
+      a1.books.set([b2, b3]);
+
+      // Check changes
+      expect(await a1.changes.books.added).toMatchEntity([b3]);
+      expect(await a1.changes.books.removed).toMatchEntity([b1]);
+      expect(await a1.changes.books.changed).toMatchEntity([b1, b3]);
+      expect(a1.changes.books.hasUpdated).toBe(true);
+      expect(a1.changes.fields).toContain("books");
+    });
+  });
+
   it("loads collections with instances already in the UoW", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });

--- a/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
@@ -75,6 +75,7 @@ describe("ReactiveQueryField", () => {
         "rating",
         "spotlightAuthor",
         "type",
+        "authors",
         "baseSyncDefault",
         "favoriteAuthor",
         "baseAsyncDefault",

--- a/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/codegen/AuthorCodegen.ts
@@ -46,6 +46,7 @@ export interface AuthorFields {
   lastName: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  books: { kind: "o2m"; type: Book };
 }
 
 export interface AuthorOpts {

--- a/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/ArtistCodegen.ts
@@ -55,6 +55,7 @@ export interface ArtistFields {
   lastName: { kind: "primitive"; type: string; unique: false; nullable: never; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  paintings: { kind: "o2m"; type: Painting };
 }
 
 export interface ArtistOpts {

--- a/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/codegen/AuthorCodegen.ts
@@ -49,6 +49,7 @@ export interface AuthorFields {
   delete: { kind: "primitive"; type: boolean; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  books: { kind: "o2m"; type: Book };
 }
 
 export interface AuthorOpts {

--- a/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/temporal/src/entities/codegen/AuthorCodegen.ts
@@ -54,6 +54,7 @@ export interface AuthorFields {
   timeToMicros: { kind: "primitive"; type: Temporal.PlainTime; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Temporal.ZonedDateTime; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Temporal.ZonedDateTime; unique: false; nullable: never; derived: true };
+  books: { kind: "o2m"; type: Book };
 }
 
 export interface AuthorOpts {

--- a/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/AuthorCodegen.ts
@@ -61,6 +61,9 @@ export interface AuthorFields {
   lastName: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  books: { kind: "o2m"; type: Book };
+  bookReviews: { kind: "o2m"; type: BookReview };
+  comments: { kind: "o2m"; type: Comment };
 }
 
 export interface AuthorOpts {

--- a/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/codegen/BookCodegen.ts
@@ -61,6 +61,7 @@ export interface BookFields {
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   author: { kind: "m2o"; type: Author; nullable: never; derived: false };
+  comments: { kind: "o2m"; type: Comment };
 }
 
 export interface BookOpts {

--- a/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/codegen/AuthorCodegen.ts
@@ -46,6 +46,7 @@ export interface AuthorFields {
   lastName: { kind: "primitive"; type: string; unique: false; nullable: undefined; derived: false };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never; derived: true };
+  books: { kind: "o2m"; type: Book };
 }
 
 export interface AuthorOpts {


### PR DESCRIPTION
Following up on the `author.changes.tags.added,removed,changed`, adds the similar methods for o2m collections:

* `author.books.added`
* `author.books.removed`
* `author.books.changed`
* `author.books.hasUpdated`

What's a little different / I'm unsure about is that these new `added` / `removed` / `changed` are not promises, because technically we can implement them without any `em.load` calls--which honestly is kind of surprising.

The reason is that, today, any "o2m mutation" (whether `b1.author.set(a2)` or `a.books.remove(b1)` or `a.books.add(b1)` requires having the full `b1` instance in-memory.

This would change if someday we added `a.books.addId("b:1")`, which technically we did (awhile ago) make the same change to m2os, where they originally required `b.author.set(loadedAuthor)` but can now be mutated like `b.author.set("a:1")`...

So, dunno, it's a little risky to have these be "not promises", but going to try it for now & see how it goes.