### PR TITLE
feat: Log to ctx.logger.debug if available

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1795,8 +1795,9 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
       "logger" in this.ctx &&
       this.ctx.logger &&
       typeof this.ctx.logger === "object" &&
-      "debug" in this.ctx.logger
-        ? (this.ctx.logger.debug as Function).bind(this.ctx.logger)
+      "debug" in this.ctx.logger &&
+      this.ctx.logger.debug instanceof Function
+        ? this.ctx.logger.debug.bind(this.ctx.logger)
         : console.log;
     if (typeof arg === "boolean") {
       this.#fieldLogger = arg ? new FieldLogger([], writeFn) : undefined;

--- a/packages/orm/src/config.test.ts
+++ b/packages/orm/src/config.test.ts
@@ -24,6 +24,29 @@ describe("config", () => {
         `"    at async Object.savePersonalizationOptionGroup (/home/stephen/homebound/graphql-service/src/resolvers/mutations/designPackage/savePersonalizationOptionGroupResolver.ts:43:5)"`,
       );
     });
+
+    it("works on cascadeDeletes", () => {
+      const lines = [
+        "    at getStackFromCapture (/home/node/app/node_modules/joist-orm/src/config.ts:393:9)",
+        "    at getFuzzyCallerName (/home/node/app/node_modules/joist-orm/src/config.ts:338:15)",
+        "    at FieldLogger.logSet (/home/node/app/node_modules/joist-orm/src/logging/FieldLogger.ts:52:36)",
+        "    at setField (/home/node/app/node_modules/joist-orm/src/fields.ts:113:16)",
+        "    at ManyToOneReferenceImpl.setImpl (/home/node/app/node_modules/joist-orm/src/relations/ManyToOneReference.ts:231:13)",
+        "    at ManyToOneReferenceImpl.set (/home/node/app/node_modules/joist-orm/src/relations/ManyToOneReference.ts:112:10)",
+        "    at OneToManyCollection.remove (/home/node/app/node_modules/joist-orm/src/relations/OneToManyCollection.ts:234:34)",
+        "    at ManyToOneReferenceImpl.cleanupOnEntityDeleted (/home/node/app/node_modules/joist-orm/src/relations/ManyToOneReference.ts:266:13)",
+        "    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)",
+        "    at async Promise.all (index 6)",
+        "    at async EntityManager.cascadeDeletes (/home/node/app/node_modules/joist-orm/src/EntityManager.ts:1769:5)",
+        "    at async <anonymous> (/home/node/app/node_modules/joist-orm/src/EntityManager.ts:1341:11)",
+        "    at async runHooksOnPendingEntities (/home/node/app/node_modules/joist-orm/src/EntityManager.ts:1322:9)",
+        "    at async EntityManager.flush (/home/node/app/node_modules/joist-orm/src/EntityManager.ts:1388:29)",
+        "    at async Object.savePersonalizationOptionGroup (/home/stephen/homebound/graphql-service/src/resolvers/mutations/designPackage/savePersonalizationOptionGroupResolver.ts:46:5)",
+      ];
+      expect(findUserCodeLine(lines)).toMatchInlineSnapshot(
+        `"    at async Object.savePersonalizationOptionGroup (/home/stephen/homebound/graphql-service/src/resolvers/mutations/designPackage/savePersonalizationOptionGroupResolver.ts:46:5)"`,
+      );
+    });
   });
 
   describe("getFilePath", () => {

--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -363,7 +363,7 @@ export function findUserCodeLine(lines: string[]): string {
       const withinWorkingCopyJoist = line.includes("/packages/orm/");
       // But once we're not in a working copy, assume any `/joist-orm/` in the path === internal orm stack frames
       const withinProductionJoist = !withinWorkingCopyJoist && line.includes("/joist-orm/src/");
-      const nodeInternals = line.includes("node:internal/") || line.includes("Promise.allSettled");
+      const nodeInternals = line.includes("node:internal/") || line.includes("Promise.all");
       const isUserCode = !withinWorkingCopyJoist && !withinProductionJoist && !nodeInternals;
       // const isRecalc = line.includes(".recalcPending");
       const isDefault = line.includes("/defaults.ts");

--- a/packages/orm/src/logging/FieldLogger.ts
+++ b/packages/orm/src/logging/FieldLogger.ts
@@ -28,7 +28,7 @@ export class FieldLogger {
     writeFn?: WriteFn,
   ) {
     // We default to process.stdout.write to side-step around Jest's console.log instrumentation
-    this.#writeFn = writeFn ?? process.stdout.write.bind(process.stdout);
+    this.#writeFn = writeFn ?? ((line) => process.stdout.write(`${line}\n`));
     this.#watching = watching ?? [];
   }
 
@@ -55,7 +55,7 @@ export class FieldLogger {
   }
 
   private log(...line: string[]): void {
-    this.#writeFn(`${line.join(" ")}\n`);
+    this.#writeFn(`${line.join(" ")}`);
   }
 
   private shouldLog(entity: Entity, fieldName: string): boolean | "breakpoint" {

--- a/packages/orm/src/logging/FieldLogger.ts
+++ b/packages/orm/src/logging/FieldLogger.ts
@@ -3,7 +3,7 @@ import { Entity, isEntity } from "../Entity";
 import { getFuzzyCallerName } from "../config";
 
 const { gray, green, yellow, blue, red } = ansis;
-type WriteFn = (line: string) => void;
+export type WriteFn = (line: string) => void;
 
 export type FieldLoggerWatch = {
   /** The entity name, i.e. `Author` */

--- a/packages/tests/integration/src/FieldLogging.test.ts
+++ b/packages/tests/integration/src/FieldLogging.test.ts
@@ -13,9 +13,9 @@ describe("FieldLogging", () => {
     em.setFieldLogging(new StubFieldLogger());
     const a1 = await em.load(Author, "1");
     a1.firstName = "a2";
-    expect(fieldOutput[0]).toMatch(/a:1.firstName = a2 at FieldLogging.test.ts:(\d+)↩/);
+    expect(fieldOutput[0]).toMatch(/a:1.firstName = a2 at FieldLogging.test.ts:(\d+)/);
     a1.firstName = "a1";
-    expect(fieldOutput[1]).toMatch(/a:1.firstName = a1 at FieldLogging.test.ts:(\d+)↩/);
+    expect(fieldOutput[1]).toMatch(/a:1.firstName = a1 at FieldLogging.test.ts:(\d+)/);
   });
 
   it("sees primitive unsets", async () => {
@@ -24,7 +24,7 @@ describe("FieldLogging", () => {
     em.setFieldLogging(new StubFieldLogger());
     const a1 = await em.load(Author, "1");
     a1.lastName = undefined;
-    expect(fieldOutput[0]).toMatch(/a:1.lastName = undefined at FieldLogging.test.ts:(\d+)↩/);
+    expect(fieldOutput[0]).toMatch(/a:1.lastName = undefined at FieldLogging.test.ts:(\d+)/);
   });
 
   it("sees m2o sets", async () => {
@@ -35,7 +35,7 @@ describe("FieldLogging", () => {
     const p1 = await em.load(Publisher, "p:1");
     const a1 = await em.load(Author, "a:1");
     a1.publisher.set(p1);
-    expect(fieldOutput[0]).toMatch(/a:1.publisher = p:1 at FieldLogging.test.ts:(\d+)↩/);
+    expect(fieldOutput[0]).toMatch(/a:1.publisher = p:1 at FieldLogging.test.ts:(\d+)/);
   });
 
   it("sees o2o sets", async () => {
@@ -44,8 +44,8 @@ describe("FieldLogging", () => {
     const b2 = newBook(em);
     em.setFieldLogging(new StubFieldLogger());
     b2.sequel.set(b1);
-    expect(fieldOutput[0]).toMatch(/b#2.sequel = Book#1 at FieldLogging.test.ts:(\d+)↩/);
-    expect(fieldOutput[1]).toMatch(/b#1.prequel = Book#2 at FieldLogging.test.ts:(\d+)↩/);
+    expect(fieldOutput[0]).toMatch(/b#2.sequel = Book#1 at FieldLogging.test.ts:(\d+)/);
+    expect(fieldOutput[1]).toMatch(/b#1.prequel = Book#2 at FieldLogging.test.ts:(\d+)/);
   });
 
   it("sees poly sets", async () => {
@@ -54,7 +54,7 @@ describe("FieldLogging", () => {
     const a1 = newAuthor(em);
     em.setFieldLogging(new StubFieldLogger());
     c1.parent.set(a1);
-    expect(fieldOutput[0]).toMatch(/comment#1.parent = Author#2 at FieldLogging.test.ts:(\d+)↩/);
+    expect(fieldOutput[0]).toMatch(/comment#1.parent = Author#2 at FieldLogging.test.ts:(\d+)/);
   });
 
   it("sees all fields by default", async () => {
@@ -63,17 +63,17 @@ describe("FieldLogging", () => {
     newBook(em);
     expect(fieldOutput).toMatchInlineSnapshot(`
      [
-       "a#1 created at newAuthor.ts:13↩",
-       "a#1.firstName = a1 at newAuthor.ts:13↩",
-       "a#1.age = 40 at newAuthor.ts:13↩",
-       "a#1.isFunny = false at defaults.ts:45↩",
-       "a#1.nickNames = a1 at defaults.ts:191↩",
-       "b#1 created at newBook.ts:9↩",
-       "b#1.title = title at newBook.ts:9↩",
-       "b#1.order = 1 at newBook.ts:9↩",
-       "b#1.author = Author#1 at newBook.ts:9↩",
-       "b#1.notes = Notes for title at defaults.ts:45↩",
-       "b#1.authorsNickNames = a1 at defaults.ts:191↩",
+       "a#1 created at newAuthor.ts:13",
+       "a#1.firstName = a1 at newAuthor.ts:13",
+       "a#1.age = 40 at newAuthor.ts:13",
+       "a#1.isFunny = false at defaults.ts:45",
+       "a#1.nickNames = a1 at defaults.ts:191",
+       "b#1 created at newBook.ts:9",
+       "b#1.title = title at newBook.ts:9",
+       "b#1.order = 1 at newBook.ts:9",
+       "b#1.author = Author#1 at newBook.ts:9",
+       "b#1.notes = Notes for title at defaults.ts:45",
+       "b#1.authorsNickNames = a1 at defaults.ts:191",
      ]
     `);
   });
@@ -82,7 +82,7 @@ describe("FieldLogging", () => {
     const em = newEntityManager();
     em.setFieldLogging(new StubFieldLogger());
     const a1 = newAuthor(em);
-    expect(fieldOutput[0]).toMatch(/a#1 created at newAuthor.ts:(\d+)↩/);
+    expect(fieldOutput[0]).toMatch(/a#1 created at newAuthor.ts:(\d+)/);
   });
 
   it("can filter fields by entity", async () => {
@@ -91,11 +91,11 @@ describe("FieldLogging", () => {
     newBook(em);
     expect(fieldOutput).toMatchInlineSnapshot(`
      [
-       "a#1 created at newAuthor.ts:13↩",
-       "a#1.firstName = a1 at newAuthor.ts:13↩",
-       "a#1.age = 40 at newAuthor.ts:13↩",
-       "a#1.isFunny = false at defaults.ts:45↩",
-       "a#1.nickNames = a1 at defaults.ts:191↩",
+       "a#1 created at newAuthor.ts:13",
+       "a#1.firstName = a1 at newAuthor.ts:13",
+       "a#1.age = 40 at newAuthor.ts:13",
+       "a#1.isFunny = false at defaults.ts:45",
+       "a#1.nickNames = a1 at defaults.ts:191",
      ]
     `);
   });
@@ -106,7 +106,7 @@ describe("FieldLogging", () => {
     newBook(em);
     expect(fieldOutput).toMatchInlineSnapshot(`
      [
-       "a#1.age = 40 at newAuthor.ts:13↩",
+       "a#1.age = 40 at newAuthor.ts:13",
      ]
     `);
   });
@@ -117,7 +117,7 @@ describe("FieldLogging", () => {
     newBook(em);
     expect(fieldOutput).toMatchInlineSnapshot(`
      [
-       "a#1 created at newAuthor.ts:13↩",
+       "a#1 created at newAuthor.ts:13",
      ]
     `);
   });
@@ -129,13 +129,13 @@ describe("FieldLogging", () => {
     newSmallPublisher(em, { name: "pp1" });
     expect(fieldOutput).toMatchInlineSnapshot(`
      [
-       "p#1 created at newLargePublisher.ts:6↩",
-       "p#1.rating = 0 at newLargePublisher.ts:6↩",
-       "p#1.name = lp1 at newLargePublisher.ts:6↩",
-       "p#1.numberOfBookReviews = 0 at defaults.ts:36↩",
-       "p#1.type = BIG at defaults.ts:45↩",
-       "p#1.baseSyncDefault = LPSyncDefault at defaults.ts:45↩",
-       "p#1.baseAsyncDefault = LPAsyncDefault at defaults.ts:191↩",
+       "p#1 created at newLargePublisher.ts:6",
+       "p#1.rating = 0 at newLargePublisher.ts:6",
+       "p#1.name = lp1 at newLargePublisher.ts:6",
+       "p#1.numberOfBookReviews = 0 at defaults.ts:36",
+       "p#1.type = BIG at defaults.ts:45",
+       "p#1.baseSyncDefault = LPSyncDefault at defaults.ts:45",
+       "p#1.baseAsyncDefault = LPAsyncDefault at defaults.ts:191",
      ]
     `);
   });
@@ -147,7 +147,7 @@ describe("FieldLogging", () => {
     newSmallPublisher(em, { name: "pp1" });
     expect(fieldOutput).toMatchInlineSnapshot(`
      [
-       "p#1.name = lp1 at newLargePublisher.ts:6↩",
+       "p#1.name = lp1 at newLargePublisher.ts:6",
      ]
     `);
   });
@@ -198,7 +198,7 @@ class StubFieldLogger extends FieldLogger {
     // uncomment to see colorized output
     // super();
     super(watching, (line: string) => {
-      fieldOutput.push(line.replace(ansiRegex(), "").replace("\n", "↩"));
+      fieldOutput.push(line.replace(ansiRegex(), ""));
     });
   }
 }


### PR DESCRIPTION
Not that it'd be enabled in production, but if locally you run:

```
    em.setFieldLogging("TakeoffLineItemVersion");
```

In some backend code, it will route through the `ctx.logger.debug`, instead of the default `process.stdout`, which will get batched/aligned better with the rest of the log output.

