### PR TITLE
fix: Limit withLoaded destructures to loaded relations.

### DIFF
--- a/packages/core/src/withLoaded.ts
+++ b/packages/core/src/withLoaded.ts
@@ -7,6 +7,8 @@ import {
   type LoadedReadOnlyCollection,
   type LoadedReference,
   type PolymorphicReference,
+  type Property,
+  type Relation,
   isAsyncReactiveField,
   isLoadedCollection,
   isLoadedProperty,
@@ -20,8 +22,10 @@ import { type MaybePromise, fail, maybePromiseThen } from "./utils.ts";
 
 // This type seems is overly complex for references, but it's necessary in order to ensure that potential
 // undefined references are properly propagated and that polymorphic references don't overwhelm the type system.
-export type WithLoaded<T extends Entity, H extends LoadHint<T>, L extends Loaded<T, H>> = T & {
-  [K in keyof L]: L[K] extends PolymorphicReference<T, infer U, infer N>
+export type WithLoaded<T extends Entity, H extends LoadHint<T>, L extends Loaded<T, H>> = {
+  [
+    K in keyof L as L[K] extends { get: unknown } ? K : L[K] extends Relation<any, any> | Property<any, any> ? never : K
+  ]: L[K] extends PolymorphicReference<T, infer U, infer N>
     ? L[K] extends LoadedReference<T, U, N>
       ? U | N
       : L[K]

--- a/packages/tests/integration/src/withLoaded.test.ts
+++ b/packages/tests/integration/src/withLoaded.test.ts
@@ -43,6 +43,7 @@ describe("withLoaded", () => {
   it("with a m2o", async () => {
     const em = newEntityManager();
     const author = newAuthor(em, { publisher: {} });
+    const a = withLoaded(author);
     const { publisher } = withLoaded(author);
     expect(publisher?.name).toEqual("LargePublisher 1");
   });
@@ -53,7 +54,8 @@ describe("withLoaded", () => {
     const em = newEntityManager();
     const book = await em.load(Book, "b:1");
     expect(() => {
-      const { author } = withLoaded(book as any);
+      const { author } = withLoaded(book as Book);
+      console.log(author.id);
     }).toThrow("Book:1.author is not loaded");
   });
 

--- a/packages/tests/integration/src/withLoaded.test.ts
+++ b/packages/tests/integration/src/withLoaded.test.ts
@@ -47,14 +47,32 @@ describe("withLoaded", () => {
     expect(publisher?.name).toEqual("LargePublisher 1");
   });
 
-  it("with an unloaded m2o", async () => {
+  it("rejects destructuring an unloaded m2o and fails at runtime", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     const em = newEntityManager();
     const book = await em.load(Book, "b:1");
     expect(() => {
-      const { author } = withLoaded(book as any);
+      // @ts-expect-error author is not loaded
+      const { author } = withLoaded(book);
     }).toThrow("Book:1.author is not loaded");
+  });
+
+  it("allows destructuring a loaded m2o", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertBook({ title: "b1", author_id: 1 });
+    const em = newEntityManager();
+    const book = await em.load(Book, "b:1", "author");
+    const { author } = withLoaded(book);
+    expect(author.firstName).toBe("a1");
+  });
+
+  it("rejects an invalid key but returns undefined at runtime", async () => {
+    const em = newEntityManager();
+    const book = newBook(em);
+    // @ts-expect-error invalidKey is not a Book property
+    const { invalidKey } = withLoaded(book);
+    expect(invalidKey).toBeUndefined();
   });
 
   it("with a m2o and primitive", async () => {


### PR DESCRIPTION
Previously `withLoaded` would accept any keys in the `{ foo, bar } = withLoaded` destructure, but fail at runtime if `foo` or `bar` was not loaded.

Now only keys that are known to be loaded are available to destructure.