### PR TITLE
feat: add includeSchema option to config, with default of public

### DIFF
--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -142,7 +142,7 @@ export const config = z
     version: z.string().default("0.0.0"),
 
     /** A list of postgres schemas to use for finding tables */
-    includeSchema: z.optional(z.array(z.string())),
+    schemas: z.optional(z.array(z.string())),
   })
   .strict();
 

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -142,7 +142,7 @@ export const config = z
     version: z.string().default("0.0.0"),
 
     /** A list of postgres schemas to use for finding tables */
-    includeSchema: z.array(z.string()).default(["public"]),
+    includeSchema: z.optional(z.array(z.string())),
   })
   .strict();
 

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -140,6 +140,7 @@ export const config = z
     allowImportingTsExtensions: z.optional(z.boolean()),
     // The version of Joist that generated this config.
     version: z.string().default("0.0.0"),
+    includeSchema: z.array(z.string()).default(['public']),
   })
   .strict();
 

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -140,7 +140,9 @@ export const config = z
     allowImportingTsExtensions: z.optional(z.boolean()),
     // The version of Joist that generated this config.
     version: z.string().default("0.0.0"),
-    includeSchema: z.array(z.string()).default(['public']),
+
+    /** A list of postgres schemas to use for finding tables */
+    includeSchema: z.array(z.string()).default(["public"]),
   })
   .strict();
 

--- a/packages/codegen/src/utils.ts
+++ b/packages/codegen/src/utils.ts
@@ -195,5 +195,5 @@ function isIgnored(config: Config, t: Table): boolean {
 }
 
 function shouldIncludeSchema(config: Config, t: Table): boolean {
-  return config.includeSchema ? config.includeSchema.includes(t.schema.name) : t.schema.name === "public";
+  return config.schemas ? config.schemas.includes(t.schema.name) : t.schema.name === "public";
 }

--- a/packages/codegen/src/utils.ts
+++ b/packages/codegen/src/utils.ts
@@ -191,9 +191,9 @@ export function uncapitalize(s: string): string {
 }
 
 function isIgnored(config: Config, t: Table): boolean {
-  return (config.ignoredTables || ["migrations", "pgmigrations"]).includes(t.name) || !shouldIncludeSchema(t);
+  return (config.ignoredTables || ["migrations", "pgmigrations"]).includes(t.name) || !shouldIncludeSchema(config, t);
 }
 
-function shouldIncludeSchema(t: Table): boolean {
-  return t.schema.name === "public";
+function shouldIncludeSchema(config: Config, t: Table): boolean {
+  return config.includeSchema.includes(t.schema.name);
 }

--- a/packages/codegen/src/utils.ts
+++ b/packages/codegen/src/utils.ts
@@ -195,5 +195,5 @@ function isIgnored(config: Config, t: Table): boolean {
 }
 
 function shouldIncludeSchema(config: Config, t: Table): boolean {
-  return config.includeSchema.includes(t.schema.name);
+  return config.includeSchema ? config.includeSchema.includes(t.schema.name) : t.schema.name === "public";
 }


### PR DESCRIPTION
- Fixes #1398
- Add optional `"includeSchema"` option to `joist-config.json`
- Taking an array of schema names
