### PR TITLE
fix: Fix subtype specialization type errors

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -478,6 +478,10 @@ function generateOptsFields(meta: EntityDbMetadata): Code[] {
   });
   const m2o = meta.manyToOnes
     .filter(({ derived }) => !derived)
+    // If a `group: { subType: SmallPublisherGroup }` is specializing this relation, that's
+    // fine for most things, but not the `SmallPublisherOpts`, b/c it will break the contravariance
+    // of `Publisher.setOpts` and `SmallPublisher.setOpts`
+    .filter(({ fieldName }) => !meta.baseType?.manyToOnes.find((o) => o.fieldName === fieldName))
     .map((field) => {
       const { fieldName, otherEntity, notNull } = field;
       const maybeNull = maybeUnionNull(notNull);

--- a/packages/tests/integration/src/ClassTableInheritance.test.ts
+++ b/packages/tests/integration/src/ClassTableInheritance.test.ts
@@ -1,4 +1,4 @@
-import { getProperties } from "joist-orm";
+import { Changes, type FieldsOf, getProperties, type RelationsOf } from "joist-orm";
 import {
   AdminUser,
   Author,
@@ -14,7 +14,9 @@ import {
   newUser,
   Publisher,
   PublisherGroup,
+  PublisherOpts,
   SmallPublisher,
+  SmallPublisherOpts,
   Tag,
   User,
 } from "src/entities";
@@ -574,5 +576,36 @@ describe("ClassTableInheritance", () => {
     await insertPublisher({ name: "sp1" });
     const em = newEntityManager();
     await expect(em.loadAll(LargePublisher, ["p:1"])).rejects.toThrow("p:1 were not found");
+  });
+
+  describe("types", () => {
+    it("changes does not break covariance", () => {
+      // Given a base type with a changes type
+      type PublisherChanges = Changes<
+        Publisher,
+        | keyof (FieldsOf<Publisher> & RelationsOf<Publisher>)
+        | keyof (FieldsOf<LargePublisher> & RelationsOf<LargePublisher>)
+        | keyof (FieldsOf<SmallPublisher> & RelationsOf<SmallPublisher>)
+      >;
+      // And the subtype has its own as well
+      type SmallPublisherChanges = Changes<SmallPublisher>;
+      // When we return the changes covariantly
+      type ReturnChange = () => PublisherChanges;
+      const spChanges: SmallPublisherChanges = null!;
+      // Then the subtype substitutes w/o errors
+      const _: ReturnChange = () => spChanges;
+    });
+
+    it("set(opts) does not break contravariance", () => {
+      // Given a base type with a set(ops) method
+      type PublisherSetter = (opts: PublisherOpts) => void;
+      // And the subtype overrides it with its own set(opts)
+      type SmallPublisherSetter = (opts: SmallPublisherOpts) => void;
+      // When we want to accept the setter contravariantly
+      function setPublisher(_: PublisherSetter): void {}
+      const spSetter: SmallPublisherSetter = null!;
+      // Then the subtype substitutes w/o errors
+      setPublisher(spSetter);
+    });
   });
 });

--- a/packages/tests/integration/src/ClassTableInheritance.test.ts
+++ b/packages/tests/integration/src/ClassTableInheritance.test.ts
@@ -380,7 +380,7 @@ describe("ClassTableInheritance", () => {
   it("can initialize persisted fields on a subtype", async () => {
     const em = newEntityManager();
     // Given a small publisher
-    const sp = newSmallPublisher(em, { name: "sp1" });
+    newSmallPublisher(em, { name: "sp1" });
     await em.flush();
     // Then the field was initialized
     expect(await select("small_publishers")).toMatchObject([{ all_author_names: "" }]);
@@ -548,13 +548,12 @@ describe("ClassTableInheritance", () => {
     const em = newEntityManager();
     // And try to give a non-small group
     const pg = newPublisherGroup(em);
-    const sp = newSmallPublisher(
+    newSmallPublisher(
       em,
-      // Then we get a compile error
-      // @ts-expect-error
+      // Then we cannot get a type error due to Liskov subtyping restrictions
       { group: pg },
     );
-    // And em.flush fails
+    // But em.flush fails at runtime
     await expect(em.flush()).rejects.toThrow("group must be a SmallPublisherGroup not PublisherGroup#1");
   });
 

--- a/packages/tests/integration/src/ClassTableInheritance.test.ts
+++ b/packages/tests/integration/src/ClassTableInheritance.test.ts
@@ -596,7 +596,7 @@ describe("ClassTableInheritance", () => {
     });
 
     it("set(opts) does not break contravariance", () => {
-      // Given a base type with a set(ops) method
+      // Given a base type with a set(opts) method
       type PublisherSetter = (opts: PublisherOpts) => void;
       // And the subtype overrides it with its own set(opts)
       type SmallPublisherSetter = (opts: SmallPublisherOpts) => void;

--- a/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/LargePublisherCodegen.ts
@@ -86,7 +86,6 @@ export interface LargePublisherOpts extends PublisherOpts {
   sharedColumn?: string | null;
   country?: string | null;
   rating: number;
-  spotlightAuthor: Author | AuthorId;
   critics?: Critic[];
   users?: User[];
 }

--- a/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/SmallPublisherCodegen.ts
@@ -86,7 +86,6 @@ export interface SmallPublisherOpts extends PublisherOpts {
   city?: string;
   sharedColumn?: string | null;
   selfReferential?: SmallPublisher | SmallPublisherId | null;
-  group?: SmallPublisherGroup | SmallPublisherGroupId | null;
   smallPublishers?: SmallPublisher[];
   users?: User[];
 }

--- a/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskNewCodegen.ts
@@ -79,7 +79,6 @@ export interface TaskNewOpts extends TaskOpts {
   specialNewField?: number | null;
   selfReferential?: TaskNew | TaskNewId | null;
   specialNewAuthor?: Author | AuthorId | null;
-  copiedFrom?: TaskNew | TaskNewId | null;
   newTaskTaskItems?: TaskItem[];
   selfReferentialTasks?: TaskNew[];
   copiedTo?: TaskNew[];

--- a/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
+++ b/packages/tests/integration/src/entities/codegen/TaskOldCodegen.ts
@@ -83,7 +83,6 @@ export interface TaskOldFields extends TaskFields {
 export interface TaskOldOpts extends TaskOpts {
   specialOldField: number;
   parentOldTask?: TaskOld | TaskOldId | null;
-  copiedFrom?: TaskOld | TaskOldId | null;
   comments?: Comment[];
   oldTaskTaskItems?: TaskItem[];
   tasks?: TaskOld[];


### PR DESCRIPTION
Very odd, these errors were ghost-like in that they only showed up in Webstorm, but not `tsc`, even though they were valid compile errors (i.e. `SmallPublisher` not being a valid subtype of `Publisher` due to the `set(opts)` parameter not being contravariant).

I was able to fully reproduce (i.e. get `tsc` to fail on them) both errors by extracting/recreating a few simplified scenarios added to the `ClassTableInheritance.test.ts`.

The two fixes are:

1. Keeping `SmallPublisherOpts.group: PublisherGroup` instead of specializing it to `SmallPublisherGroup`

The reason is that code like:

```
updatePublisher(p: Publisher): void {
  p.set({ group: regularPublisherGroup });
}
```

Needs to accept `SmallPublisher`s, and not break its type contract, which making `sp.set({ group: ... })` typed as a `SmallPublisherGroup` breaks.

Of course, we'd like to keep the enforcement as much as possible, but to keep the subtype valid, we need to accept writes of `PublisherGroup` in the type system, and enforce the `SmallPublisherGroup`-ness via validation rules (which we already had in place).

2. Updating the `Changes` type to have smaller/tighter interfaces of `OneToManyFieldStatus` and `ManyToManyFieldStatus` instead of using the class definitions.

I can't fully explain this, but something about using the class impls with the private fields of `#o2m` and `#m2m` involved made the type checker complain about `Changes<SmallPublisher>` not being a subtpye of `Changes<Publisher>`.

It seems like if the `#o2m: OneToManyCollectionImpl` and `#m2m: ManyToManyCollectionImpl` had issues, that our entity relations themselves (i.e. `Publisher.authors`) would have issues as well, although the entity relations work because they also are strictly defined as the interfaces of `Reference<Publisher, Author>`?

Not sure, but overall happy + pleasantly surprised + slightly concerning that the shot-in-the-dark of "maybe try interfaces" here ended up working out.
