### PR TITLE
fix: reset currentlyInstantiatingEntity inside setSyncDefaults

### DIFF
--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -3,7 +3,8 @@ import { Entity, EntityManager, InstanceData, TaggedId, deTagId, getMetadata, ke
 
 export let currentlyInstantiatingEntity: Entity | undefined;
 
-/** Should only be used by our `joist-transform-properties` to lazy init properties. */
+/** Used by our `joist-transform-properties` to lazy init properties and by sync defaults to reset if an entity is
+ * created as a default. */
 export function setCurrentlyInstantiatingEntity(entity: Entity): void {
   currentlyInstantiatingEntity = entity;
 }

--- a/packages/orm/src/defaults.ts
+++ b/packages/orm/src/defaults.ts
@@ -1,5 +1,5 @@
 import { Deferred } from "joist-utils";
-import { getInstanceData } from "./BaseEntity";
+import { getInstanceData, setCurrentlyInstantiatingEntity } from "./BaseEntity";
 import { Entity } from "./Entity";
 import { EntityMetadata, EnumField, Field, getBaseAndSelfMetas, getMetadata, PrimitiveField } from "./EntityMetadata";
 import { setField } from "./fields";
@@ -52,6 +52,9 @@ export function setSyncDefaults(entity: Entity): void {
         // require a field hint (so would be async) to get "the other entity". However, something like:
         // `config.setDefault("original", (self) => self);` is technically valid.
         value.set(maybeFn instanceof Function ? maybeFn(entity) : maybeFn);
+        // Since a reference is an entity, maybeFn could have returned a new entity. If so, the new
+        // entity would have set currentlyInstantiatingEntity to itself, so we need to reset now to this entity;
+        setCurrentlyInstantiatingEntity(entity);
       }
     }
   }

--- a/packages/tests/integration/src/FieldLogging.test.ts
+++ b/packages/tests/integration/src/FieldLogging.test.ts
@@ -47,12 +47,12 @@ describe("FieldLogging", () => {
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
        "a#1.isFunny = false at defaults.ts:45↩",
-       "a#1.nickNames = a1 at defaults.ts:188↩",
+       "a#1.nickNames = a1 at defaults.ts:191↩",
        "b#1.title = title at newBook.ts:9↩",
        "b#1.order = 1 at newBook.ts:9↩",
        "b#1.author = Author#1 at newBook.ts:9↩",
        "b#1.notes = Notes for title at defaults.ts:45↩",
-       "b#1.authorsNickNames = a1 at defaults.ts:188↩",
+       "b#1.authorsNickNames = a1 at defaults.ts:191↩",
      ]
     `);
   });
@@ -66,7 +66,7 @@ describe("FieldLogging", () => {
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
        "a#1.isFunny = false at defaults.ts:45↩",
-       "a#1.nickNames = a1 at defaults.ts:188↩",
+       "a#1.nickNames = a1 at defaults.ts:191↩",
      ]
     `);
   });


### PR DESCRIPTION
If an entity has a synchronous `config.setDefault` that creates a new entity, then this will create a new entity from within the call stack of another entity's constructor.  This will change `currentlyInstantiatingEntity` to the newest entity and any code in the original entity's constructor that executes after, eg custom relations without `properties-transformer`, will pull in the wrong entity leading to unpredictably behavior.