### PR TITLE
fix: Fix preloading m2os from the base type.

### DIFF
--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -881,9 +881,7 @@ export function addTablePerClassJoinsAndClassTag(
     if (isPrimary) {
       selects.push(`${alias}_b${i}.*`);
     }
-    // Put the join right after the primary `FROM` table, so that it comes before any
-    // preloading `CROSS JOIN LATERAL`s that might want to use its columns for their joins.
-    tables.splice(1, 0, {
+    tables.push({
       alias: `${alias}_b${i}`,
       table: bt.tableName,
       join: "outer",
@@ -905,7 +903,7 @@ export function addTablePerClassJoinsAndClassTag(
     meta.subTypes.forEach((st, i) => {
       const stAlias = `${alias}_s${i}`;
       selects.push(`${stAlias}.*`);
-      tables.splice(1, 0, {
+      tables.push({
         alias: stAlias,
         table: st.tableName,
         join: "outer",

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -881,7 +881,9 @@ export function addTablePerClassJoinsAndClassTag(
     if (isPrimary) {
       selects.push(`${alias}_b${i}.*`);
     }
-    tables.push({
+    // Put the join right after the primary `FROM` table, so that it comes before any
+    // preloading `CROSS JOIN LATERAL`s that might want to use its columns for their joins.
+    tables.splice(1, 0, {
       alias: `${alias}_b${i}`,
       table: bt.tableName,
       join: "outer",
@@ -903,7 +905,7 @@ export function addTablePerClassJoinsAndClassTag(
     meta.subTypes.forEach((st, i) => {
       const stAlias = `${alias}_s${i}`;
       selects.push(`${stAlias}.*`);
-      tables.push({
+      tables.splice(1, 0, {
         alias: stAlias,
         table: st.tableName,
         join: "outer",

--- a/packages/orm/src/dataloaders/populateDataLoader.ts
+++ b/packages/orm/src/dataloaders/populateDataLoader.ts
@@ -76,10 +76,10 @@ export function populateDataLoader(
               },
               orderBys: [],
             };
-            const hydrator = preloader.addPreloading(meta, layerNode, query);
             // If we're selecting from small_publishers, join in our base class in case
             // the preloader wants to join on a column like `publishers.group_id`
             addTablePerClassJoinsAndClassTag(query, meta, alias, false);
+            const hydrator = preloader.addPreloading(meta, layerNode, query);
             if (hydrator) {
               const rows = await em.driver.executeFind(em, query, {});
               const entitiesById = indexBy(entities, (e) => keyToNumber(meta, e.id));


### PR DESCRIPTION
The base type join needs to come first, i.e. this works:

```sql
SELECT sp.id, _a._ as _a
 FROM small_publishers AS sp
 LEFT OUTER JOIN publishers AS sp_b0 ON sp.id = sp_b0.id
 CROSS JOIN LATERAL (SELECT json_agg(...) as _ FROM authors AS _a WHERE _a.id = sp_b0.spotlight_author_id) AS _a
 WHERE sp.id = ANY($1);
```

But this does not:

```sql
SELECT sp.id, _a._ as _a
 FROM small_publishers AS sp
 CROSS JOIN LATERAL (SELECT json_agg(...) as _ FROM authors AS _a WHERE _a.id = sp_b0.spotlight_author_id) AS _a
 LEFT OUTER JOIN publishers AS sp_b0 ON sp.id = sp_b0.id
 WHERE sp.id = ANY($1);
```

Because the sp_b0.spotlight_author_id column isn't available to the CROSS JOIN LATERAL.