### PR TITLE
fix: update handling of polymorphic references so subtypes aren't thrown out

### DIFF
--- a/packages/orm/src/relations/PolymorphicReference.ts
+++ b/packages/orm/src/relations/PolymorphicReference.ts
@@ -233,8 +233,24 @@ export class PolymorphicReferenceImpl<T extends Entity, U extends Entity, N exte
 
     ensureNotDeleted(this.entity, "pending");
 
-    // Prefer to keep the id in our data hash, but if this is a new entity w/o an id, use the entity itself
-    const changed = setField(this.entity, this.fieldName, isEntity(other) ? (other?.idTaggedMaybe ?? other) : other);
+    // Prefer to keep the id in our data hash, but if this is a new entity w/o an id, use the entity itself.
+    // We also need to keep the entity itself if we have other components with the same base type.  This is due to
+    // subtypes sharing the same tag as their base type, so we cannot tell which subtype an id belongs to
+    if (isEntity(other)) {
+      const otherMeta = getMetadata(other);
+      const hasComponentsWithSameBaseType =
+        otherMeta.baseType &&
+        this.field.components.some(
+          (c) => c.otherMetadata().baseType === otherMeta.baseType && !(other instanceof c.otherMetadata().cstr),
+        );
+      setField(
+        this.entity,
+        this.fieldName,
+        other.isNewEntity || hasComponentsWithSameBaseType ? other : other.idTagged,
+      );
+    } else {
+      setField(this.entity, this.fieldName, other);
+    }
 
     if (typeof other === "string") {
       this.loaded = undefined;

--- a/packages/orm/src/serde.ts
+++ b/packages/orm/src/serde.ts
@@ -357,14 +357,18 @@ export class PolymorphicKeySerde implements FieldSerde {
       isArray: false,
       otherMetadata: comp.otherMetadata,
       dbValue(data: any): any {
-        const id = maybeResolveReferenceToId(data[fieldName]);
-        const cstr = id ? getConstructorFromTaggedId(id) : undefined;
+        const value = data[fieldName];
+        const id = maybeResolveReferenceToId(value);
+        const cstr = isEntity(value) ? value.constructor : id ? getConstructorFromTaggedId(id) : undefined;
         // We'll have multiple columns, i.e. [parent_author_id, parent_book_id], and each column
         // will only return a value if the `id` matches its type, i.e. `parent_author_id=a:1` will
         // return 1, but `parent_book_id` will return null.
+        const otherMeta = comp.otherMetadata();
         const idAppliesToThisColumn = hasMultipleComponentsWithSameBaseType
-          ? cstr === comp.otherMetadata().cstr
-          : cstr === getBaseMeta(comp.otherMetadata()).cstr;
+          ? cstr === otherMeta.cstr
+          : cstr === otherMeta.cstr ||
+            cstr === getBaseMeta(otherMeta).cstr ||
+            otherMeta.subTypes.some((subTypeMeta) => cstr === subTypeMeta.cstr);
         return idAppliesToThisColumn ? keyToNumber(comp.otherMetadata(), id) : undefined;
       },
       mapToDb(value: any): any {


### PR DESCRIPTION
this is only a partial fix, as passing an ID will still get thrown out