### PR TITLE
feat: Use cross join for em.find batching.

### DIFF
--- a/packages/orm/src/ConditionBuilder.ts
+++ b/packages/orm/src/ConditionBuilder.ts
@@ -1,0 +1,185 @@
+import { ExpressionFilter } from "./EntityFilter";
+import { isDefined } from "./EntityManager";
+import {
+  ColumnCondition,
+  mapToDb,
+  ParsedExpressionCondition,
+  ParsedExpressionFilter,
+  ParsedValueFilter,
+  RawCondition,
+  skipCondition,
+} from "./QueryParser";
+import { Column } from "./serde";
+import { assertNever, partition } from "./utils";
+
+type PartialSome<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+/** Converts domain-level values like string ids/enums into their db equivalent. */
+export class ConditionBuilder {
+  /** Simple, single-column conditions, which will be AND-d together. */
+  private conditions: (ColumnCondition | RawCondition)[] = [];
+  /** Complex expressions, which will also be AND-d together with `conditions`. */
+  private expressions: ParsedExpressionFilter[] = [];
+
+  /** Accepts a raw user-facing DSL filter, and parses it into a `ParsedExpressionFilter`. */
+  maybeAddExpression(expression: ExpressionFilter): void {
+    const parsed = parseExpression(expression);
+    if (parsed) this.expressions.push(parsed);
+  }
+
+  /** Adds an already-db-level condition to the simple conditions list. */
+  addSimpleCondition(condition: ColumnCondition): void {
+    this.conditions.push(condition);
+  }
+
+  /** Adds an already-db-level condition to the simple conditions list. */
+  addRawCondition(condition: PartialSome<RawCondition, "kind" | "bindings">): void {
+    this.conditions.push({
+      kind: "raw",
+      bindings: [],
+      ...condition,
+    });
+  }
+
+  /** Adds an already-db-level expression to the expressions list. */
+  addParsedExpression(parsed: ParsedExpressionFilter): void {
+    this.expressions.push(parsed);
+  }
+
+  /**
+   * Adds a user-facing `ParsedValueFilter` to the inline conditions.
+   *
+   * Unless it's something like `in: [a1, null]`, in which case we split it into two `is-null` and `in` conditions.
+   */
+  addValueFilter(alias: string, column: Column, filter: ParsedValueFilter<any>): void {
+    if (filter.kind === "in" && filter.value.includes(null)) {
+      // If the filter contains a null, we need to split it into an `is-null` and `in` condition
+      const isNull = {
+        kind: "column",
+        alias,
+        column: column.columnName,
+        dbType: column.dbType,
+        cond: { kind: "is-null" },
+      } satisfies ColumnCondition;
+      const inValues = {
+        kind: "column",
+        alias,
+        column: column.columnName,
+        dbType: column.dbType,
+        cond: {
+          kind: "in",
+          // Filter out the nulls from the in condition
+          value: filter.value.filter((v) => v !== null).map((v) => column.mapToDb(v)),
+        },
+      } satisfies ColumnCondition;
+      // Now OR them back together
+      this.expressions.push({ kind: "exp", op: "or", conditions: [isNull, inValues] });
+    } else {
+      const cond = {
+        kind: "column",
+        alias,
+        column: column.columnName,
+        dbType: column.dbType,
+        // Rewrite the user-facing domain values to db values
+        cond: mapToDb(column, filter),
+      } satisfies ColumnCondition;
+      this.conditions.push(cond);
+    }
+  }
+
+  /** Combines our collected `conditions` & `expressions` into a single `ParsedExpressionFilter`. */
+  toExpressionFilter(): ParsedExpressionFilter | undefined {
+    const { expressions, conditions } = this;
+    if (conditions.length === 0 && expressions.length === 1) {
+      // If no inline conditions, and just 1 opt expression, just use that
+      return expressions[0];
+    } else if (expressions.length === 1 && expressions[0].op === "and") {
+      // Merge the 1 `AND` expression with the other simple conditions
+      return { kind: "exp", op: "and", conditions: [...conditions, ...expressions[0].conditions] };
+    } else if (conditions.length > 0 || expressions.length > 0) {
+      // Combine the conditions within the `em.find` join literal & the `conditions` as ANDs
+      return { kind: "exp", op: "and", conditions: [...conditions, ...expressions] };
+    }
+    return undefined;
+  }
+
+  /**
+   * Finds `child.column.eq(...)` complex conditions that need pushed down into each lateral join.
+   *
+   * Once we find something like `{ column: "first_name", cond: { eq: "a1" } }`, we return it to the
+   * caller (for injection into the lateral join's `SELECT` clause), and replace it with a boolean
+   * expression that is basically "did any of my children match this condition?".
+   *
+   * We also assume that `findAndRewrite` is only called on the top-level/user-facing `ParsedFindQuery`,
+   * and not any intermediate `CteJoinTable` queries (which are allowed to have their own
+   * `ConditionBuilder`s for building their internal query, but it's not exposed to the user,
+   * so won't have any truly-complex conditions that should need rewritten).
+   *
+   * @param topLevelLateralJoin the outermost lateral join alias, as that will be the only alias
+   *   that is visible to the rewritten condition, i.e. `_alias._whatever_condition_`.
+   * @param alias the alias being "hidden" in a lateral join, and so its columns/data won't be
+   *   available for the top-level condition to directly AND/OR against.
+   */
+  findAndRewrite(topLevelLateralJoin: string, alias: string): { cond: ColumnCondition; as: string }[] {
+    let j = 0;
+    const found: { cond: ColumnCondition; as: string }[] = [];
+    const todo: ParsedExpressionCondition[][] = [this.conditions];
+    for (const exp of this.expressions) todo.push(exp.conditions);
+    while (todo.length > 0) {
+      const array = todo.pop()!;
+      array.forEach((cond, i) => {
+        if (cond.kind === "column") {
+          // Use startsWith to look for `_b0` / `_s0` base/subtype conditions
+          if (cond.alias === alias || cond.alias.startsWith(`${alias}_`)) {
+            if (cond.column === "_") return; // Hack to skip rewriting `alias._ > 0`
+            const as = `_${alias}_${cond.column}_${j++}`;
+            array[i] = {
+              kind: "raw",
+              aliases: [topLevelLateralJoin],
+              condition: `${topLevelLateralJoin}.${as}`,
+              bindings: [],
+              pruneable: false,
+              ...{ rewritten: true },
+            } satisfies RawCondition;
+            found.push({ cond, as });
+          }
+        } else if (cond.kind === "exp") {
+          todo.push(cond.conditions);
+        } else if (cond.kind === "raw") {
+          // what would we do here?
+          if (cond.aliases.includes(alias)) {
+            // Look for a hacky hint that this is our own already-rewritten query; this is likely
+            // because `findAndRewrite` is mutating condition expressions that get passed into
+            // `parseFindQuery` multiple times, i.e. while batching/dataloading.
+            //
+            // ...although in theory parseExpression should already be making a copy of any user-facing
+            // `em.find` conditions. :thinking:
+            if ("rewritten" in cond) return;
+            throw new Error("Joist doesn't support raw conditions in lateral joins yet");
+          }
+        } else {
+          assertNever(cond);
+        }
+      });
+    }
+    return found;
+  }
+}
+
+/** Parses user-facing `{ and: ... }` or `{ or: ... }` into a `ParsedExpressionFilter`. */
+function parseExpression(expression: ExpressionFilter): ParsedExpressionFilter | undefined {
+  // Look for `{ and: [...] }` or `{ or: [...] }`
+  const [op, expressions] =
+    "and" in expression && expression.and
+      ? ["and" as const, expression.and]
+      : "or" in expression && expression.or
+        ? ["or" as const, expression.or]
+        : fail(`Invalid expression ${expression}`);
+  // Potentially recurse into nested expressions
+  const conditions = expressions.map((exp) => (exp && ("and" in exp || "or" in exp) ? parseExpression(exp) : exp));
+  const [skip, valid] = partition(conditions, (cond) => cond === undefined || cond === skipCondition);
+  if ((skip.length > 0 && expression.pruneIfUndefined === "any") || valid.length === 0) {
+    return undefined;
+  }
+  return { kind: "exp", op, conditions: valid.filter(isDefined) };
+}

--- a/packages/orm/src/QueryParser.pruning.ts
+++ b/packages/orm/src/QueryParser.pruning.ts
@@ -1,0 +1,114 @@
+import { ColumnCondition, ParsedExpressionFilter, ParsedFindQuery, RawCondition, parseAlias } from "./QueryParser";
+import { assertNever } from "./utils";
+
+// Remove any joins that are not used in the select or conditions
+export function pruneUnusedJoins(parsed: ParsedFindQuery, keepAliases: string[]): void {
+  const dt = new DependencyTracker();
+
+  // First setup the alias -> alias dependencies...
+  const todo = [...parsed.tables];
+  while (todo.length > 0) {
+    const t = todo.pop()!;
+    if (t.join === "lateral") {
+      dt.addAlias(t.alias, [t.fromAlias]);
+      // Recurse into lateral joins...
+      todo.push(...t.query.tables);
+    } else if (t.join === "cross") {
+      // Doesn't have any conditions
+    } else if (t.join !== "primary") {
+      dt.addAlias(t.alias, [parseAlias(t.col1)]);
+    }
+  }
+
+  // Mark all terminal usages
+  parsed.selects.forEach((s) => {
+    if (typeof s === "string") {
+      if (!s.includes("count(")) dt.markRequired(parseAlias(s));
+    } else {
+      for (const a of s.aliases) dt.markRequired(a);
+    }
+  });
+  parsed.orderBys.forEach((o) => dt.markRequired(o.alias));
+  keepAliases.forEach((a) => dt.markRequired(a));
+  // Look recursively into CTE & lateral join conditions
+  const todo2 = [parsed];
+  while (todo2.length > 0) {
+    const query = todo2.pop()!;
+    deepFindConditions(query.condition, true).forEach((c) => {
+      if (c.kind === "column") {
+        dt.markRequired(c.alias);
+      } else if (c.kind === "raw") {
+        for (const alias of c.aliases) dt.markRequired(alias);
+      } else {
+        assertNever(c);
+      }
+    });
+    todo2.push(...query.tables.filter((t) => t.join === "lateral").map((t) => t.query));
+  }
+
+  // Now remove any unused joins
+  parsed.tables = parsed.tables.filter((t) => dt.required.has(t.alias));
+
+  // And then remove any inline soft-delete conditions we don't need anymore
+  if (parsed.condition && parsed.condition.op === "and") {
+    parsed.condition.conditions = parsed.condition.conditions.filter((c) => {
+      if (c.kind === "column") {
+        const prune = c.pruneable && !dt.required.has(c.alias);
+        // if (prune) console.log(`DROPPING`, c);
+        return !prune;
+      } else {
+        return c;
+      }
+    });
+  }
+
+  // Remove any `{ and: [...] }`s that are empty; we should probably do this deeply?
+  if (parsed.condition && parsed.condition.conditions.length === 0) {
+    parsed.condition = undefined;
+  }
+}
+
+/** Pulls out a flat list of all `ColumnCondition`s from a `ParsedExpressionFilter` tree. */
+export function deepFindConditions(
+  condition: ParsedExpressionFilter | undefined,
+  filterPruneable: boolean,
+): (ColumnCondition | RawCondition)[] {
+  const todo = condition ? [condition] : [];
+  const result: (ColumnCondition | RawCondition)[] = [];
+  while (todo.length !== 0) {
+    const cc = todo.pop()!;
+    for (const c of cc.conditions) {
+      if (c.kind === "exp") {
+        todo.push(c);
+      } else if (c.kind === "column" || c.kind === "raw") {
+        if (!filterPruneable || !c.pruneable) result.push(c);
+      } else {
+        assertNever(c);
+      }
+    }
+  }
+  return result;
+}
+
+/** Track join dependencies for `pruneUnusedJoins`. */
+class DependencyTracker {
+  private nodes: Map<string, string[]> = new Map();
+  required: Set<string> = new Set();
+
+  addAlias(alias: string, dependencies: string[] = []): void {
+    this.nodes.set(alias, dependencies);
+  }
+
+  markRequired(alias: string): void {
+    const marked = new Set<string>();
+    const todo = [alias];
+    while (todo.length > 0) {
+      const alias = todo.pop()!;
+      if (!marked.has(alias)) {
+        marked.add(alias);
+        todo.push(...(this.nodes.get(alias) || []));
+      }
+    }
+    this.required = new Set([...this.required, ...marked]);
+  }
+}

--- a/packages/orm/src/QueryVisitor.ts
+++ b/packages/orm/src/QueryVisitor.ts
@@ -25,11 +25,11 @@ export function visitConditions(query: ParsedFindQuery, visitor: Visitor): void 
   while (todo.length > 0) {
     const query = todo.pop()!;
     if (query.condition) visitFilter(query.condition, visitor);
-    // for (const table of query.tables) {
-    //   if (table.join === "lateral" || table.join === "cte") {
-    //     todo.push(table.query);
-    //   }
-    // }
+    for (const table of query.tables) {
+      if (table.join === "lateral") {
+        todo.push(table.query);
+      }
+    }
   }
 }
 

--- a/packages/orm/src/QueryVisitor.ts
+++ b/packages/orm/src/QueryVisitor.ts
@@ -1,10 +1,17 @@
-import { ColumnCondition, ParsedExpressionFilter, ParsedFindQuery, RawCondition } from "./QueryParser";
+import {
+  ColumnCondition,
+  ParsedExpressionCondition,
+  ParsedExpressionFilter,
+  ParsedFindQuery,
+  RawCondition,
+} from "./QueryParser";
+import { assertNever } from "./utils";
 
 /** A generic visitor over the simple & complex conditions of a query. */
 interface Visitor {
   visitExp?(c: ParsedExpressionFilter): ParsedExpressionFilter | void;
   visitRaw?(c: RawCondition): RawCondition | ParsedExpressionFilter | void;
-  visitCond(c: ColumnCondition): ColumnCondition | ParsedExpressionFilter | void;
+  visitCond(c: ColumnCondition): ColumnCondition | ParsedExpressionFilter | RawCondition | void;
 }
 
 /**
@@ -14,26 +21,50 @@ interface Visitor {
  * will replace the original one at that location in the expression.
  */
 export function visitConditions(query: ParsedFindQuery, visitor: Visitor): void {
-  function visit(ef: ParsedExpressionFilter) {
-    ef.conditions.forEach((c, i) => {
+  const todo = [query];
+  while (todo.length > 0) {
+    const query = todo.pop()!;
+    if (query.condition) visitFilter(query.condition, visitor);
+    // for (const table of query.tables) {
+    //   if (table.join === "lateral" || table.join === "cte") {
+    //     todo.push(table.query);
+    //   }
+    // }
+  }
+}
+
+export function visitFilter(pc: ParsedExpressionCondition, visitor: Visitor) {
+  if (pc.kind === "exp") {
+    pc.conditions.forEach((c, i) => {
       if (c.kind === "column") {
         const result = visitor.visitCond(c);
         if (result) {
-          ef.conditions[i] = result;
+          pc.conditions[i] = result;
         }
       } else if (c.kind === "exp") {
         const result = visitor.visitExp?.(c);
-        if (result) ef.conditions[i] = result;
-        visit(result ?? c);
+        if (result) pc.conditions[i] = result;
+        visitFilter(result ?? c, visitor);
       } else if (c.kind === "raw") {
         const result = visitor.visitRaw?.(c);
         if (result) {
-          ef.conditions[i] = result;
+          pc.conditions[i] = result;
         }
       } else {
-        throw new Error(`Unsupported kind ${c}`);
+        assertNever(c);
       }
     });
+  } else if (pc.kind === "column") {
+    const result = visitor.visitCond(pc);
+    if (result) {
+      throw new Error("ParsedExpressionCondition overload not support mutating the condition");
+    }
+  } else if (pc.kind === "raw") {
+    const result = visitor.visitRaw?.(pc);
+    if (result) {
+      throw new Error("ParsedExpressionCondition overload not support mutating the condition");
+    }
+  } else {
+    assertNever(pc);
   }
-  if (query.condition) visit(query.condition);
 }

--- a/packages/orm/src/dataloaders/findCountDataLoader.ts
+++ b/packages/orm/src/dataloaders/findCountDataLoader.ts
@@ -3,13 +3,11 @@ import { Entity } from "../Entity";
 import { FilterAndSettings } from "../EntityFilter";
 import { EntityManager, MaybeAbstractEntityConstructor } from "../EntityManager";
 import { getMetadata } from "../EntityMetadata";
-import { getTables, joinKeywords, parseFindQuery } from "../QueryParser";
-import { kq } from "../keywords";
-import { cleanSql, fail } from "../utils";
+import { ParsedFindQuery, parseFindQuery } from "../QueryParser";
+import { fail } from "../utils";
 import {
-  buildConditions,
   buildValuesCte,
-  collectArgs,
+  collectAndReplaceArgs,
   createBindings,
   getBatchKeyFromGenericStructure,
   whereFilterHash,
@@ -22,7 +20,7 @@ export function findCountDataLoader<T extends Entity>(
 ): DataLoader<FilterAndSettings<T>, number> {
   const { where, ...opts } = filter;
   if (opts.limit || opts.offset) {
-    throw new Error("Cannot use limit/offset with findDataLoader");
+    throw new Error("Cannot use limit/offset with findCountDataLoader");
   }
 
   const meta = getMetadata(type);
@@ -40,45 +38,50 @@ export function findCountDataLoader<T extends Entity>(
         const { where, ...options } = queries[0];
         const query = parseFindQuery(getMetadata(type), where, options);
         const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
-        query.selects = [`count(distinct "${primary.alias}".id) as count`];
+        query.selects = [`count("${primary.alias}".id) as count`];
         query.orderBys = [];
         const rows = await em.driver.executeFind(em, query, {});
         return [Number(rows[0].count)];
       }
 
-      // WITH data(tag, arg1, arg2) AS (VALUES
+      // WITH _find (tag, arg1, arg2) AS (VALUES
       //   (0::int, 'a'::varchar, 'a'::varchar),
       //   (1, 'b', 'b'),
       //   (2, 'c', 'c')
       // )
-      // SELECT d.tag, count(*)
-      // FROM authors a
-      // JOIN data d ON (d.arg1 = a.first_name OR d.arg2 = a.last_name)
-      // group by d.tag;
+      // SELECT _find.tag, _data.count
+      // FROM _find
+      // CROSS JOIN LATERAL (
+      //   SELECT count(*) as count
+      //   FROM author a WHERE a.first_name = _find.arg1 OR a.last_name = _find.arg2
+      // ) _data
 
       // Build the list of 'arg1', 'arg2', ... strings
-      const args = collectArgs(query);
+      const { where, ...options } = queries[0];
+      const query = parseFindQuery(getMetadata(type), where, options);
+      const args = collectAndReplaceArgs(query);
       args.unshift({ columnName: "tag", dbType: "int" });
 
-      const [primary, joins] = getTables(query);
-      // Use count(distinct id) in case two o2m joins end up duplicating rows
-      const selects = ["_find.tag as tag", `count(distinct ${kq(primary.alias)}.id) as count`];
+      // We're not returning the entities, just counting them...
+      query.selects = ["count(*) as count"];
+      query.orderBys = [];
 
-      // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
-      const bindings = createBindings(meta, queries);
-      // Create the JOIN clause, i.e. ON a.firstName = _find.arg0
-      const [conditions] = buildConditions(query.condition!);
+      const query2: ParsedFindQuery = {
+        selects: ["_find.tag as tag", "_data.count as count"],
+        tables: [
+          { join: "primary", table: "_find", alias: "_find" },
+          // Not sure what fromAlias is for/that it matters...
+          { join: "lateral", query: query, table: meta.tableName, alias: "_data", fromAlias: "_f" },
+        ],
+        // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
+        cte: {
+          sql: buildValuesCte("_find", args, queries),
+          bindings: createBindings(meta, queries),
+        },
+        orderBys: [],
+      };
 
-      const sql = `
-        ${buildValuesCte("_find", args, queries)}
-        SELECT ${selects.join(", ")}
-        FROM ${primary.table} as ${kq(primary.alias)}
-        ${joins.map((j) => `${joinKeywords(j)} ${j.table} ${kq(j.alias)} ON ${j.col1} = ${j.col2}`).join(" ")}
-        JOIN _find ON ${conditions}
-        GROUP BY _find.tag
-      `;
-
-      const rows = await em.driver.executeQuery(em, cleanSql(sql), bindings);
+      const rows = await em.driver.executeFind(em, query2, {});
 
       // Make an empty array for each batched query, per the dataloader contract
       const results = queries.map(() => 0);

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -9,11 +9,11 @@ import { EntityMetadata, getMetadata } from "../EntityMetadata";
 import { buildHintTree } from "../HintTree";
 import {
   ColumnCondition,
-  ParsedExpressionFilter,
   ParsedFindQuery,
   ParsedValueFilter,
+  RawCondition,
   getTables,
-  joinKeywords,
+  parseAlias,
   parseFindQuery,
 } from "../QueryParser";
 import { visitConditions } from "../QueryVisitor";
@@ -21,7 +21,7 @@ import { kq, kqDot } from "../keywords";
 import { LoadHint } from "../loadHints";
 import { maybeRequireTemporal } from "../temporal";
 import { plainDateMapper, plainDateTimeMapper, plainTimeMapper, zonedDateTimeMapper } from "../temporalMappers";
-import { assertNever, cleanSql } from "../utils";
+import { assertNever } from "../utils";
 
 export function findDataLoader<T extends Entity>(
   em: EntityManager,
@@ -65,65 +65,62 @@ export function findDataLoader<T extends Entity>(
         return [entities];
       }
 
-      // WITH data(tag, arg1, arg2) AS (VALUES
+      // WITH _find (tag, arg1, arg2) AS (VALUES
       //   (0::int, 'a'::varchar, 'a'::varchar),
       //   (1, 'b', 'b'),
       //   (2, 'c', 'c')
       // )
-      // SELECT array_agg(d.tag), a.*
+      // SELECT a.*, array_agg(_find.tag) AS _tags
       // FROM authors a
-      // JOIN data d ON (d.arg1 = a.first_name OR d.arg2 = a.last_name)
-      // group by a.id;
+      // CROSS JOIN _find AS _find
+      // WHERE a.first_name = _find.arg0 OR a.last_name = _find.arg1
+      // GROUP BY a.id
 
       // Build the list of 'arg1', 'arg2', ... strings
-      const args = collectArgs(query);
+      const { where, ...options } = queries[0];
+      const query = parseFindQuery(getMetadata(type), where, options);
+      const args = collectAndReplaceArgs(query);
       args.unshift({ columnName: "tag", dbType: "int" });
 
-      const selects = ["array_agg(_find.tag) as _tags", ...query.selects];
-      const [primary, joins] = getTables(query);
-
-      // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
-      const bindings = createBindings(meta, queries);
-      // Create the JOIN clause, i.e. ON a.firstName = _find.arg0
-      const [conditions] = buildConditions(query.condition!);
-
+      query.selects.unshift("array_agg(_find.tag) as _tags");
+      // Inject a cross join into the query
+      query.tables.unshift({ join: "cross", table: "_find", alias: "_find" });
+      query.cte = {
+        sql: buildValuesCte("_find", args, queries),
+        bindings: createBindings(meta, queries),
+      };
       // Because we want to use `array_agg(tag)`, add `GROUP BY`s to the values we're selecting
-      const groupBys = selects
+      query.groupBys = query.selects
+        .filter((s) => typeof s === "string")
         .filter((s) => !s.includes("array_agg") && !s.includes("CASE") && !s.includes(" as "))
-        .map((s) => s.replace("*", "id"));
+        .map((s) => {
+          // Make a liberal assumption that this is a `a.id` or `a_st0.id` string
+          const alias = parseAlias(s);
+          return { alias, column: "id" };
+        });
 
       // Also because of our `array_agg` group by, add any order bys to the group by
-      for (const o of query.orderBys) {
-        if (o.alias !== primary.alias) {
-          groupBys.push(kqDot(o.alias, o.column));
+      const [primary] = getTables(query);
+      for (const { alias, column } of query.orderBys) {
+        if (alias !== primary.alias) {
+          query.groupBys.push({ alias, column });
         }
       }
 
       const { preloader } = getEmInternalApi(em);
       const preloadJoins = preloader && hint && preloader.getPreloadJoins(meta, buildHintTree(hint), query);
       if (preloadJoins) {
-        selects.push(
+        query.selects.push(
           ...preloadJoins.flatMap((j) =>
             // Because we 'group by primary.id' to collapse the "a1 matched multiple finds" into
             // a single row, we also need to pick just the first value of each preload column
             j.selects.map((s) => `(array_agg(${s.value}))[1] AS ${s.as}`),
           ),
         );
+        query.tables.push(...preloadJoins.map((j) => j.join));
       }
 
-      const sql = `
-        ${buildValuesCte("_find", args, queries)}
-        SELECT ${selects.join(", ")}
-        FROM ${primary.table} as ${kq(primary.alias)}
-        ${joins.map((j) => `${joinKeywords(j)} ${j.table} ${kq(j.alias)} ON ${j.col1} = ${j.col2}`).join(" ")}
-        JOIN _find ON ${conditions}
-        ${preloadJoins?.map((j) => j.join).join(" ") ?? ""}
-        GROUP BY ${groupBys.join(", ")}
-        ORDER BY ${query.orderBys.map((o) => `${kq(o.alias)}.${o.column} ${o.order}`).join(", ")}
-        LIMIT ${em.entityLimit};
-      `;
-
-      const rows = await em.driver.executeQuery(em, cleanSql(sql), bindings);
+      const rows = await em.driver.executeFind(em, query, { limit: em.entityLimit });
       ensureUnderLimit(em, rows);
 
       const entities = em.hydrate(type, rows);
@@ -172,26 +169,56 @@ export function whereFilterHash(where: FilterAndSettings<any>): any {
   return hash(where, { replacer, algorithm: "md5" });
 }
 
-/** Collects & names all the args in a query, i.e. `['arg1', 'arg2']`--not the actual values. */
-export function collectArgs(query: ParsedFindQuery): { columnName: string; dbType: string }[] {
+class ArgCounter {
+  private index = 0;
+  next(): number {
+    return this.index++;
+  }
+}
+
+/**
+ * Recursively finds args in `query` and replaces them with `_find.argX` placeholders.
+ *
+ * We also return the name/type of each found/rewritten arg so we can build the `_find` CTE table.
+ */
+export function collectAndReplaceArgs(query: ParsedFindQuery): { columnName: string; dbType: string }[] {
   const args: { columnName: string; dbType: string }[] = [];
+  const argsIndex = new ArgCounter();
   visitConditions(query, {
     visitCond(c: ColumnCondition) {
       if ("value" in c.cond) {
         const { kind } = c.cond;
         if (kind === "in" || kind === "nin") {
           args.push({ columnName: `arg${args.length}`, dbType: `${c.dbType}[]` });
+          return rewriteToRawCondition(c, argsIndex);
         } else if (kind === "between") {
           // between has two values
           args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
           args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
+          return rewriteToRawCondition(c, argsIndex);
         } else {
           args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
+          return rewriteToRawCondition(c, argsIndex);
         }
+      } else if (c.cond.kind === "is-null" || c.cond.kind === "not-null") {
+        // leave it alone
+      } else {
+        throw new Error("Unsupported");
       }
     },
   });
   return args;
+}
+
+function rewriteToRawCondition(c: ColumnCondition, argsIndex: ArgCounter): RawCondition {
+  const [op, negate] = makeOp(c.cond, argsIndex);
+  return {
+    kind: "raw",
+    aliases: [c.alias],
+    condition: `${negate ? "NOT " : ""}${kqDot(c.alias, c.column)} ${op}`,
+    pruneable: c.pruneable ?? false,
+    bindings: [],
+  };
 }
 
 export function createBindings(meta: EntityMetadata, queries: readonly FilterAndSettings<any>[]): any[] {
@@ -233,51 +260,8 @@ function stripValues(query: ParsedFindQuery): void {
   });
 }
 
-/**
- * Creates the `a1.firstName = _find.args1` AND a2.lastName = _find.args2` condition
- * that joins our `_find` CTE (1 row per query that's getting auto-joined together)
- * into the main table.
- *
- * We return a tuple for `[SQL, argsTaken]`, but `argsTaken` is only used for recursive
- * calls to know which `_find.argsX` they should use, as we match up columns of the `_find`
- * CTE (`args0`, `args1`, `args2`, ...) to positions in the `JOIN ON (...)` "batched where"
- * clause.
- */
-export function buildConditions(ef: ParsedExpressionFilter, argsIndex: number = 0): [string, number] {
-  const conditions = [] as string[];
-  const originalIndex = argsIndex;
-  ef.conditions.forEach((c) => {
-    if (c.kind === "column") {
-      const [op, argsTaken, negate] = makeOp(c.cond, argsIndex);
-      if (c.alias === "unset") {
-        throw new Error("Alias was not bound in em.find");
-      }
-      if (negate) {
-        conditions.push(`NOT (${kqDot(c.alias, c.column)} ${op})`);
-      } else {
-        conditions.push(`${kqDot(c.alias, c.column)} ${op}`);
-      }
-      argsIndex += argsTaken;
-    } else if (c.kind === "exp") {
-      let [cond, argsTaken] = buildConditions(c, argsIndex);
-      const needsWrap = !("cond" in c);
-      if (needsWrap) cond = `(${cond})`;
-      conditions.push(cond);
-      argsIndex += argsTaken;
-    } else if (c.kind === "raw") {
-      conditions.push(c.condition);
-      if (c.bindings.length > 0) {
-        throw new Error("RawConditions with bindings is not batchable yet");
-      }
-    } else {
-      throw new Error(`Unsupported condition kind ${c}`);
-    }
-  });
-  const argsTaken = argsIndex - originalIndex;
-  return [conditions.join(` ${ef.op.toUpperCase()} `), argsTaken];
-}
-
-function makeOp(cond: ParsedValueFilter<any>, argsIndex: number): [string, number, boolean] {
+/** Returns [operator, argsTaken, negate], i.e. `["=", 1, false]`. */
+function makeOp(cond: ParsedValueFilter<any>, argsIndex: ArgCounter): [string, boolean] {
   switch (cond.kind) {
     case "eq":
     case "ne":
@@ -297,23 +281,23 @@ function makeOp(cond: ParsedValueFilter<any>, argsIndex: number): [string, numbe
     case "overlaps":
     case "containedBy": {
       const fn = opToFn[cond.kind] ?? fail(`Invalid operator ${cond.kind}`);
-      return [`${fn} _find.arg${argsIndex}`, 1, false];
+      return [`${fn} _find.arg${argsIndex.next()}`, false];
     }
     case "noverlaps":
     case "ncontains": {
       const fn = (opToFn as any)[cond.kind.substring(1)] ?? fail(`Invalid operator ${cond.kind}`);
-      return [`${fn} _find.arg${argsIndex}`, 1, true];
+      return [`${fn} _find.arg${argsIndex.next()}`, true];
     }
     case "is-null":
-      return [`IS NULL`, 0, false];
+      return [`IS NULL`, false];
     case "not-null":
-      return [`IS NOT NULL`, 0, false];
+      return [`IS NOT NULL`, false];
     case "in":
-      return [`= ANY(_find.arg${argsIndex})`, 1, false];
+      return [`= ANY(_find.arg${argsIndex.next()})`, false];
     case "nin":
-      return [`!= ALL(_find.arg${argsIndex})`, 1, false];
+      return [`!= ALL(_find.arg${argsIndex.next()})`, false];
     case "between":
-      return [`BETWEEN _find.arg${argsIndex} AND _find.arg${argsIndex + 1}`, 2, false];
+      return [`BETWEEN _find.arg${argsIndex.next()} AND _find.arg${argsIndex.next()}`, false];
     default:
       assertNever(cond);
   }

--- a/packages/orm/src/drivers/buildRawQuery.ts
+++ b/packages/orm/src/drivers/buildRawQuery.ts
@@ -21,7 +21,7 @@ export function buildRawQuery(
   const needsDistinct =
     parsed.tables.some((t) => t.join === "outer" && t.distinct !== false) &&
     // If this is a `findCount`, it will rewrite the `select` to have its own distinct
-    !parsed.selects.find((s) => s.startsWith("count("));
+    !parsed.selects.find((s) => typeof s === "string" && s.startsWith("count("));
 
   let sql = "";
   const bindings: any[] = [];
@@ -35,7 +35,12 @@ export function buildRawQuery(
   parsed.selects.forEach((s, i) => {
     const maybeDistinct = i === 0 && needsDistinct ? buildDistinctOn(parsed, primary) : "";
     const maybeComma = i === parsed.selects.length - 1 ? "" : ", ";
-    sql += maybeDistinct + s + maybeComma;
+    if (typeof s === "string") {
+      sql += maybeDistinct + s + maybeComma;
+    } else {
+      sql += maybeDistinct + s.sql + maybeComma;
+      bindings.push(...s.bindings);
+    }
   });
 
   // If we're doing "select distinct" for o2m joins, then all order bys must be selects
@@ -56,14 +61,15 @@ export function buildRawQuery(
       sql += ` LEFT OUTER JOIN ${as(t)} ON ${t.col1} = ${t.col2}`;
     } else if (t.join === "primary") {
       // handled above
+    } else if (t.join === "lateral") {
+      const { sql: subQ, bindings: subB } = buildRawQuery(t.query, {});
+      sql += ` CROSS JOIN LATERAL (${subQ}) AS ${kq(t.alias)}`;
+      bindings.push(...subB);
+    } else if (t.join === "cross") {
+      sql += ` CROSS JOIN ${as(t)}`;
     } else {
       assertNever(t.join);
     }
-  }
-
-  if (parsed.lateralJoins) {
-    sql += " " + parsed.lateralJoins.joins.join("\n");
-    bindings.push(...parsed.lateralJoins.bindings);
   }
 
   if (parsed.condition) {
@@ -72,6 +78,10 @@ export function buildRawQuery(
       sql += " WHERE " + where[0];
       bindings.push(...where[1]);
     }
+  }
+
+  if (parsed.groupBys && parsed.groupBys.length > 0) {
+    sql += " GROUP BY " + parsed.groupBys.map((ob) => kqDot(ob.alias, ob.column)).join(", ");
   }
 
   if (parsed.orderBys.length > 0) {

--- a/packages/orm/src/drivers/buildRawQuery.ts
+++ b/packages/orm/src/drivers/buildRawQuery.ts
@@ -1,6 +1,6 @@
 import { ParsedFindQuery, ParsedTable } from "../QueryParser";
 import { kq, kqDot } from "../keywords";
-import { assertNever } from "../utils";
+import { assertNever, cleanSql } from "../utils";
 import { buildWhereClause } from "./buildUtils";
 
 /**
@@ -27,7 +27,7 @@ export function buildRawQuery(
   const bindings: any[] = [];
 
   if (parsed.cte) {
-    sql += parsed.cte.sql + " ";
+    sql += cleanSql(parsed.cte.sql) + " ";
     bindings.push(...parsed.cte.bindings);
   }
 

--- a/packages/orm/src/drivers/buildUtils.ts
+++ b/packages/orm/src/drivers/buildUtils.ts
@@ -26,10 +26,7 @@ export function buildWhereClause(exp: ParsedExpressionFilter, topLevel = false):
 }
 
 function buildRawCondition(raw: RawCondition): [string, any[]] {
-  if (raw.bindings.length > 0) {
-    throw new Error("Not implemented");
-  }
-  return [raw.condition, []];
+  return [raw.condition, raw.bindings];
 }
 
 /** Returns a tuple of `["column op ?"`, bindings]`. */

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -22,6 +22,7 @@ export { newPgConnectionConfig } from "joist-utils";
 export { AliasAssigner } from "./AliasAssigner";
 export * from "./Aliases";
 export { BaseEntity, getInstanceData, setCurrentlyInstantiatingEntity } from "./BaseEntity";
+export { ConditionBuilder } from "./ConditionBuilder";
 export { Entity, IdType, isEntity } from "./Entity";
 export * from "./EntityFields";
 export * from "./EntityFilter";

--- a/packages/orm/src/plugins/PreloadPlugin.ts
+++ b/packages/orm/src/plugins/PreloadPlugin.ts
@@ -2,7 +2,7 @@ import { Entity } from "../Entity";
 import { EntityMetadata } from "../EntityMetadata";
 import { EntityOrId, HintNode } from "../HintTree";
 import { LoadHint, NestedLoadHint } from "../loadHints";
-import { ParsedFindQuery } from "../QueryParser";
+import { LateralJoinTable, ParsedFindQuery } from "../QueryParser";
 
 /**
  * This is a plugin API dedicated to preloading data for subtrees of entities.
@@ -75,9 +75,7 @@ export type JoinResult = {
   /** The select clause(s) for this join, i.e. `b._ as _b` or `c._ as _c`. */
   selects: { value: string; as: string }[];
   /** The SQL for this child's lateral join, which itself might have recursive lateral joins. */
-  join: string;
+  join: LateralJoinTable;
   /** The processor for this child's lateral join, which itself might recursively processor subjoins. */
   hydrator: PreloadHydrator;
-  /** Any bindings for filtering subjoins by a subset of the root entities, to avoid over-fetching. */
-  bindings: any[];
 };

--- a/packages/plugins/join-preloading/src/JsonAggregatePreloader.ts
+++ b/packages/plugins/join-preloading/src/JsonAggregatePreloader.ts
@@ -1,21 +1,24 @@
 import {
   AliasAssigner,
+  ConditionBuilder,
   Entity,
   EntityMetadata,
   EntityOrId,
+  getEmInternalApi,
+  getTables,
   HintNode,
   JoinResult,
+  JoinTable,
+  keyToNumber,
+  keyToTaggedId,
+  kq,
+  kqDot,
+  LateralJoinTable,
   LoadHint,
   NestedLoadHint,
   ParsedFindQuery,
   PreloadHydrator,
   PreloadPlugin,
-  getEmInternalApi,
-  getTables,
-  keyToNumber,
-  keyToTaggedId,
-  kq,
-  kqDot,
 } from "joist-orm";
 import { canPreload } from "./canPreload";
 import { partitionHint } from "./partitionHint";
@@ -43,21 +46,24 @@ export class JsonAggregatePreloader implements PreloadPlugin {
     const alias = getTables(query)[0].alias;
     const joins = calcLateralJoins(getAlias, { tree: root, alias, meta }, root, alias, meta);
     // If there are no sql-based preload in the hints, just return
-    if (joins.length === 0) {
-      return undefined;
-    }
+    if (joins.length === 0) return undefined;
 
     // Include the aggregate `books._ as books`, `comments._ as comments`
-    query.selects.push(...joins.map((j) => `${kqDot(j.alias, "_")} as ${kq(j.alias)}`));
-    query.lateralJoins = {
-      joins: joins.map((j) => j.join),
-      bindings: joins.flatMap((j) => j.bindings),
-    };
+    for (const { alias, join } of joins) {
+      query.selects.push({
+        sql: `${kqDot(alias, "_")} as ${kq(alias)}`,
+        aliases: [alias],
+        bindings: [],
+      });
+      query.tables.push(join);
+    }
 
     return (rows, entities) => {
       rows.forEach((row, i) => {
         const parent = entities[i];
-        joins.forEach((join) => join.hydrator(parent, parent, row[join.alias] ?? []));
+        for (const { alias, hydrator } of joins) {
+          hydrator(parent, parent, row[alias] ?? []);
+        }
       });
     };
   }
@@ -81,7 +87,6 @@ export class JsonAggregatePreloader implements PreloadPlugin {
             join.hydrator(parent, parent, row[join.alias] ?? []);
           });
         },
-        bindings: join.bindings,
       };
     });
   }
@@ -141,53 +146,89 @@ function calcLateralJoins<I extends EntityOrId>(
 
       const aliasMaybeSuffix = kq(`${parentAlias}${field.aliasSuffix}`);
 
-      let where: string;
-      let m2mFrom = "";
+      const cb = new ConditionBuilder();
+      let m2mTable: JoinTable | undefined;
       if (otherField.kind === "m2o") {
-        where = `${kqDot(otherAlias, otherField.serde.columns[0].columnName)} = ${kqDot(parentAlias, "id")}`;
+        cb.addRawCondition({
+          aliases: [otherAlias, parentAlias],
+          condition: `${kqDot(otherAlias, otherField.serde.columns[0].columnName)} = ${kqDot(parentAlias, "id")}`,
+          pruneable: true,
+        });
       } else if (otherField.kind === "poly") {
         // Get the component that points to us
         // const comp = otherField.components.find((c) => getAllMetas(parentMeta).some((m) => m.cstr === c.otherMetadata().cstr)) ??
         const comp =
           otherField.components.find((c) => parentMeta.cstr === c.otherMetadata().cstr) ??
           fail(`No component found for ${field.fieldName} -> ${otherField.fieldName}`);
-        where = `${kqDot(otherAlias, comp.columnName)} = ${kqDot(parentAlias, "id")}`;
+        cb.addRawCondition({
+          aliases: [otherAlias, parentAlias],
+          condition: `${kqDot(otherAlias, comp.columnName)} = ${kqDot(parentAlias, "id")}`,
+          pruneable: true,
+        });
       } else if (otherField.kind === "o2m" || otherField.kind === "lo2m") {
-        where = `${kqDot(otherAlias, "id")} = ${aliasMaybeSuffix}.${kq(field.serde!.columns[0].columnName)}`;
+        cb.addRawCondition({
+          aliases: [otherAlias, aliasMaybeSuffix],
+          condition: `${kqDot(otherAlias, "id")} = ${aliasMaybeSuffix}.${kq(field.serde!.columns[0].columnName)}`,
+          pruneable: true,
+        });
       } else if (otherField.kind === "o2o") {
-        where = `${kqDot(otherAlias, "id")} = ${aliasMaybeSuffix}.${kq(field.serde!.columns[0].columnName)}`;
+        cb.addRawCondition({
+          aliases: [otherAlias, aliasMaybeSuffix],
+          condition: `${kqDot(otherAlias, "id")} = ${aliasMaybeSuffix}.${kq(field.serde!.columns[0].columnName)}`,
+          pruneable: true,
+        });
       } else if (otherField.kind === "m2m") {
         const m2mAlias = getAlias(otherField.joinTableName);
         // Get the m2m row's id to track in JoinRows
         selects.unshift(kqDot(m2mAlias, "id"));
-        m2mFrom = `, ${kq(otherField.joinTableName)} ${kq(m2mAlias)}`;
-        where = `
-            ${kqDot(parentAlias, "id")} = ${kqDot(m2mAlias, otherField.columnNames[1])} AND
-            ${kqDot(m2mAlias, otherField.columnNames[0])} = ${kqDot(otherAlias, "id")}
-          `;
+        m2mTable = {
+          join: "inner",
+          table: otherField.joinTableName,
+          alias: m2mAlias,
+          col1: kqDot(parentAlias, "id"),
+          col2: kqDot(m2mAlias, otherField.columnNames[1]),
+        };
+        cb.addRawCondition({
+          aliases: [m2mAlias, otherAlias],
+          condition: `${kqDot(m2mAlias, otherField.columnNames[0])} = ${kqDot(otherAlias, "id")}`,
+          pruneable: true,
+        });
       } else {
         throw new Error(`Unsupported otherField.kind ${otherField.kind}`);
       }
 
-      const bindings = subJoins.flatMap((sj) => sj.bindings);
       const needsSubSelect = subTree.entities.size !== root.tree.entities.size;
       if (needsSubSelect) {
-        bindings.push(
-          [...subTree.entities]
-            .filter((e) => typeof e === "string" || !e.isNewEntity)
-            .map((e) => keyToNumber(root.meta, typeof e === "string" ? e : e.id)),
-        );
+        cb.addRawCondition({
+          aliases: [root.alias],
+          condition: `${kqDot(root.alias, "id")} = ANY(?)`,
+          bindings: [
+            [...subTree.entities]
+              .filter((e) => typeof e === "string" || !e.isNewEntity)
+              .map((e) => keyToNumber(root.meta, typeof e === "string" ? e : e.id)),
+          ],
+          pruneable: true,
+        });
       }
 
-      const join = `
-        cross join lateral (
-          select json_agg(json_build_array(${selects.join(", ")}) order by ${kq(otherAlias)}.id) as _
-          from ${kq(otherMeta.tableName)} ${kq(otherAlias)} ${m2mFrom}
-          ${subJoins.map((sb) => sb.join).join("\n")}
-          where ${where}
-          ${needsSubSelect ? ` AND ${kqDot(root.alias, "id")} = ANY(?)` : ""}
-        ) ${kq(otherAlias)}
-      `;
+      const join: LateralJoinTable = {
+        join: "lateral",
+        alias: otherAlias,
+        // Do we need to say which alias we're coming from, to avoid having it pruned?
+        // ...maybe not because preloading is always on the primary table?
+        fromAlias: "unset",
+        table: otherMeta.tableName,
+        query: {
+          selects: [`json_agg(json_build_array(${selects.join(", ")}) order by ${kq(otherAlias)}.id) as _`],
+          tables: [
+            { join: "primary", table: otherMeta.tableName, alias: otherAlias },
+            ...(m2mTable ? [m2mTable] : []),
+            ...subJoins.map((sj) => sj.join),
+          ],
+          condition: cb.toExpressionFilter(),
+          orderBys: [],
+        },
+      };
 
       const hydrator: AggregateJsonHydrator = (root, parent, arrays) => {
         const { em } = root;
@@ -234,7 +275,7 @@ function calcLateralJoins<I extends EntityOrId>(
         getEmInternalApi(em).setPreloadedRelation(parent.idTagged, key, children);
       };
 
-      results.push({ alias: otherAlias, join, bindings, hydrator });
+      results.push({ alias: otherAlias, join, hydrator });
     }
   });
 
@@ -246,9 +287,7 @@ type AggregateJoinResult = {
   /** The alias for this child's single json-array-d column, i.e. `b._` or `c._`. */
   alias: string;
   /** The SQL for this child's lateral join, which itself might have recursive lateral joins. */
-  join: string;
+  join: LateralJoinTable;
   /** The hydrator for this child's lateral join, which itself might recursively hydrator subjoins. */
   hydrator: AggregateJsonHydrator;
-  /** Any bindings for filtering subjoins by a subset of the root entities, to avoid over-fetching. */
-  bindings: any[];
 };

--- a/packages/tests/integration/src/EntityManager.find.batch.test.ts
+++ b/packages/tests/integration/src/EntityManager.find.batch.test.ts
@@ -35,12 +35,13 @@ describe("EntityManager.find.batch", () => {
         ` SELECT array_agg(_find.tag) as _tags, p.*, p_s0.*, p_s1.*, p.id as id,`,
         ` COALESCE(p_s0.shared_column, p_s1.shared_column) as shared_column,`,
         ` CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class`,
-        ` FROM publishers as p`,
-        ` LEFT OUTER JOIN large_publishers p_s0 ON p.id = p_s0.id`,
-        ` LEFT OUTER JOIN small_publishers p_s1 ON p.id = p_s1.id`,
-        ` JOIN _find ON p.deleted_at IS NULL AND p.id = _find.arg0 GROUP BY p.id, p_s0.id, p_s1.id`,
+        ` FROM publishers AS p`,
+        ` CROSS JOIN _find AS _find`,
+        ` LEFT OUTER JOIN large_publishers AS p_s0 ON p.id = p_s0.id`,
+        ` LEFT OUTER JOIN small_publishers AS p_s1 ON p.id = p_s1.id`,
+        ` WHERE p.deleted_at IS NULL AND p.id = _find.arg0 GROUP BY p.id, p_s0.id, p_s1.id`,
         ` ORDER BY p.id ASC`,
-        ` LIMIT 50000;`,
+        ` LIMIT $5`,
       ].join(""),
     ]);
     expect(q1.length).toEqual(1);
@@ -64,11 +65,12 @@ describe("EntityManager.find.batch", () => {
         `WITH _find (tag, arg0, arg1) AS (VALUES`,
         ` ($1::int, $2::character varying, $3::character varying), ($4, $5, $6) )`,
         ` SELECT array_agg(_find.tag) as _tags, a.*`,
-        ` FROM authors as a`,
-        ` JOIN _find ON a.deleted_at IS NULL AND a.first_name = _find.arg0 AND a.last_name = _find.arg1`,
+        ` FROM authors AS a`,
+        ` CROSS JOIN _find AS _find`,
+        ` WHERE a.deleted_at IS NULL AND a.first_name = _find.arg0 AND a.last_name = _find.arg1`,
         ` GROUP BY a.id`,
         ` ORDER BY a.id ASC`,
-        ` LIMIT 50000;`,
+        ` LIMIT $7`,
       ].join(""),
     ]);
   });
@@ -91,11 +93,12 @@ describe("EntityManager.find.batch", () => {
         `WITH _find (tag, arg0, arg1) AS (VALUES`,
         ` ($1::int, $2::character varying, $3::character varying), ($4, $5, $6) )`,
         ` SELECT array_agg(_find.tag) as _tags, a.*`,
-        ` FROM authors as a`,
-        ` JOIN _find ON a.deleted_at IS NULL AND (a.first_name = _find.arg0 OR a.last_name = _find.arg1)`,
+        ` FROM authors AS a`,
+        ` CROSS JOIN _find AS _find`,
+        ` WHERE a.deleted_at IS NULL AND (a.first_name = _find.arg0 OR a.last_name = _find.arg1)`,
         ` GROUP BY a.id`,
         ` ORDER BY a.id ASC`,
-        ` LIMIT 50000;`,
+        ` LIMIT $7`,
       ].join(""),
     ]);
   });
@@ -128,9 +131,9 @@ describe("EntityManager.find.batch", () => {
     expect(numberOfQueries).toEqual(1);
     // And it is still auto-batched
     expect(queries).toMatchInlineSnapshot(`
-      [
-        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors as a JOIN _find ON a.id = _find.arg0 GROUP BY a.id ORDER BY a.first_name DESC, a.id ASC LIMIT 50000;",
-      ]
+     [
+       "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find WHERE a.id = _find.arg0 GROUP BY a.id ORDER BY a.first_name DESC, a.id ASC LIMIT $5",
+     ]
     `);
     // And the results are the expected reverse of each other
     expect(a1.reverse()).toEqual(a2);
@@ -147,9 +150,9 @@ describe("EntityManager.find.batch", () => {
     expect(numberOfQueries).toEqual(1);
     // And it is still auto-batched
     expect(queries).toMatchInlineSnapshot(`
-      [
-        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors as a LEFT OUTER JOIN publishers p ON a.publisher_id = p.id JOIN _find ON a.id = _find.arg0 GROUP BY a.id, p.id ORDER BY p.id ASC, a.id ASC LIMIT 50000;",
-      ]
+     [
+       "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE a.id = _find.arg0 GROUP BY a.id, p.id ORDER BY p.id ASC, a.id ASC LIMIT $5",
+     ]
     `);
     // And the results are the expected reverse of each other
     expect(a1.reverse()).toEqual(a2);
@@ -162,9 +165,9 @@ describe("EntityManager.find.batch", () => {
       em.find(Author, { age: { between: [30, 40] } }),
     ]);
     expect(queries).toMatchInlineSnapshot(`
-      [
-        "WITH _find (tag, arg0, arg1) AS (VALUES ($1::int, $2::int, $3::int), ($4, $5, $6) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.age BETWEEN _find.arg0 AND _find.arg1 GROUP BY a.id ORDER BY a.id ASC LIMIT 50000;",
-      ]
+     [
+       "WITH _find (tag, arg0, arg1) AS (VALUES ($1::int, $2::int, $3::int), ($4, $5, $6) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find WHERE a.deleted_at IS NULL AND a.age BETWEEN _find.arg0 AND _find.arg1 GROUP BY a.id ORDER BY a.id ASC LIMIT $7",
+     ]
     `);
   });
 
@@ -181,9 +184,9 @@ describe("EntityManager.find.batch", () => {
     expect(q1.length).toBe(2);
     expect(q2.length).toBe(2);
     expect(queries).toMatchInlineSnapshot(`
-      [
-        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int[]), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.age = ANY(_find.arg0) GROUP BY a.id ORDER BY a.id ASC LIMIT 50000;",
-      ]
+     [
+       "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int[]), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find WHERE a.deleted_at IS NULL AND a.age = ANY(_find.arg0) GROUP BY a.id ORDER BY a.id ASC LIMIT $5",
+     ]
     `);
   });
 
@@ -200,9 +203,9 @@ describe("EntityManager.find.batch", () => {
     expect(q1.length).toBe(1);
     expect(q2.length).toBe(1);
     expect(queries).toMatchInlineSnapshot(`
-      [
-        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int[]), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.age != ALL(_find.arg0) GROUP BY a.id ORDER BY a.id ASC LIMIT 50000;",
-      ]
+     [
+       "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int[]), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find WHERE a.deleted_at IS NULL AND a.age != ALL(_find.arg0) GROUP BY a.id ORDER BY a.id ASC LIMIT $5",
+     ]
     `);
   });
 
@@ -224,9 +227,9 @@ describe("EntityManager.find.batch", () => {
       em.find(Author, { firstName: { like: "a2%" } }),
     ]);
     expect(queries).toMatchInlineSnapshot(`
-      [
-        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::character varying), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.first_name LIKE _find.arg0 GROUP BY a.id ORDER BY a.id ASC LIMIT 50000;",
-      ]
+     [
+       "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::character varying), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find WHERE a.deleted_at IS NULL AND a.first_name LIKE _find.arg0 GROUP BY a.id ORDER BY a.id ASC LIMIT $5",
+     ]
     `);
   });
 
@@ -295,11 +298,12 @@ describe("EntityManager.find.batch", () => {
         `WITH _find (tag, arg0) AS (VALUES`,
         ` ($1::int, $2::favorite_shape), ($3, $4) )`,
         ` SELECT array_agg(_find.tag) as _tags, a.*`,
-        ` FROM authors as a`,
-        ` JOIN _find ON a.deleted_at IS NULL AND a.favorite_shape = _find.arg0`,
+        ` FROM authors AS a`,
+        ` CROSS JOIN _find AS _find`,
+        ` WHERE a.deleted_at IS NULL AND a.favorite_shape = _find.arg0`,
         ` GROUP BY a.id`,
         ` ORDER BY a.id ASC`,
-        ` LIMIT 50000;`,
+        ` LIMIT $5`,
       ].join(""),
     ]);
   });
@@ -358,10 +362,11 @@ describe("EntityManager.find.batch", () => {
       [
         `WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) )`,
         ` SELECT array_agg(_find.tag) as _tags, "as".*`,
-        ` FROM author_schedules as "as"`,
-        ` JOIN _find ON "as".id = _find.arg0 GROUP BY "as".id`,
+        ` FROM author_schedules AS "as"`,
+        ` CROSS JOIN _find AS _find`,
+        ` WHERE "as".id = _find.arg0 GROUP BY "as".id`,
         ` ORDER BY "as".id ASC`,
-        ` LIMIT 50000;`,
+        ` LIMIT $5`,
       ].join(""),
     ]);
     expect(q1.length).toEqual(0);
@@ -382,10 +387,10 @@ describe("EntityManager.find.batch", () => {
     expect(queries).toEqual([
       [
         `WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) )`,
-        ` SELECT _find.tag as tag, count(distinct "as".id) as count`,
-        ` FROM author_schedules as "as"`,
-        ` JOIN _find ON "as".id = _find.arg0`,
-        ` GROUP BY _find.tag`,
+        ` SELECT _find.tag as tag, _data.count as count FROM _find AS _find`,
+        ` CROSS JOIN LATERAL`,
+        ` (SELECT count(distinct "as".id) as count FROM author_schedules AS "as" WHERE "as".id = _find.arg0)`,
+        ` AS _data LIMIT $5`,
       ].join(""),
     ]);
     expect(q1).toEqual(0);
@@ -407,9 +412,10 @@ describe("EntityManager.find.batch", () => {
       [
         `WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) )`,
         ` SELECT array_agg(_find.tag) as _tags, a.*`,
-        ` FROM authors as a`,
-        ` JOIN _find ON a.deleted_at IS NULL AND a.number_of_public_reviews = _find.arg0`,
-        ` GROUP BY a.id ORDER BY a.id ASC LIMIT 50000;`,
+        ` FROM authors AS a`,
+        ` CROSS JOIN _find AS _find`,
+        ` WHERE a.deleted_at IS NULL AND a.number_of_public_reviews = _find.arg0`,
+        ` GROUP BY a.id ORDER BY a.id ASC LIMIT $5`,
       ].join(""),
     ]);
     expect(q1).toEqual([]);
@@ -431,9 +437,10 @@ describe("EntityManager.find.batch", () => {
       [
         `WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) )`,
         ` SELECT array_agg(_find.tag) as _tags, a.*`,
-        ` FROM authors as a`,
-        ` JOIN _find ON a.deleted_at IS NULL AND a."numberOfPublicReviews2" = _find.arg0`,
-        ` GROUP BY a.id ORDER BY a.id ASC LIMIT 50000;`,
+        ` FROM authors AS a`,
+        ` CROSS JOIN _find AS _find`,
+        ` WHERE a.deleted_at IS NULL AND a."numberOfPublicReviews2" = _find.arg0`,
+        ` GROUP BY a.id ORDER BY a.id ASC LIMIT $5`,
       ].join(""),
     ]);
     expect(q1).toEqual([]);

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2457,7 +2457,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(tm, where, opts)).toMatchObject({
       selects: [`t.*`],
       tables: [{ alias: "t", table: "tasks", join: "primary" }],
-      condition: { kind: "exp", op: "and", conditions: [] },
+      condition: undefined,
     });
   });
 
@@ -3043,12 +3043,7 @@ describe("EntityManager.queries", () => {
               cond: { kind: "is-null" },
               pruneable: true,
             },
-            {
-              conditions: [
-                { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a" } },
-              ],
-              op: "and",
-            },
+            { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a" } },
           ],
         },
         orderBys: [expect.anything()],

--- a/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
@@ -42,7 +42,9 @@ describe("ReactiveQueryField", () => {
     // After the INSERTs, there is a SELECT to calc the data, and then an `UPDATE`
     expect(queries).toMatchInlineSnapshot(`
      [
-       "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::character varying), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.last_name = _find.arg0 GROUP BY a.id ORDER BY a.id ASC LIMIT 50000;",
+       "WITH _find (tag, arg0) AS (VALUES
+           ($1::int, $2::character varying), ($3, $4)
+       ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find WHERE a.deleted_at IS NULL AND a.last_name = _find.arg0 GROUP BY a.id ORDER BY a.id ASC LIMIT $5",
        "select nextval('publishers_id_seq') from generate_series(1, 1) UNION ALL select nextval('authors_id_seq') from generate_series(1, 1) UNION ALL select nextval('books_id_seq') from generate_series(1, 2) UNION ALL select nextval('book_reviews_id_seq') from generate_series(1, 2)",
        "BEGIN;",
        "INSERT INTO "publishers" ("id", "name", "latitude", "longitude", "huge_number", "number_of_book_reviews", "deleted_at", "titles_of_favorite_books", "book_advance_titles_snapshot", "number_of_book_advances_snapshot", "base_sync_default", "base_async_default", "created_at", "updated_at", "favorite_author_name", "rating", "size_id", "type_id", "favorite_author_id", "group_id", "spotlight_author_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)",

--- a/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
@@ -23,7 +23,7 @@ describe("ReactiveQueryField", () => {
        "INSERT INTO "publishers" ("id", "name", "latitude", "longitude", "huge_number", "number_of_book_reviews", "deleted_at", "titles_of_favorite_books", "book_advance_titles_snapshot", "number_of_book_advances_snapshot", "base_sync_default", "base_async_default", "created_at", "updated_at", "favorite_author_name", "rating", "size_id", "type_id", "favorite_author_id", "group_id", "spotlight_author_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)",
        "INSERT INTO "large_publishers" ("id", "shared_column", "country") VALUES ($1, $2, $3)",
        "INSERT INTO "authors" ("id", "first_name", "last_name", "ssn", "initials", "number_of_books", "book_comments", "is_popular", "age", "graduated", "nick_names", "nick_names_upper", "was_ever_popular", "is_funny", "mentor_names", "address", "business_address", "quotes", "number_of_atoms", "deleted_at", "number_of_public_reviews", "numberOfPublicReviews2", "tags_of_all_books", "search", "certificate", "created_at", "updated_at", "favorite_shape", "range_of_books", "favorite_colors", "mentor_id", "root_mentor_id", "current_draft_book_id", "favorite_book_id", "publisher_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35)",
-       "SELECT count(distinct "br".id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2",
+       "SELECT count(distinct br.id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2",
        "COMMIT;",
      ]
     `);
@@ -42,9 +42,7 @@ describe("ReactiveQueryField", () => {
     // After the INSERTs, there is a SELECT to calc the data, and then an `UPDATE`
     expect(queries).toMatchInlineSnapshot(`
      [
-       "WITH _find (tag, arg0) AS (VALUES
-           ($1::int, $2::character varying), ($3, $4)
-       ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find WHERE a.deleted_at IS NULL AND a.last_name = _find.arg0 GROUP BY a.id ORDER BY a.id ASC LIMIT $5",
+       "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::character varying), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find WHERE a.deleted_at IS NULL AND a.last_name = _find.arg0 GROUP BY a.id ORDER BY a.id ASC LIMIT $5",
        "select nextval('publishers_id_seq') from generate_series(1, 1) UNION ALL select nextval('authors_id_seq') from generate_series(1, 1) UNION ALL select nextval('books_id_seq') from generate_series(1, 2) UNION ALL select nextval('book_reviews_id_seq') from generate_series(1, 2)",
        "BEGIN;",
        "INSERT INTO "publishers" ("id", "name", "latitude", "longitude", "huge_number", "number_of_book_reviews", "deleted_at", "titles_of_favorite_books", "book_advance_titles_snapshot", "number_of_book_advances_snapshot", "base_sync_default", "base_async_default", "created_at", "updated_at", "favorite_author_name", "rating", "size_id", "type_id", "favorite_author_id", "group_id", "spotlight_author_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)",
@@ -52,7 +50,7 @@ describe("ReactiveQueryField", () => {
        "INSERT INTO "authors" ("id", "first_name", "last_name", "ssn", "initials", "number_of_books", "book_comments", "is_popular", "age", "graduated", "nick_names", "nick_names_upper", "was_ever_popular", "is_funny", "mentor_names", "address", "business_address", "quotes", "number_of_atoms", "deleted_at", "number_of_public_reviews", "numberOfPublicReviews2", "tags_of_all_books", "search", "certificate", "created_at", "updated_at", "favorite_shape", "range_of_books", "favorite_colors", "mentor_id", "root_mentor_id", "current_draft_book_id", "favorite_book_id", "publisher_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35)",
        "INSERT INTO "books" ("id", "title", "order", "notes", "acknowledgements", "authors_nick_names", "search", "deleted_at", "created_at", "updated_at", "prequel_id", "author_id", "reviewer_id", "random_comment_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14),($15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)",
        "INSERT INTO "book_reviews" ("id", "rating", "is_public", "is_test", "created_at", "updated_at", "book_id", "critic_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8),($9, $10, $11, $12, $13, $14, $15, $16)",
-       "SELECT count(distinct "br".id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2",
+       "SELECT count(distinct br.id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2",
        "WITH data (id, number_of_book_reviews, updated_at, __original_updated_at) AS (VALUES ($1::int, $2::int, $3::timestamp with time zone, $4::timestamptz) ) UPDATE publishers SET number_of_book_reviews = data.number_of_book_reviews, updated_at = data.updated_at FROM data WHERE publishers.id = data.id AND date_trunc('milliseconds', publishers.updated_at) = data.__original_updated_at RETURNING publishers.id",
        "COMMIT;",
        "select * from "publishers" order by "id" asc",
@@ -115,7 +113,7 @@ describe("ReactiveQueryField", () => {
       number_of_book_reviews: 1,
     });
     expect(queries).toContain(
-      `SELECT count(distinct "br".id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2`,
+      `SELECT count(distinct br.id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2`,
     );
   });
 


### PR DESCRIPTION
This backports a cleaner `em.find` batching from the `fix-joins-again` branch, and lands it by itself w/o the CTE-based/non-DISTINCT joins.