### PR TITLE
feat: Add support for logging instantiation.

### DIFF
--- a/docs/src/content/docs/logging/field-logging.md
+++ b/docs/src/content/docs/logging/field-logging.md
@@ -17,6 +17,7 @@ em.setFieldLogging(true);
 This will produce console output like:
 
 ```
+a#1 created at newAuthor.ts:13
 a#1.firstName = a1 at newAuthor.ts:13
 a#1.age = 40 at newAuthor.ts:13
 b#1.title = title at newBook.ts:9
@@ -56,6 +57,8 @@ em.setFieldLogging(new FieldLogger([
   { entity: "Author" },
   // Log only title changes to Books
   { entity: "Book", fieldNames: ["title"] },
+  // Log only instantiation of BookReview
+  { entity: "BookReview", fieldNames: ["constructor"] },
 ]));
 ```
 

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -1,5 +1,14 @@
 import { IdType } from "./Entity";
-import { Entity, EntityManager, InstanceData, TaggedId, deTagId, getMetadata, keyToNumber } from "./index";
+import {
+  Entity,
+  EntityManager,
+  InstanceData,
+  TaggedId,
+  deTagId,
+  getEmInternalApi,
+  getMetadata,
+  keyToNumber,
+} from "./index";
 
 export let currentlyInstantiatingEntity: Entity | undefined;
 
@@ -36,7 +45,12 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
     // This makes it non-enumerable to avoid Jest/recursive things tripping over it
     Object.defineProperty(this, "__data", { value: data, enumerable: false, writable: false, configurable: false });
     // Only do em.register for em.create-d entities, otherwise defer to hydrate to em.register
-    if (isNew) em.register(this, optsOrId?.id);
+    if (isNew) {
+      em.register(this, optsOrId?.id);
+      // api will be undefined during getFakeInstance
+      const api = getEmInternalApi(em);
+      api?.fieldLogger?.logCreate(this);
+    }
     currentlyInstantiatingEntity = this;
   }
 

--- a/packages/orm/src/logging/FieldLogger.ts
+++ b/packages/orm/src/logging/FieldLogger.ts
@@ -3,7 +3,6 @@ import { Entity, isEntity } from "../Entity";
 import { getFuzzyCallerName } from "../config";
 
 const { gray, green, yellow, blue, red } = ansis;
-let globalLogger: FieldLogger | undefined = undefined;
 type WriteFn = (line: string) => void;
 
 export type FieldLoggerWatch = {
@@ -31,6 +30,13 @@ export class FieldLogger {
     // We default to process.stdout.write to side-step around Jest's console.log instrumentation
     this.#writeFn = writeFn ?? process.stdout.write.bind(process.stdout);
     this.#watching = watching ?? [];
+  }
+
+  logCreate(entity: Entity): void {
+    const log = this.shouldLog(entity, "constructor");
+    if (!log) return;
+    this.log(green.bold(`${entity.toTaggedString()}`) + " " + yellow(`created`), gray(`at ${getFuzzyCallerName()}`));
+    if (log === "breakpoint") debugger;
   }
 
   logSet(entity: Entity, fieldName: string, value: unknown): void {

--- a/packages/tests/integration/src/FieldLogging.test.ts
+++ b/packages/tests/integration/src/FieldLogging.test.ts
@@ -1,6 +1,6 @@
 import ansiRegex = require("ansi-regex");
 import { FieldLogger, FieldLoggerWatch } from "joist-orm";
-import { Author, Publisher, newBook } from "src/entities";
+import { Author, Publisher, newAuthor, newBook } from "src/entities";
 import { insertAuthor, insertPublisher } from "src/entities/inserts";
 import { newEntityManager } from "src/testEm";
 
@@ -44,10 +44,12 @@ describe("FieldLogging", () => {
     newBook(em);
     expect(fieldOutput).toMatchInlineSnapshot(`
      [
+       "a#1 created at newAuthor.ts:13↩",
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
        "a#1.isFunny = false at defaults.ts:45↩",
        "a#1.nickNames = a1 at defaults.ts:191↩",
+       "b#1 created at newBook.ts:9↩",
        "b#1.title = title at newBook.ts:9↩",
        "b#1.order = 1 at newBook.ts:9↩",
        "b#1.author = Author#1 at newBook.ts:9↩",
@@ -57,12 +59,20 @@ describe("FieldLogging", () => {
     `);
   });
 
+  it("sees instantiations", async () => {
+    const em = newEntityManager();
+    em.setFieldLogging(new StubFieldLogger());
+    const a1 = newAuthor(em);
+    expect(fieldOutput[0]).toMatch(/a#1 created at newAuthor.ts:(\d+)↩/);
+  });
+
   it("can filter fields by entity", async () => {
     const em = newEntityManager();
     em.setFieldLogging(new StubFieldLogger([{ entity: "Author" }]));
     newBook(em);
     expect(fieldOutput).toMatchInlineSnapshot(`
      [
+       "a#1 created at newAuthor.ts:13↩",
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
        "a#1.isFunny = false at defaults.ts:45↩",
@@ -78,6 +88,17 @@ describe("FieldLogging", () => {
     expect(fieldOutput).toMatchInlineSnapshot(`
      [
        "a#1.age = 40 at newAuthor.ts:13↩",
+     ]
+    `);
+  });
+
+  it("can filter by constructor", async () => {
+    const em = newEntityManager();
+    em.setFieldLogging(new StubFieldLogger([{ entity: "Author", fieldNames: ["constructor"] }]));
+    newBook(em);
+    expect(fieldOutput).toMatchInlineSnapshot(`
+     [
+       "a#1 created at newAuthor.ts:13↩",
      ]
     `);
   });


### PR DESCRIPTION
- `em.setFieldLogging("Author.constructor")` will log each time an author is `em.create`-d
- `em.setFieldLogging("Author.constructor!")` will breakpoint each time an author is `em.create`-d


With the existing breakpoint support, this also supports debugging when entities are created.

Currently this specifically creating of new entities, and not hydration of existing entities into memory.