### PR TITLE
fix: Fix preloading with temporal

### DIFF
--- a/packages/orm/src/serde.ts
+++ b/packages/orm/src/serde.ts
@@ -114,7 +114,11 @@ export class CustomSerdeAdapter implements FieldSerde {
   }
 
   mapFromJsonAgg(value: any): any {
-    return value === null ? value : this.mapper.fromDb(value);
+    return value === null
+      ? value
+      : this.isArray
+        ? value.map((value: any) => this.mapper.fromDb(value))
+        : this.mapper.fromDb(value);
   }
 }
 

--- a/packages/tests/temporal/package.json
+++ b/packages/tests/temporal/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "joist-orm": "workspace:*",
+    "joist-plugin-join-preloading": "workspace:*",
     "node-pg-migrate": "^7.9.1",
     "temporal-polyfill": "^0.3.0"
   },

--- a/packages/tests/temporal/src/entities/temporal.plainDate.test.ts
+++ b/packages/tests/temporal/src/entities/temporal.plainDate.test.ts
@@ -92,13 +92,25 @@ describe("plainDate", () => {
     expect(result).toEqual([b1, b2]);
   });
 
-  it("works with preloading", async () => {
+  it("works with preloading array columns", async () => {
     const em = newEntityManager();
-    const authors = [jan1, jan2, jan3].map((birthday) => newAuthor(em, { birthday }));
-    const [b1, b2, b3] = authors.map((author) => newBook(em, { author }));
+    // Given books have a timestamp array column
+    newAuthor(em, { books: [{}, {}] });
     await em.flush();
-
+    // When we preload the books
     const em2 = newEntityManager({ preloadPlugin: new JsonAggregatePreloader() });
-    const loaded = await em2.find(Author, {}, { populate: "books" });
+    // Then it works
+    await em2.findOneOrFail(Author, {}, { populate: "books" });
+  });
+
+  it("works with preloading timestamp columns", async () => {
+    const em = newEntityManager();
+    // Given books have a timestamp column
+    newAuthor(em, { books: [{}] });
+    await em.flush();
+    const em2 = newEntityManager({ preloadPlugin: new JsonAggregatePreloader() });
+    const a1 = await em2.findOneOrFail(Author, {}, { populate: "books" });
+    // When we access it
+    console.log(a1.books.get[0].updatedAt);
   });
 });

--- a/packages/tests/temporal/src/entities/temporal.plainDate.test.ts
+++ b/packages/tests/temporal/src/entities/temporal.plainDate.test.ts
@@ -92,25 +92,29 @@ describe("plainDate", () => {
     expect(result).toEqual([b1, b2]);
   });
 
-  it("works with preloading array columns", async () => {
-    const em = newEntityManager();
-    // Given books have a timestamp array column
-    newAuthor(em, { books: [{}, {}] });
-    await em.flush();
-    // When we preload the books
-    const em2 = newEntityManager({ preloadPlugin: new JsonAggregatePreloader() });
-    // Then it works
-    await em2.findOneOrFail(Author, {}, { populate: "books" });
-  });
+  // These are really preloading tests, that are in the temporal test suite primarily
+  // because it's the easiest place to reproduce the issues we found in prod.
+  describe("preloading", () => {
+    it("works with preloading array columns", async () => {
+      const em = newEntityManager();
+      // Given books have a timestamp array column
+      newAuthor(em, { books: [{}, {}] });
+      await em.flush();
+      // When we preload the books
+      const em2 = newEntityManager({ preloadPlugin: new JsonAggregatePreloader() });
+      // Then it works
+      await em2.findOneOrFail(Author, {}, { populate: "books" });
+    });
 
-  it("works with preloading timestamp columns", async () => {
-    const em = newEntityManager();
-    // Given books have a timestamp column
-    newAuthor(em, { books: [{}] });
-    await em.flush();
-    const em2 = newEntityManager({ preloadPlugin: new JsonAggregatePreloader() });
-    const a1 = await em2.findOneOrFail(Author, {}, { populate: "books" });
-    // When we access it
-    console.log(a1.books.get[0].updatedAt);
+    it("works with preloading timestamp columns", async () => {
+      const em = newEntityManager();
+      // Given books have a timestamp column
+      newAuthor(em, { books: [{}] });
+      await em.flush();
+      const em2 = newEntityManager({ preloadPlugin: new JsonAggregatePreloader() });
+      const a1 = await em2.findOneOrFail(Author, {}, { populate: "books" });
+      // When we access it, it does not blow up
+      expect(a1.books.get[0].updatedAt).toBeInstanceOf(Temporal.ZonedDateTime);
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8652,6 +8652,7 @@ __metadata:
     joist-codegen: "workspace:*"
     joist-migration-utils: "workspace:*"
     joist-orm: "workspace:*"
+    joist-plugin-join-preloading: "workspace:*"
     joist-test-utils: "workspace:*"
     node-pg-migrate: "npm:^7.9.1"
     prettier: "npm:^3.5.3"


### PR DESCRIPTION
`mapFromJsonAgg` doesn't need to decode to the domain-value, b/c we lazy decode result-value to domain-value all the time, so having `mapFromJsonAgg` do it on the way into `row` meant we'd do it twice.

Added docs.