### PR TITLE
fix: Fix setting over ReactiveReferences.

### DIFF
--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -44,7 +44,7 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
     const data = new InstanceData(em, (this.constructor as any).metadata, isNew);
     // This makes it non-enumerable to avoid Jest/recursive things tripping over it
     Object.defineProperty(this, "__data", { value: data, enumerable: false, writable: false, configurable: false });
-    // Only do em.register for em.create-d entities, otherwise defer to hydrate to em.register
+    // Only do em.register for `new Author`-d entities, otherwise defer to em.create and em.hydrate to em.register
     if (isNew) {
       em.register(this, optsOrId?.id);
       // api will be undefined during getFakeInstance

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -661,8 +661,12 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
   /** Creates a new `type` and marks it as loaded, i.e. we know its collections are all safe to access in memory. */
   public create<T extends EntityW, O extends OptsOf<T>>(type: EntityConstructor<T>, opts: O): New<T, O> {
+    // Specifically do *not* call `setOpts` until the instance is fully created/the constructor has completed
+    // See https://github.com/joist-orm/joist-orm/issues/1442
     // The constructor will run setOpts which handles defaulting collections to the right state.
-    return new type(this, opts) as New<T, O>;
+    const entity = new type(this, undefined!);
+    setOpts(entity, opts as OptsOf<T>, { partial: true, calledFromConstructor: true });
+    return entity as New<T, O>;
   }
 
   /** Creates a new `type` but with `opts` that are nullable, to accept partial-update-style input. */

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -229,6 +229,7 @@ export function setOpts<T extends Entity>(
       } else if (isAsyncProperty(current) || isReactiveGetter(current)) {
         throw new Error(`Invalid argument, cannot set over ${key} ${current.constructor.name}`);
       } else if (isReactiveField(current) || isReactiveQueryField(current)) {
+        // Note that `ReactiveReference`s are AbstractRelationImpls, so go through the ^ flow
         if (value instanceof FactoryInitialValue) {
           if (current instanceof ReactiveFieldImpl) {
             current.setFactoryValue(value.value);

--- a/packages/tests/integration/src/Entity.test.ts
+++ b/packages/tests/integration/src/Entity.test.ts
@@ -107,11 +107,18 @@ describe("Entity", () => {
       }).toThrow("Unknown field fooBar");
     });
 
-    it("cannot set over an async field", async () => {
+    it("cannot set over an AsyncProperty in set", async () => {
       const em = newEntityManager();
       const a1 = em.create(Author, { firstName: "a1" });
       expect(() => {
         a1.set({ latestComments: [] } as any);
+      }).toThrow("Invalid argument, cannot set over latestComments AsyncPropertyImpl");
+    });
+
+    it("cannot set over an AsyncProperty in em.create", async () => {
+      const em = newEntityManager();
+      expect(() => {
+        em.create(Author, { firstName: "a1", latestComments: [] });
       }).toThrow("Invalid argument, cannot set over latestComments AsyncPropertyImpl");
     });
 
@@ -123,12 +130,53 @@ describe("Entity", () => {
       }).toThrow("'set' not implemented on CustomReference");
     });
 
-    it("cannot set over a reactive field", async () => {
+    it("cannot set over ReactiveField in set", async () => {
       const em = newEntityManager();
       const a1 = em.create(Author, { firstName: "a1" });
       expect(() => {
         a1.set({ numberOfPublicReviews: 2 } as any);
       }).toThrow("Invalid argument, cannot set over numberOfPublicReviews ReactiveFieldImpl");
+    });
+
+    it("cannot set over ReactiveField in em.create", async () => {
+      const em = newEntityManager();
+      expect(() => {
+        // -- @ts-expect-error
+        em.create(Author, { firstName: "a1", numberOfPublicReviews: 2 });
+      }).toThrow("Invalid argument, cannot set over numberOfPublicReviews ReactiveFieldImpl");
+    });
+
+    it("cannot set over ReactiveField in em.createPartial", async () => {
+      const em = newEntityManager();
+      expect(() => {
+        // @ts-expect-error
+        em.createPartial(Author, { numberOfPublicReviews: 2 });
+      }).toThrow("Invalid argument, cannot set over numberOfPublicReviews ReactiveFieldImpl");
+    });
+
+    it("cannot set over ReactiveReference in set", async () => {
+      const em = newEntityManager();
+      const a1 = em.create(Author, { firstName: "a1" });
+      expect(() => {
+        // @ts-expect-error
+        a1.set({ favoriteBook: undefined });
+      }).toThrow("Cannot set Author#1.favoriteBook ReactiveReference directly.");
+    });
+
+    it("cannot set over ReactiveReference in em.create", async () => {
+      const em = newEntityManager();
+      expect(() => {
+        // -- @ts-expect-error
+        em.create(Author, { firstName: "a1", favoriteBook: 123 });
+      }).toThrow("ReactiveReferences cannot be set via opts");
+    });
+
+    it("cannot set over ReactiveReference in em.createPartial", async () => {
+      const em = newEntityManager();
+      expect(() => {
+        // @ts-expect-error
+        em.createPartial(Author, { favoriteBook: 123 });
+      }).toThrow("ReactiveReferences cannot be set via opts");
     });
 
     it("can setPartial with a null required field", async () => {

--- a/packages/tests/integration/src/FieldLogging.test.ts
+++ b/packages/tests/integration/src/FieldLogging.test.ts
@@ -45,15 +45,15 @@ describe("FieldLogging", () => {
     expect(fieldOutput).toMatchInlineSnapshot(`
      [
        "a#1 created at newAuthor.ts:13↩",
+       "a#1.isFunny = false at defaults.ts:45↩",
        "a#1.firstName = a1 at newAuthor.ts:13↩",
        "a#1.age = 40 at newAuthor.ts:13↩",
-       "a#1.isFunny = false at defaults.ts:45↩",
        "a#1.nickNames = a1 at defaults.ts:191↩",
        "b#1 created at newBook.ts:9↩",
+       "b#1.notes = Notes for undefined at defaults.ts:45↩",
        "b#1.title = title at newBook.ts:9↩",
        "b#1.order = 1 at newBook.ts:9↩",
        "b#1.author = Author#1 at newBook.ts:9↩",
-       "b#1.notes = Notes for title at defaults.ts:45↩",
        "b#1.authorsNickNames = a1 at defaults.ts:191↩",
      ]
     `);


### PR DESCRIPTION
Calling `em.create(Author, { favoriteBook: b1 })` would work because invoking `setOpts` from the constructor meant that `a.favoriteBook` was not initialized yet, so the `current instanceof ...` logic in `setOpts` was not kicking in.

Now, we have `em.create` not call `setOpts` until after the instance is fully initialized.

We don't go all the way to hard deprecating the `new Author(em, ...)` syntax, but we should plan on doing so.

Fixes #1442.