### PR TITLE
feat: Allow setting preloadPlugin at the driver level.

### DIFF
--- a/packages/drivers/bun-pg/src/BunPgDriver.ts
+++ b/packages/drivers/bun-pg/src/BunPgDriver.ts
@@ -98,6 +98,10 @@ export class BunPgDriver implements Driver<TransactionSQL> {
   flushJoinTables(em: EntityManager, joinRows: Record<string, JoinRowTodo>): Promise<void> {
     throw new Error("Method not implemented.");
   }
+
+  get defaultPlugins() {
+    return {};
+  }
 }
 
 // Issue 1 INSERT statement with N `VALUES (..., ...), (..., ...), ...`

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -234,6 +234,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   constructor(ctx: C, driver: Driver<TX>);
   constructor(emOrCtx: EntityManager<C, Entity, TX> | C, driverOrOpts?: EntityManagerOpts<TX> | Driver<TX>) {
     if (emOrCtx instanceof EntityManager) {
+      // Setup from the existing EntityManager
       const em = emOrCtx;
       this.driver = em.driver;
       this.#preloader = em.#preloader;
@@ -246,13 +247,15 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
         this.ctx = Object.assign(this.ctx, { em: this });
       }
     } else if (driverOrOpts && "executeFind" in driverOrOpts) {
+      // Passed a driver directly
       this.ctx = emOrCtx;
       this.driver = driverOrOpts;
-      this.#preloader = undefined;
+      this.#preloader = this.driver.defaultPlugins.preloadPlugin;
     } else {
+      // Passed an opts hash
       this.ctx = emOrCtx;
       this.driver = driverOrOpts!.driver;
-      this.#preloader = driverOrOpts!.preloadPlugin;
+      this.#preloader = driverOrOpts!.preloadPlugin ?? this.driver.defaultPlugins.preloadPlugin;
     }
 
     // Expose some of our private fields as the EntityManagerInternalApi

--- a/packages/orm/src/drivers/Driver.ts
+++ b/packages/orm/src/drivers/Driver.ts
@@ -1,6 +1,7 @@
 import { EntityManager } from "../EntityManager";
 import { ParsedFindQuery } from "../QueryParser";
 import { JoinRowTodo, Todo } from "../Todo";
+import { PreloadPlugin } from "../plugins/PreloadPlugin";
 
 /**
  * Isolates all SQL calls that Joist needs to make to fetch/save data.
@@ -25,4 +26,7 @@ export interface Driver<TX = unknown> {
   flushEntities(em: EntityManager, todos: Record<string, Todo>): Promise<void>;
 
   flushJoinTables(em: EntityManager, joinRows: Record<string, JoinRowTodo>): Promise<void>;
+
+  /** Allows the driver to opt `EntityManager`s into plugins it has enabled/supported by default. */
+  defaultPlugins: { preloadPlugin?: PreloadPlugin };
 }

--- a/packages/tests/integration/src/testDrivers.ts
+++ b/packages/tests/integration/src/testDrivers.ts
@@ -1,5 +1,6 @@
 import { recordQuery } from "@src/testEm";
 import { Driver, PostgresDriver } from "joist-orm";
+import { JsonAggregatePreloader } from "joist-plugin-join-preloading";
 import { newPgConnectionConfig } from "joist-utils";
 import { Knex, knex as createKnex } from "knex";
 
@@ -30,7 +31,7 @@ export class PostgresTestDriver implements TestDriver {
   public knex: Knex;
   public isInMemory = false;
 
-  constructor() {
+  constructor(isPreloadingEnabled: boolean) {
     this.knex = createKnex({
       client: "pg",
       connection: newPgConnectionConfig() as any,
@@ -39,7 +40,8 @@ export class PostgresTestDriver implements TestDriver {
     }).on("query", (e: any) => {
       recordQuery(e.sql);
     });
-    this.driver = new PostgresDriver(this.knex);
+    const preloadPlugin = isPreloadingEnabled ? new JsonAggregatePreloader() : undefined;
+    this.driver = new PostgresDriver(this.knex, { preloadPlugin });
   }
 
   async beforeEach() {

--- a/packages/tests/integration/src/testEm.ts
+++ b/packages/tests/integration/src/testEm.ts
@@ -1,25 +1,21 @@
 import { EntityManager } from "@src/entities";
 import { PostgresTestDriver, TestDriver } from "@src/testDrivers";
 import { EntityManagerOpts } from "joist-orm";
-import { JsonAggregatePreloader } from "joist-plugin-join-preloading";
 import { Knex } from "knex";
 
 // Create a shared test context that tests can use, and also we'll use to auto-flush the db between tests.
-export let testDriver: TestDriver = new PostgresTestDriver();
+const plugins = (process.env.PLUGINS ?? "join-preloading").split(",");
+export const isPreloadingEnabled = plugins.includes("join-preloading");
+export let testDriver: TestDriver = new PostgresTestDriver(isPreloadingEnabled);
 export let knex: Knex = testDriver.knex;
 export let numberOfQueries = 0;
 export let queries: string[] = [];
-const plugins = (process.env.PLUGINS ?? "join-preloading").split(",");
-export const isPreloadingEnabled = plugins.includes("join-preloading");
 
 let makeApiCall: Function = null!;
 
 export function newEntityManager(): EntityManager {
   const ctx = { knex };
-  const opts: EntityManagerOpts<any> = {
-    driver: testDriver.driver,
-    preloadPlugin: isPreloadingEnabled ? new JsonAggregatePreloader() : undefined,
-  };
+  const opts: EntityManagerOpts<any> = { driver: testDriver.driver };
   const em = new EntityManager(ctx as any, opts);
   Object.assign(ctx, { em, makeApiCall });
   return em;


### PR DESCRIPTION
Given EntityManagers are request-level, they can end up be instantiated all over the place.

But the Driver is typically process-level, so instantiated just once during context boot.

Given this, the driver is a more natural "global behavior on/off" choke point -- and the preload setting is very driver-based anyway, i.e. currently uses JSON aggregate/pg-specific details.