### PR TITLE
fix: allow HookFn return value

### DIFF
--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -28,7 +28,7 @@ export type EntityHook =
   | "afterValidation"
   | "beforeCommit"
   | "afterCommit";
-type HookFn<T extends Entity, C> = (entity: T, ctx: C) => MaybePromise<void>;
+type HookFn<T extends Entity, C> = (entity: T, ctx: C) => MaybePromise<unknown>;
 
 export const constraintNameToValidationError: Record<string, string> = {};
 

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -227,6 +227,7 @@ describe("Author", () => {
     const a1 = new Author(em, { firstName: "a1" });
     expect(a1.transientFields.beforeFlushRan).toBe(false);
     expect(a1.transientFields.beforeCreateRan).toBe(false);
+    expect(a1.transientFields.beforeCreateAsyncRan).toBe(false);
     expect(a1.transientFields.beforeUpdateRan).toBe(false);
     expect(a1.transientFields.afterCommitRan).toBe(false);
     expect(a1.transientFields.afterCommitIdIsSet).toBe(false);
@@ -237,6 +238,7 @@ describe("Author", () => {
     await em.flush();
     expect(a1.transientFields.beforeFlushRan).toBe(true);
     expect(a1.transientFields.beforeCreateRan).toBe(true);
+    expect(a1.transientFields.beforeCreateAsyncRan).toBe(true);
     expect(a1.transientFields.beforeUpdateRan).toBe(false);
     expect(a1.transientFields.beforeDeleteRan).toBe(false);
     expect(a1.transientFields.afterValidationRan).toBe(true);
@@ -246,8 +248,10 @@ describe("Author", () => {
     expect(a1.transientFields.afterCommitIsNewEntity).toBe(true);
     a1.firstName = "new name";
     a1.transientFields.beforeCreateRan = false;
+    a1.transientFields.beforeCreateAsyncRan = false;
     await em.flush();
     expect(a1.transientFields.beforeCreateRan).toBe(false);
+    expect(a1.transientFields.beforeCreateAsyncRan).toBe(false);
     expect(a1.transientFields.beforeUpdateRan).toBe(true);
     em.delete(a1);
     await em.flush();

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -414,7 +414,8 @@ config.beforeCreate((author) => {
 });
 
 config.beforeCreate((author) => {
-  return Promise.resolve(author.transientFields.beforeCreateAsyncRan = true);
+  author.transientFields.beforeCreateAsyncRan = true;
+  return Promise.resolve("testing not void");
 });
 
 config.beforeUpdate((author) => {

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -116,6 +116,7 @@ export class Author extends AuthorCodegen {
   public transientFields = {
     beforeFlushRan: false,
     beforeCreateRan: false,
+    beforeCreateAsyncRan: false,
     beforeUpdateRan: false,
     beforeDeleteRan: false,
     afterValidationRan: false,
@@ -409,7 +410,11 @@ config.beforeFlush(async (author, { em }) => {
 });
 
 config.beforeCreate((author) => {
-  author.transientFields.beforeCreateRan = true;
+  author.transientFields.beforeCreateRan = true
+});
+
+config.beforeCreate((author) => {
+  return Promise.resolve(author.transientFields.beforeCreateAsyncRan = true);
 });
 
 config.beforeUpdate((author) => {


### PR DESCRIPTION
Allow hooks like `beforeCreate`/`beforeUpdate`/etc to receive a returnable function, so it can save the `async/await` when doing something else rather than setting a default value.

Before:
```js
config.beforeCreate(async (author) => {
  await maybePublishAuthorBooks(author);
});
```

After:
```js
config.beforeCreate((author) => maybePublishAuthorBooks(author));
```

