### PR TITLE
fix: Allow passing null to EntityAlias.in.

### DIFF
--- a/packages/orm/src/Aliases.ts
+++ b/packages/orm/src/Aliases.ts
@@ -62,8 +62,8 @@ export interface PrimitiveAlias<V, N extends null | never> {
 export interface EntityAlias<T> {
   eq(value: T | IdOf<T> | null | undefined): ExpressionCondition;
   ne(value: T | IdOf<T> | null | undefined): ExpressionCondition;
-  in(value: Array<T | IdOf<T>> | undefined): ExpressionCondition;
   // Adding `| null` for GraphQL support
+  in(value: Array<T | IdOf<T>> | null | undefined): ExpressionCondition;
   gt(value: IdOf<T> | null | undefined): ExpressionCondition;
   gte(value: IdOf<T> | null | undefined): ExpressionCondition;
   lt(value: IdOf<T> | null | undefined): ExpressionCondition;

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -521,6 +521,27 @@ describe("EntityManager.queries", () => {
     });
   });
 
+  it("can find by foreign key id in empty list", async () => {
+    await insertPublisher({ id: 1, name: "p1" });
+    await insertAuthor({ id: 2, first_name: "a1" });
+    await insertAuthor({ id: 3, first_name: "a2", publisher_id: 1 });
+
+    const em = newEntityManager();
+    const where = { publisher: { id: { in: [] } } } satisfies AuthorFilter;
+    const authors = await em.findGql(Author, where);
+    expect(authors.length).toEqual(0);
+
+    expect(parseFindQuery(am, where, opts)).toMatchObject({
+      selects: [`a.*`],
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
+      orderBys: [expect.anything()],
+      condition: {
+        op: "and",
+        conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "in", value: [] } }],
+      },
+    });
+  });
+
   it("can find by foreign key id nin list", async () => {
     await insertPublisher({ id: 1, name: "p1" });
     await insertPublisher({ id: 2, name: "p2" });
@@ -3135,6 +3156,18 @@ describe("EntityManager.queries", () => {
       const a1 = await em.load(Author, "a:1");
       const b = alias(Book);
       expect(b.author.in([a1, "a:2"])).toEqual({
+        kind: "column",
+        alias: "unset",
+        column: "author_id",
+        dbType: "int",
+        cond: { kind: "in", value: [1, 2] },
+      });
+    });
+
+    it("can in a foreign key with gql string[] | null", async () => {
+      const b = alias(Book);
+      const maybeIds: string[] | null | undefined = null as any;
+      expect(b.author.in(maybeIds)).toEqual({
         kind: "column",
         alias: "unset",
         column: "author_id",


### PR DESCRIPTION
I.e. destructured string[]s of ids in GraphQL filters.