### PR TITLE
feat: Use indexes for findWithNewOrChanged

### DIFF
--- a/.idea/joist-orm.iml
+++ b/.idea/joist-orm.iml
@@ -25,6 +25,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.yarn" />
       <excludeFolder url="file://$MODULE_DIR$/packages/tests/immediate-foreign-keys/build" />
       <excludeFolder url="file://$MODULE_DIR$/docs/.astro" />
+      <excludeFolder url="file://$MODULE_DIR$/.jj" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -201,12 +201,13 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   /** When we're flushing, the connection/transaction. */
   public txn: TX | undefined;
   public entityLimit: number = defaultEntityLimit;
-  readonly #entities: Entity[] = [];
+  readonly #entitiesByTag: Map<string, Entity[]> = new Map();
+  readonly #entitiesArray: Entity[] = [];
   // Indexes the currently loaded entities by their tagged ids. This fixes a real-world
   // performance issue where `findExistingInstance` scanning `#entities` was an `O(n^2)`.
   readonly #entityIndex: Map<string, Entity> = new Map();
   // Provides field-based indexing for entity types with >1000 entities to optimize findWithNewOrChanged
-  readonly #indexManager: IndexManager = new IndexManager();
+  readonly #indexManager = new IndexManager();
   #isValidating: boolean = false;
   readonly #pendingChildren: Map<string, Map<string, { adds: Entity[]; removes: Entity[] }>> = new Map();
   #preloadedRelations: Map<string, Map<string, Entity[]>> = new Map();
@@ -271,10 +272,8 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
       mutatedCollections: new Set(),
       hooks: this.#hooks,
       rm: this.#rm,
+      indexManager: this.#indexManager,
       isLoadedCache: this.#isLoadedCache,
-      get indexManager() {
-        return em.#indexManager;
-      },
 
       joinRows(m2m: ManyToManyCollection<any, any>): JoinRows {
         return getOrSet(em.#joinRows, m2m.joinTableName, () => new JoinRows(m2m, em.#rm));
@@ -312,7 +311,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
   /** Returns a read-only shallow copy of the currently-loaded entities. */
   get entities(): ReadonlyArray<Entity> {
-    return [...this.#entities];
+    return [...this.#entitiesArray];
   }
 
   /** Looks up `id` in the list of already-loaded entities. */
@@ -554,7 +553,9 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     // clause before knowing if it should adjust teh amount.
     const isSelectAll = Object.keys(where).length === 0;
     if (isSelectAll) {
-      for (const entity of this.#entities) {
+      const tagged = this.#entitiesByTag.get(getMetadata(type).tagName) ?? [];
+      for (const entity of tagged) {
+        // Still do an `instanceof` to handle subtypes
         if (entity instanceof type) {
           if (entity.isNewEntity) {
             count++;
@@ -583,16 +584,16 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
    * @param type the entity type to find
    * @param where the fields to look up the existing entity by
    */
-  async findWithNewOrChanged<T extends EntityW, F extends Partial<OptsOf<T>>>(
+  async findWithNewOrChanged<T extends Entity, F extends Partial<OptsOf<T>>>(
     type: EntityConstructor<T>,
     where: F,
   ): Promise<T[]>;
-  async findWithNewOrChanged<T extends EntityW, F extends Partial<OptsOf<T>>, const H extends LoadHint<T>>(
+  async findWithNewOrChanged<T extends Entity, F extends Partial<OptsOf<T>>, const H extends LoadHint<T>>(
     type: EntityConstructor<T>,
     where: F,
     options?: { populate?: H; softDeletes?: "include" | "exclude" },
   ): Promise<Loaded<T, H>[]>;
-  async findWithNewOrChanged<T extends EntityW, F extends Partial<OptsOf<T>>, const H extends LoadHint<T>>(
+  async findWithNewOrChanged<T extends Entity, F extends Partial<OptsOf<T>>, const H extends LoadHint<T>>(
     type: EntityConstructor<T>,
     where: F,
     options?: { populate?: H; softDeletes?: "include" | "exclude" },
@@ -603,7 +604,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     const copy: any = Object.fromEntries(Object.entries(where).filter(([, v]) => v !== undefined));
     const persisted = await this.find(type, copy, { softDeletes });
     const unchanged = persisted.filter((e) => !e.isNewEntity && !e.isDirtyEntity && !e.isDeletedEntity);
-    const maybeNew = this.#findEntitiesWithIndexes(type, where).filter(
+    const maybeNew = this.#filterEntities<T>(type, where).filter(
       (e) => (e.isNewEntity || e.isDirtyEntity) && !e.isDeletedEntity,
     );
     const found = [...unchanged, ...maybeNew];
@@ -1207,6 +1208,9 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
   /** Registers a newly-instantiated entity with our EntityManager; only called by entity constructors. */
   register(entity: Entity, maybeExplicitId?: string): void {
+    const baseMeta = getBaseMeta(getMetadata(entity));
+
+    // Keep our indexes up to date...
     const maybeId = entity.idTaggedMaybe ?? maybeExplicitId;
     if (maybeId) {
       if (this.findExistingInstance(maybeId) !== undefined) {
@@ -1214,18 +1218,20 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
       }
       this.#entityIndex.set(maybeId, entity);
     }
+    this.#entitiesArray.push(entity);
+    const set = this.#entitiesByTag.get(baseMeta.tagName) ?? [];
+    if (set.length === 0) this.#entitiesByTag.set(baseMeta.tagName, set);
+    set.push(entity);
 
-    this.#entities.push(entity);
-    if (this.#entities.length >= this.entityLimit) {
+    if (this.#entitiesArray.length >= this.entityLimit) {
       throw new Error(`More than ${this.entityLimit} entities have been instantiated`);
     }
 
-    // Check if we should enable indexing for this entity type
-    this.#maybeEnableIndexingForEntityType(entity);
+    // If indexing is enabled for this type, add it...
+    this.#indexManager.maybeIndexEntity(entity);
 
     // Set a default createdAt/updatedAt that we'll keep if this is a new entity, or over-write if we're loaded an existing row
     if (entity.isNewEntity) {
-      const baseMeta = getBaseMeta(getMetadata(entity));
       const { createdAt, updatedAt } = baseMeta.timestampFields ?? {};
       const { data } = getInstanceData(entity);
       const now = new Date();
@@ -1560,7 +1566,13 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     this.#preloadedRelations = new Map();
     const deepLoad = param && "deepLoad" in param && param.deepLoad;
     let todo =
-      param === undefined ? this.#entities : Array.isArray(param) ? param : isEntity(param) ? [param] : this.#entities;
+      param === undefined
+        ? this.#entitiesArray
+        : Array.isArray(param)
+          ? param
+          : isEntity(param)
+            ? [param]
+            : this.#entitiesArray;
     const done = new Set<Entity>();
     while (todo.length > 0) {
       const copy = [...todo];
@@ -1672,10 +1684,13 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
         // This is a mini copy-paste of em.register that doesn't re-findExistingInstance
         this.#entityIndex.set(taggedId, entity as any);
-        this.#entities.push(entity as any);
-        if (this.#entities.length >= this.entityLimit) {
+        this.#entitiesArray.push(entity as any);
+        if (this.#entitiesArray.length >= this.entityLimit) {
           throw new Error(`More than ${this.entityLimit} entities have been instantiated`);
         }
+        const set = this.#entitiesByTag.get(maybeBaseMeta.tagName) ?? [];
+        if (set.length === 0) this.#entitiesByTag.set(maybeBaseMeta.tagName, set);
+        set.push(entity as any);
       } else if (options?.overwriteExisting === true) {
         // Usually if the entity already exists, we don't write over it, but in this case we assume that
         // `EntityManager.refresh` is telling us to explicitly load the latest data.
@@ -1863,42 +1878,16 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     await this.flush();
   }
 
-  /**
-   * Checks if indexing should be enabled for the entity type and enables it if threshold is reached.
-   */
-  #maybeEnableIndexingForEntityType(entity: Entity): void {
-    const meta = getMetadata(entity);
-    const entityType = meta.cstr as any;
-    const typeName = meta.type;
-
-    // Count entities of this type
-    const entitiesOfType = this.#entities.filter((e) => e instanceof entityType);
-
-    // If not indexed yet, check if we should enable indexing
-    if (!this.#indexManager.indexedTypes.has(typeName)) {
-      if (this.#indexManager.shouldIndexType(entitiesOfType.length)) {
-        // enableIndexingForType will index all entities including the current one
-        this.#indexManager.enableIndexingForType(entityType, entitiesOfType);
-        return; // No need to add individually since enableIndexingForType handles it
-      }
+  /** Returns entities matching the filter using indexed search when available. */
+  #filterEntities<T extends Entity>(cstr: EntityConstructor<T>, where: any): T[] {
+    const meta = getMetadata(cstr);
+    const entities = (this.#entitiesByTag.get(meta.tagName) as T[]) ?? [];
+    if (this.#indexManager.shouldIndexType(entities.length)) {
+      this.#indexManager.enableIndexingForType(meta, entities);
+      return this.#indexManager.findMatching(meta, where)!.filter((e) => !e.isDeletedEntity);
     } else {
-      // Type is already indexed, add this entity to the index
-      this.#indexManager.addEntity(entity);
+      return this.entities.filter((e) => e instanceof cstr && !e.isDeletedEntity && entityMatches(e, where)) as T[];
     }
-  }
-
-  /**
-   * Returns entities matching the filter using indexed search when available.
-   */
-  #findEntitiesWithIndexes<T extends Entity>(entityType: any, where: any): T[] {
-    // Try indexed search first
-    const indexedResults = this.#indexManager.findMatching(entityType, where);
-    if (indexedResults !== null) {
-      return indexedResults as T[];
-    }
-
-    // Fallback to linear search
-    return this.entities.filter((e) => e instanceof entityType && !e.isDeletedEntity && entityMatches(e, where)) as T[];
   }
 }
 
@@ -1918,12 +1907,12 @@ export interface EntityManagerInternalApi {
 
   hooks: Record<EntityManagerHook, HookFn<any>[]>;
   rm: ReactionsManager;
+  indexManager: IndexManager;
   preloader: PreloadPlugin | undefined;
   isValidating: boolean;
   checkWritesAllowed: () => void;
   get fieldLogger(): FieldLogger | undefined;
   get isLoadedCache(): IsLoadedCache;
-  get indexManager(): IndexManager;
 }
 
 export function getEmInternalApi(em: EntityManager): EntityManagerInternalApi {

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1876,7 +1876,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
     // If not indexed yet, check if we should enable indexing
     if (!this.#indexManager.indexedTypes.has(typeName)) {
-      if (this.#indexManager.shouldIndexType(entityType, entitiesOfType.length)) {
+      if (this.#indexManager.shouldIndexType(entitiesOfType.length)) {
         // enableIndexingForType will index all entities including the current one
         this.#indexManager.enableIndexingForType(entityType, entitiesOfType);
         return; // No need to add individually since enableIndexingForType handles it

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1884,9 +1884,19 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     const entities = (this.#entitiesByTag.get(meta.tagName) as T[]) ?? [];
     if (this.#indexManager.shouldIndexType(entities.length)) {
       this.#indexManager.enableIndexingForType(meta, entities);
-      return this.#indexManager.findMatching(meta, where)!.filter((e) => !e.isDeletedEntity);
+      return (
+        this.#indexManager
+          .findMatching(meta, where)
+          // Still filter by `instanceof cstr` to handle subtyping
+          .filter((e) => e instanceof cstr && !e.isDeletedEntity)
+      );
     } else {
-      return this.entities.filter((e) => e instanceof cstr && !e.isDeletedEntity && entityMatches(e, where)) as T[];
+      return (
+        this.#entitiesByTag
+          .get(meta.tagName)!
+          // Still filter by `instanceof cstr` to handle subtyping
+          .filter((e) => e instanceof cstr && !e.isDeletedEntity && entityMatches(e, where)) as T[]
+      );
     }
   }
 }

--- a/packages/orm/src/IndexManager.ts
+++ b/packages/orm/src/IndexManager.ts
@@ -1,0 +1,408 @@
+import { Entity, isEntity } from "./Entity";
+import { EntityMetadata, getMetadata, isManyToOneField, isPolymorphicField } from "./EntityMetadata";
+import { ManyToOneReference, PolymorphicReference, isLoadedReference } from "./relations";
+
+type FieldValue = any;
+type FieldName = string;
+type EntityTypeName = string;
+
+// Index structure: EntityType -> FieldName -> FieldValue -> Set<Entity>
+type FieldIndex = Map<FieldValue, Set<Entity>>;
+type EntityFieldIndexes = Map<FieldName, FieldIndex>;
+type TypeIndexes = Map<EntityTypeName, EntityFieldIndexes>;
+
+// Special indexes for m2o fields that can be either saved (id-based) or unsaved (instance-based)
+type M2oIndex = {
+  byId: Map<string, Set<Entity>>; // For saved entities: id -> entities
+  byInstance: Map<Entity, Set<Entity>>; // For unsaved entities: entity instance -> entities
+  byNull: Set<Entity>; // For null/undefined values
+};
+
+/**
+ * IndexManager provides field-based indexing for entity queries to avoid O(n) linear scans.
+ *
+ * Key features:
+ * - Only indexes entity types with >1000 entities to avoid overhead for small datasets
+ * - Supports dual indexing for m2o/poly fields (by ID for saved, by instance for unsaved)
+ * - Automatically maintains indexes when fields are updated via setField()
+ * - Drop-in replacement for linear entityMatches filtering
+ */
+export class IndexManager {
+  private indexes: TypeIndexes = new Map();
+  private m2oIndexes: Map<EntityTypeName, Map<FieldName, M2oIndex>> = new Map();
+  readonly indexedTypes: Set<EntityTypeName> = new Set();
+  private readonly indexThreshold = 1_000;
+
+  /**
+   * Determines if a given entity type should be indexed based on entity count.
+   */
+  shouldIndexType(entityType: any, entityCount: number): boolean {
+    return entityCount >= this.indexThreshold;
+  }
+
+  /**
+   * Enables indexing for an entity type and builds initial indexes.
+   */
+  enableIndexingForType<T extends Entity>(entityType: any, entities: T[]): void {
+    const typeName = entityType.name;
+
+    if (this.indexedTypes.has(typeName)) {
+      return; // Already indexed
+    }
+
+    this.indexedTypes.add(typeName);
+    const meta = getMetadata(entityType);
+
+    // Initialize index structures
+    this.indexes.set(typeName, new Map());
+    this.m2oIndexes.set(typeName, new Map());
+
+    // Build indexes for all entities of this type
+    for (const entity of entities) {
+      this.addEntityToIndexes(entity, meta);
+    }
+  }
+
+  /**
+   * Disables indexing for an entity type (when count drops below threshold).
+   */
+  disableIndexingForType(entityType: any): void {
+    const typeName = entityType.name;
+    this.indexedTypes.delete(typeName);
+    this.indexes.delete(typeName);
+    this.m2oIndexes.delete(typeName);
+  }
+
+  /**
+   * Adds an entity to all relevant indexes.
+   */
+  addEntity<T extends Entity>(entity: T): void {
+    const meta = getMetadata(entity);
+    const typeName = meta.type;
+
+    if (!this.indexedTypes.has(typeName)) {
+      return; // Type not indexed
+    }
+
+    this.addEntityToIndexes(entity, meta);
+  }
+
+  /**
+   * Removes an entity from all relevant indexes.
+   */
+  removeEntity<T extends Entity>(entity: T): void {
+    const meta = getMetadata(entity);
+    const typeName = meta.type;
+
+    if (!this.indexedTypes.has(typeName)) {
+      return; // Type not indexed
+    }
+
+    this.removeEntityFromIndexes(entity, meta);
+  }
+
+  /**
+   * Updates indexes when a field value changes.
+   */
+  updateFieldIndex<T extends Entity>(entity: T, fieldName: string, oldValue: any, newValue: any): void {
+    const meta = getMetadata(entity);
+    const typeName = meta.type;
+
+    if (!this.indexedTypes.has(typeName)) {
+      return; // Type not indexed
+    }
+
+    const field = meta.allFields[fieldName];
+    if (!field) return;
+
+    // Remove from old value index
+    this.removeFromFieldIndex(entity, meta, fieldName, oldValue);
+
+    // Add to new value index
+    this.addToFieldIndex(entity, meta, fieldName, newValue);
+  }
+
+  /**
+   * Finds entities matching the given where clause using indexes.
+   * Returns null if the type is not indexed (fallback to linear search).
+   */
+  findMatching<T extends Entity>(entityType: any, where: any): T[] | null {
+    const typeName = entityType.name;
+
+    if (!this.indexedTypes.has(typeName)) {
+      return null; // Not indexed, use linear search
+    }
+
+    const typeIndexes = this.indexes.get(typeName)!;
+    const typeM2oIndexes = this.m2oIndexes.get(typeName)!;
+
+    // Start with all entities, then intersect with each field constraint
+    let candidates: Set<Entity> | null = null;
+
+    for (const [fieldName, value] of Object.entries(where)) {
+      const fieldCandidates = this.getFieldMatches(typeIndexes, typeM2oIndexes, fieldName, value);
+
+      if (candidates === null) {
+        candidates = fieldCandidates;
+      } else {
+        // Intersect with previous candidates
+        candidates = this.intersectSets(candidates, fieldCandidates);
+      }
+
+      // Early exit if no candidates remain
+      if (candidates.size === 0) {
+        break;
+      }
+    }
+
+    return candidates ? (Array.from(candidates) as T[]) : [];
+  }
+
+  private addEntityToIndexes<T extends Entity>(entity: T, meta: EntityMetadata): void {
+    const typeName = meta.type;
+    const typeIndexes = this.indexes.get(typeName)!;
+    const typeM2oIndexes = this.m2oIndexes.get(typeName)!;
+
+    // Index all fields
+    for (const [fieldName, field] of Object.entries(meta.allFields)) {
+      try {
+        const value = this.getFieldValue(entity, fieldName);
+        this.addToFieldIndex(entity, meta, fieldName, value);
+      } catch (e) {
+        // Skip fields that can't be read (e.g., unloaded references)
+        continue;
+      }
+    }
+  }
+
+  private removeEntityFromIndexes<T extends Entity>(entity: T, meta: EntityMetadata): void {
+    const typeName = meta.type;
+
+    // Remove from all field indexes
+    for (const [fieldName, field] of Object.entries(meta.allFields)) {
+      try {
+        const value = this.getFieldValue(entity, fieldName);
+        this.removeFromFieldIndex(entity, meta, fieldName, value);
+      } catch (e) {
+        // Skip fields that can't be read
+        continue;
+      }
+    }
+  }
+
+  private addToFieldIndex<T extends Entity>(entity: T, meta: EntityMetadata, fieldName: string, value: any): void {
+    const typeName = meta.type;
+    const field = meta.allFields[fieldName];
+    if (!field) return;
+
+    if (isManyToOneField(field) || isPolymorphicField(field)) {
+      this.addToM2oIndex(entity, typeName, fieldName, value);
+    } else {
+      this.addToRegularIndex(entity, typeName, fieldName, value);
+    }
+  }
+
+  private removeFromFieldIndex<T extends Entity>(entity: T, meta: EntityMetadata, fieldName: string, value: any): void {
+    const typeName = meta.type;
+    const field = meta.allFields[fieldName];
+    if (!field) return;
+
+    if (isManyToOneField(field) || isPolymorphicField(field)) {
+      this.removeFromM2oIndex(entity, typeName, fieldName, value);
+    } else {
+      this.removeFromRegularIndex(entity, typeName, fieldName, value);
+    }
+  }
+
+  private addToRegularIndex(entity: Entity, typeName: string, fieldName: string, value: any): void {
+    const typeIndexes = this.indexes.get(typeName)!;
+
+    if (!typeIndexes.has(fieldName)) {
+      typeIndexes.set(fieldName, new Map());
+    }
+
+    const fieldIndex = typeIndexes.get(fieldName)!;
+    if (!fieldIndex.has(value)) {
+      fieldIndex.set(value, new Set());
+    }
+
+    fieldIndex.get(value)!.add(entity);
+  }
+
+  private removeFromRegularIndex(entity: Entity, typeName: string, fieldName: string, value: any): void {
+    const typeIndexes = this.indexes.get(typeName);
+    if (!typeIndexes) return;
+
+    const fieldIndex = typeIndexes.get(fieldName);
+    if (!fieldIndex) return;
+
+    const valueSet = fieldIndex.get(value);
+    if (valueSet) {
+      valueSet.delete(entity);
+      if (valueSet.size === 0) {
+        fieldIndex.delete(value);
+      }
+    }
+  }
+
+  private addToM2oIndex(entity: Entity, typeName: string, fieldName: string, value: any): void {
+    const typeM2oIndexes = this.m2oIndexes.get(typeName)!;
+
+    if (!typeM2oIndexes.has(fieldName)) {
+      typeM2oIndexes.set(fieldName, {
+        byId: new Map(),
+        byInstance: new Map(),
+        byNull: new Set(),
+      });
+    }
+
+    const m2oIndex = typeM2oIndexes.get(fieldName)!;
+
+    if (value === null || value === undefined) {
+      m2oIndex.byNull.add(entity);
+    } else if (isEntity(value)) {
+      if (value.isNewEntity) {
+        // Unsaved entity - index by instance
+        if (!m2oIndex.byInstance.has(value)) {
+          m2oIndex.byInstance.set(value, new Set());
+        }
+        m2oIndex.byInstance.get(value)!.add(entity);
+      } else {
+        // Saved entity - index by ID
+        const id = value.idTaggedMaybe || value.id;
+        if (id) {
+          const idStr = String(id);
+          if (!m2oIndex.byId.has(idStr)) {
+            m2oIndex.byId.set(idStr, new Set());
+          }
+          m2oIndex.byId.get(idStr)!.add(entity);
+        }
+      }
+    } else if (typeof value === "string") {
+      // Direct ID reference
+      if (!m2oIndex.byId.has(value)) {
+        m2oIndex.byId.set(value, new Set());
+      }
+      m2oIndex.byId.get(value)!.add(entity);
+    }
+  }
+
+  private removeFromM2oIndex(entity: Entity, typeName: string, fieldName: string, value: any): void {
+    const typeM2oIndexes = this.m2oIndexes.get(typeName);
+    if (!typeM2oIndexes) return;
+
+    const m2oIndex = typeM2oIndexes.get(fieldName);
+    if (!m2oIndex) return;
+
+    if (value === null || value === undefined) {
+      m2oIndex.byNull.delete(entity);
+    } else if (isEntity(value)) {
+      if (value.isNewEntity) {
+        const instanceSet = m2oIndex.byInstance.get(value);
+        if (instanceSet) {
+          instanceSet.delete(entity);
+          if (instanceSet.size === 0) {
+            m2oIndex.byInstance.delete(value);
+          }
+        }
+      } else {
+        const id = value.idTaggedMaybe || value.id;
+        if (id) {
+          const idStr = String(id);
+          const idSet = m2oIndex.byId.get(idStr);
+          if (idSet) {
+            idSet.delete(entity);
+            if (idSet.size === 0) {
+              m2oIndex.byId.delete(idStr);
+            }
+          }
+        }
+      }
+    } else if (typeof value === "string") {
+      const idSet = m2oIndex.byId.get(value);
+      if (idSet) {
+        idSet.delete(entity);
+        if (idSet.size === 0) {
+          m2oIndex.byId.delete(value);
+        }
+      }
+    }
+  }
+
+  private getFieldMatches(
+    typeIndexes: EntityFieldIndexes,
+    typeM2oIndexes: Map<FieldName, M2oIndex>,
+    fieldName: string,
+    value: any,
+  ): Set<Entity> {
+    // Check if it's an m2o field
+    const m2oIndex = typeM2oIndexes.get(fieldName);
+    if (m2oIndex) {
+      return this.getM2oMatches(m2oIndex, value);
+    }
+
+    // Regular field index
+    const fieldIndex = typeIndexes.get(fieldName);
+    if (!fieldIndex) {
+      return new Set(); // No index for this field
+    }
+
+    return fieldIndex.get(value) || new Set();
+  }
+
+  private getM2oMatches(m2oIndex: M2oIndex, value: any): Set<Entity> {
+    if (value === null || value === undefined) {
+      return new Set(m2oIndex.byNull);
+    } else if (isEntity(value)) {
+      if (value.isNewEntity) {
+        return m2oIndex.byInstance.get(value) || new Set();
+      } else {
+        const id = value.idTaggedMaybe || value.id;
+        return id ? m2oIndex.byId.get(String(id)) || new Set() : new Set();
+      }
+    } else if (typeof value === "string") {
+      return m2oIndex.byId.get(value) || new Set();
+    }
+
+    return new Set();
+  }
+
+  private intersectSets(set1: Set<Entity>, set2: Set<Entity>): Set<Entity> {
+    const result = new Set<Entity>();
+    for (const entity of set1) {
+      if (set2.has(entity)) {
+        result.add(entity);
+      }
+    }
+    return result;
+  }
+
+  private getFieldValue(entity: Entity, fieldName: string): any {
+    // Use the same field access pattern as entityMatches
+    const meta = getMetadata(entity);
+    const field = meta.allFields[fieldName];
+    if (!field) return undefined;
+
+    const fn = fieldName as keyof Entity;
+    switch (field.kind) {
+      case "primaryKey":
+      case "enum":
+      case "primitive":
+        return (entity as any)[fn];
+      case "m2o":
+      case "poly":
+        const relation = (entity as any)[fn] as
+          | ManyToOneReference<Entity, any, any>
+          | PolymorphicReference<Entity, any, any>;
+        if (isLoadedReference(relation)) {
+          return relation.get;
+        } else if (relation.isSet) {
+          return relation.id;
+        } else {
+          return undefined;
+        }
+      default:
+        return undefined;
+    }
+  }
+}

--- a/packages/orm/src/IndexManager.ts
+++ b/packages/orm/src/IndexManager.ts
@@ -205,9 +205,12 @@ class FieldIndex {
 }
 
 function intersectSets<T>(set1: Set<T>, set2: Set<T>): Set<T> {
+  const [smaller, larger] = set1.size <= set2.size ? [set1, set2] : [set2, set1];
   const result = new Set<T>();
-  for (const e of set1) {
-    if (set2.has(e)) result.add(e);
+  for (const item of smaller) {
+    if (larger.has(item)) {
+      result.add(item);
+    }
   }
   return result;
 }

--- a/packages/orm/src/IndexManager.ts
+++ b/packages/orm/src/IndexManager.ts
@@ -1,21 +1,11 @@
 import { Entity, isEntity } from "./Entity";
-import { EntityMetadata, getMetadata, isManyToOneField, isPolymorphicField } from "./EntityMetadata";
+import { EntityMetadata, getMetadata } from "./EntityMetadata";
 import { ManyToOneReference, PolymorphicReference, isLoadedReference } from "./relations";
+import { groupBy } from "./utils";
 
 type FieldValue = any;
 type FieldName = string;
 type EntityTag = string;
-
-// Index structure: EntityType -> FieldName -> FieldValue -> Set<Entity>
-type FieldIndex = Map<FieldValue, Set<Entity>>;
-type EntityFieldIndexes = Map<FieldName, FieldIndex>;
-
-// Special indexes for m2o fields that can be either saved (id-based) or unsaved (instance-based)
-type M2oIndex = {
-  byId: Map<string, Set<Entity>>; // For saved entities: id -> entities
-  byInstance: Map<Entity, Set<Entity>>; // For unsaved entities: entity instance -> entities
-  byNull: Set<Entity>; // For null/undefined values
-};
 
 /**
  * IndexManager provides field-based indexing for entity queries to avoid O(n) linear scans of `em.entities`.
@@ -26,9 +16,8 @@ type M2oIndex = {
  * - Automatically maintains indexes when fields are updated via setField()
  */
 export class IndexManager {
-  readonly #indexes: Map<EntityTag, EntityFieldIndexes> = new Map();
-  readonly #m2oIndexes: Map<EntityTag, Map<FieldName, M2oIndex>> = new Map();
-  readonly indexedTypes: Set<EntityTag> = new Set();
+  readonly #indexes: Map<EntityTag, Map<FieldName, FieldIndex>> = new Map();
+  readonly #indexedTags: Set<EntityTag> = new Set();
   readonly #indexThreshold = 1_000;
 
   /** @return if we should index entities of this type/count. */
@@ -36,369 +25,187 @@ export class IndexManager {
     return entityCount >= this.#indexThreshold;
   }
 
-  /**
-   * Enables indexing for an entity type and builds initial indexes.
-   */
-  enableIndexingForType<T extends Entity>(entityType: any, entities: T[]): void {
-    const typeName = entityType.name;
+  /** Visible for testing. */
+  isIndexed(tagName: string): boolean {
+    return this.#indexedTags.has(tagName);
+  }
 
-    if (this.indexedTypes.has(typeName)) {
-      return; // Already indexed
-    }
+  /** Enables indexing for an entity type and builds initial indexes. */
+  enableIndexingForType<T extends Entity>(meta: EntityMetadata<T>, entities: T[]): void {
+    const { tagName } = meta;
+    if (this.#indexedTags.has(tagName)) return; // Already indexed
+    this.#indexedTags.add(tagName);
+    this.#indexes.set(tagName, new Map());
 
-    this.indexedTypes.add(typeName);
-    const meta = getMetadata(entityType);
-
-    // Initialize index structures
-    this.#indexes.set(typeName, new Map());
-    this.#m2oIndexes.set(typeName, new Map());
-
-    // Build indexes for all entities of this type
-    for (const entity of entities) {
-      this.addEntityToIndexes(entity, meta);
+    // If subtypes are involved, group by each subtype
+    if (meta.baseType || meta.subTypes.length > 0) {
+      [...groupBy(entities, (e) => getMetadata(e)).entries()].forEach(([meta, entities]) => {
+        this.addEntitiesToIndex(meta, entities);
+      });
+    } else {
+      this.addEntitiesToIndex(meta, entities);
     }
   }
 
-  /**
-   * Disables indexing for an entity type (when count drops below threshold).
-   */
-  disableIndexingForType(entityType: any): void {
-    const typeName = entityType.name;
-    this.indexedTypes.delete(typeName);
-    this.#indexes.delete(typeName);
-    this.#m2oIndexes.delete(typeName);
-  }
-
-  /**
-   * Adds an entity to all relevant indexes.
-   */
-  addEntity<T extends Entity>(entity: T): void {
+  /** Adds an entity to all relevant indexes. */
+  maybeIndexEntity(entity: Entity): void {
     const meta = getMetadata(entity);
-    const typeName = meta.type;
-
-    if (!this.indexedTypes.has(typeName)) {
-      return; // Type not indexed
+    if (this.#indexedTags.has(meta.tagName)) {
+      this.addEntitiesToIndex(meta, [entity]);
     }
-
-    this.addEntityToIndexes(entity, meta);
   }
 
-  /**
-   * Removes an entity from all relevant indexes.
-   */
-  removeEntity<T extends Entity>(entity: T): void {
+  /** Updates indexes when a field value changes. */
+  updateFieldIndex(entity: Entity, fieldName: string, oldValue: any, newValue: any): void {
     const meta = getMetadata(entity);
-    const typeName = meta.type;
-
-    if (!this.indexedTypes.has(typeName)) {
-      return; // Type not indexed
+    if (!this.#indexedTags.has(meta.tagName)) return; // Type not indexed
+    const field = meta.allFields[fieldName] ?? fail(`Invalid field ${fieldName}`);
+    let fieldIndex = this.#indexes.get(meta.tagName)!.get(field.fieldName);
+    if (!fieldIndex) {
+      fieldIndex = new FieldIndex();
+      this.#indexes.get(meta.tagName)!.set(field.fieldName, fieldIndex);
     }
-
-    this.removeEntityFromIndexes(entity, meta);
-  }
-
-  /**
-   * Updates indexes when a field value changes.
-   */
-  updateFieldIndex<T extends Entity>(entity: T, fieldName: string, oldValue: any, newValue: any): void {
-    const meta = getMetadata(entity);
-    const typeName = meta.type;
-
-    if (!this.indexedTypes.has(typeName)) {
-      return; // Type not indexed
-    }
-
-    const field = meta.allFields[fieldName];
-    if (!field) return;
-
-    // Remove from old value index
-    this.removeFromFieldIndex(entity, meta, fieldName, oldValue);
-
-    // Add to new value index
-    this.addToFieldIndex(entity, meta, fieldName, newValue);
+    fieldIndex.remove(oldValue, entity);
+    fieldIndex.add(newValue, entity);
   }
 
   /**
    * Finds entities matching the given where clause using indexes.
    * Returns null if the type is not indexed (fallback to linear search).
    */
-  findMatching<T extends Entity>(entityType: any, where: any): T[] | null {
-    const typeName = entityType.name;
-
-    if (!this.indexedTypes.has(typeName)) {
-      return null; // Not indexed, use linear search
+  findMatching<T extends Entity>(meta: EntityMetadata<T>, where: any): T[] {
+    const { tagName } = meta;
+    if (!this.#indexedTags.has(tagName)) {
+      throw new Error(`${meta.type} is not indexed`);
     }
-
-    const typeIndexes = this.#indexes.get(typeName)!;
-    const typeM2oIndexes = this.#m2oIndexes.get(typeName)!;
-
-    // Start with all entities, then intersect with each field constraint
-    let candidates: Set<Entity> | null = null;
-
+    const fieldIndexes = this.#indexes.get(tagName)!;
+    // Start with all entities of the 1st condition, then intersect (AND) each subsequent field in `where`
+    let candidates: Set<Entity> | undefined;
     for (const [fieldName, value] of Object.entries(where)) {
-      const fieldCandidates = this.getFieldMatches(typeIndexes, typeM2oIndexes, fieldName, value);
-
-      if (candidates === null) {
-        candidates = fieldCandidates;
+      const fieldIndex = fieldIndexes.get(fieldName) ?? new FieldIndex();
+      const fieldCandidates = fieldIndex.get(value) ?? new Set();
+      if (!candidates) {
+        candidates = fieldCandidates; // This is the 1st clause
       } else {
-        // Intersect with previous candidates
-        candidates = this.intersectSets(candidates, fieldCandidates);
+        candidates = intersectSets(candidates, fieldCandidates);
       }
-
       // Early exit if no candidates remain
-      if (candidates.size === 0) {
-        break;
-      }
+      if (candidates.size === 0) break;
     }
-
-    return candidates ? (Array.from(candidates) as T[]) : [];
+    return candidates ? ([...candidates] as T[]) : [];
   }
 
-  private addEntityToIndexes<T extends Entity>(entity: T, meta: EntityMetadata): void {
-    const typeName = meta.type;
-    const typeIndexes = this.#indexes.get(typeName)!;
-    const typeM2oIndexes = this.#m2oIndexes.get(typeName)!;
-
-    // Index all fields
+  // `entities` should all be of the exact same subtype
+  private addEntitiesToIndex(meta: EntityMetadata, entities: Entity[]): void {
+    const { tagName } = meta;
+    const indexes = this.#indexes.get(tagName)!;
+    // Iterate over each field so we can do a shared fieldIndex lookup
     for (const [fieldName, field] of Object.entries(meta.allFields)) {
-      try {
-        const value = this.getFieldValue(entity, fieldName);
-        this.addToFieldIndex(entity, meta, fieldName, value);
-      } catch (e) {
-        // Skip fields that can't be read (e.g., unloaded references)
-        continue;
+      let fieldIndex = indexes.get(fieldName);
+      if (!fieldIndex) {
+        fieldIndex = new FieldIndex();
+        indexes.set(fieldName, fieldIndex);
+      }
+      for (const entity of entities) {
+        const value = getFieldValue(entity, fieldName);
+        fieldIndex.add(value, entity);
       }
     }
   }
+}
 
-  private removeEntityFromIndexes<T extends Entity>(entity: T, meta: EntityMetadata): void {
-    const typeName = meta.type;
+// Use the same field access pattern as entityMatches
+function getFieldValue(entity: Entity, fieldName: string): any {
+  const meta = getMetadata(entity);
+  const field = meta.allFields[fieldName] ?? fail();
 
-    // Remove from all field indexes
-    for (const [fieldName, field] of Object.entries(meta.allFields)) {
-      try {
-        const value = this.getFieldValue(entity, fieldName);
-        this.removeFromFieldIndex(entity, meta, fieldName, value);
-      } catch (e) {
-        // Skip fields that can't be read
-        continue;
-      }
-    }
-  }
-
-  private addToFieldIndex<T extends Entity>(entity: T, meta: EntityMetadata, fieldName: string, value: any): void {
-    const typeName = meta.type;
-    const field = meta.allFields[fieldName];
-    if (!field) return;
-
-    if (isManyToOneField(field) || isPolymorphicField(field)) {
-      this.addToM2oIndex(entity, typeName, fieldName, value);
-    } else {
-      this.addToRegularIndex(entity, typeName, fieldName, value);
-    }
-  }
-
-  private removeFromFieldIndex<T extends Entity>(entity: T, meta: EntityMetadata, fieldName: string, value: any): void {
-    const typeName = meta.type;
-    const field = meta.allFields[fieldName];
-    if (!field) return;
-
-    if (isManyToOneField(field) || isPolymorphicField(field)) {
-      this.removeFromM2oIndex(entity, typeName, fieldName, value);
-    } else {
-      this.removeFromRegularIndex(entity, typeName, fieldName, value);
-    }
-  }
-
-  private addToRegularIndex(entity: Entity, typeName: string, fieldName: string, value: any): void {
-    const typeIndexes = this.#indexes.get(typeName)!;
-
-    if (!typeIndexes.has(fieldName)) {
-      typeIndexes.set(fieldName, new Map());
-    }
-
-    const fieldIndex = typeIndexes.get(fieldName)!;
-    if (!fieldIndex.has(value)) {
-      fieldIndex.set(value, new Set());
-    }
-
-    fieldIndex.get(value)!.add(entity);
-  }
-
-  private removeFromRegularIndex(entity: Entity, typeName: string, fieldName: string, value: any): void {
-    const typeIndexes = this.#indexes.get(typeName);
-    if (!typeIndexes) return;
-
-    const fieldIndex = typeIndexes.get(fieldName);
-    if (!fieldIndex) return;
-
-    const valueSet = fieldIndex.get(value);
-    if (valueSet) {
-      valueSet.delete(entity);
-      if (valueSet.size === 0) {
-        fieldIndex.delete(value);
-      }
-    }
-  }
-
-  private addToM2oIndex(entity: Entity, typeName: string, fieldName: string, value: any): void {
-    const typeM2oIndexes = this.#m2oIndexes.get(typeName)!;
-
-    if (!typeM2oIndexes.has(fieldName)) {
-      typeM2oIndexes.set(fieldName, {
-        byId: new Map(),
-        byInstance: new Map(),
-        byNull: new Set(),
-      });
-    }
-
-    const m2oIndex = typeM2oIndexes.get(fieldName)!;
-
-    if (value === null || value === undefined) {
-      m2oIndex.byNull.add(entity);
-    } else if (isEntity(value)) {
-      if (value.isNewEntity) {
-        // Unsaved entity - index by instance
-        if (!m2oIndex.byInstance.has(value)) {
-          m2oIndex.byInstance.set(value, new Set());
-        }
-        m2oIndex.byInstance.get(value)!.add(entity);
+  const fn = fieldName as keyof Entity;
+  switch (field.kind) {
+    case "primaryKey":
+      return entity.idTaggedMaybe;
+    case "enum":
+    case "primitive":
+      return (entity as any)[fn];
+    case "m2o":
+    case "poly":
+      const relation = (entity as any)[fn] as
+        | ManyToOneReference<Entity, any, any>
+        | PolymorphicReference<Entity, any, any>;
+      if (isLoadedReference(relation)) {
+        return relation.get;
+      } else if (relation.isSet) {
+        return relation.id;
       } else {
-        // Saved entity - index by ID
-        const id = value.idTaggedMaybe || value.id;
-        if (id) {
-          const idStr = String(id);
-          if (!m2oIndex.byId.has(idStr)) {
-            m2oIndex.byId.set(idStr, new Set());
-          }
-          m2oIndex.byId.get(idStr)!.add(entity);
-        }
-      }
-    } else if (typeof value === "string") {
-      // Direct ID reference
-      if (!m2oIndex.byId.has(value)) {
-        m2oIndex.byId.set(value, new Set());
-      }
-      m2oIndex.byId.get(value)!.add(entity);
-    }
-  }
-
-  private removeFromM2oIndex(entity: Entity, typeName: string, fieldName: string, value: any): void {
-    const typeM2oIndexes = this.#m2oIndexes.get(typeName);
-    if (!typeM2oIndexes) return;
-
-    const m2oIndex = typeM2oIndexes.get(fieldName);
-    if (!m2oIndex) return;
-
-    if (value === null || value === undefined) {
-      m2oIndex.byNull.delete(entity);
-    } else if (isEntity(value)) {
-      if (value.isNewEntity) {
-        const instanceSet = m2oIndex.byInstance.get(value);
-        if (instanceSet) {
-          instanceSet.delete(entity);
-          if (instanceSet.size === 0) {
-            m2oIndex.byInstance.delete(value);
-          }
-        }
-      } else {
-        const id = value.idTaggedMaybe || value.id;
-        if (id) {
-          const idStr = String(id);
-          const idSet = m2oIndex.byId.get(idStr);
-          if (idSet) {
-            idSet.delete(entity);
-            if (idSet.size === 0) {
-              m2oIndex.byId.delete(idStr);
-            }
-          }
-        }
-      }
-    } else if (typeof value === "string") {
-      const idSet = m2oIndex.byId.get(value);
-      if (idSet) {
-        idSet.delete(entity);
-        if (idSet.size === 0) {
-          m2oIndex.byId.delete(value);
-        }
-      }
-    }
-  }
-
-  private getFieldMatches(
-    typeIndexes: EntityFieldIndexes,
-    typeM2oIndexes: Map<FieldName, M2oIndex>,
-    fieldName: string,
-    value: any,
-  ): Set<Entity> {
-    // Check if it's an m2o field
-    const m2oIndex = typeM2oIndexes.get(fieldName);
-    if (m2oIndex) {
-      return this.getM2oMatches(m2oIndex, value);
-    }
-
-    // Regular field index
-    const fieldIndex = typeIndexes.get(fieldName);
-    if (!fieldIndex) {
-      return new Set(); // No index for this field
-    }
-
-    return fieldIndex.get(value) || new Set();
-  }
-
-  private getM2oMatches(m2oIndex: M2oIndex, value: any): Set<Entity> {
-    if (value === null || value === undefined) {
-      return new Set(m2oIndex.byNull);
-    } else if (isEntity(value)) {
-      if (value.isNewEntity) {
-        return m2oIndex.byInstance.get(value) || new Set();
-      } else {
-        const id = value.idTaggedMaybe || value.id;
-        return id ? m2oIndex.byId.get(String(id)) || new Set() : new Set();
-      }
-    } else if (typeof value === "string") {
-      return m2oIndex.byId.get(value) || new Set();
-    }
-
-    return new Set();
-  }
-
-  private intersectSets(set1: Set<Entity>, set2: Set<Entity>): Set<Entity> {
-    const result = new Set<Entity>();
-    for (const entity of set1) {
-      if (set2.has(entity)) {
-        result.add(entity);
-      }
-    }
-    return result;
-  }
-
-  private getFieldValue(entity: Entity, fieldName: string): any {
-    // Use the same field access pattern as entityMatches
-    const meta = getMetadata(entity);
-    const field = meta.allFields[fieldName];
-    if (!field) return undefined;
-
-    const fn = fieldName as keyof Entity;
-    switch (field.kind) {
-      case "primaryKey":
-      case "enum":
-      case "primitive":
-        return (entity as any)[fn];
-      case "m2o":
-      case "poly":
-        const relation = (entity as any)[fn] as
-          | ManyToOneReference<Entity, any, any>
-          | PolymorphicReference<Entity, any, any>;
-        if (isLoadedReference(relation)) {
-          return relation.get;
-        } else if (relation.isSet) {
-          return relation.id;
-        } else {
-          return undefined;
-        }
-      default:
         return undefined;
+      }
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * For a given field, like `firstName`, holds the reverse index of value `bob` -> entities `[a1, a2]`.
+ *
+ * This also handles indexes `Entity` values as both instances & IDs, to handle both:
+ * - new/unpersisted entities not yet having IDs, and
+ * - relations not having loaded their instances yet
+ */
+class FieldIndex {
+  readonly #valueToEntities = new Map<FieldValue, Set<Entity>>();
+
+  /** @return entities that have `value` as their current value for this field. */
+  get(value: any): Set<Entity> | undefined {
+    if (isEntity(value) && value.idTaggedMaybe) {
+      // If `value` is a persisted entity like `a:1`, and entities could have indexed their `author_id=a:1` field
+      // values as the unloaded "just an a:1 string id" value, before `a:1` was loaded into memory.
+      const matchId = this.#valueToEntities.get(value.idTaggedMaybe);
+      // But other entities could also have indexes `a:1` as an instance, so go ahead and check both
+      const matchInstance = this.#valueToEntities.get(value);
+      if (matchId && matchInstance) {
+        return new Set([...matchId, ...matchInstance]);
+      }
+      return matchId ?? matchInstance;
+    }
+    return this.#valueToEntities.get(value);
+  }
+
+  add(value: any, entity: Entity): void {
+    // If this is an entity, store both the entity itself & its ID
+    if (isEntity(value) && value.idTaggedMaybe) {
+      this.doAdd(value.idTaggedMaybe, entity);
+    }
+    this.doAdd(value, entity);
+  }
+
+  remove(value: any, entity: Entity): void {
+    if (isEntity(value) && value.idTaggedMaybe) {
+      this.doRemove(value.idTaggedMaybe, entity);
+    }
+    this.doRemove(value, entity);
+  }
+
+  private doAdd(value: any, entity: Entity): void {
+    if (!this.#valueToEntities.has(value)) {
+      this.#valueToEntities.set(value, new Set());
+    }
+    this.#valueToEntities.get(value)!.add(entity);
+  }
+
+  private doRemove(value: any, entity: Entity): void {
+    const entities = this.#valueToEntities.get(value);
+    if (entities) {
+      entities.delete(entity);
+      if (entities.size === 0) {
+        this.#valueToEntities.delete(value);
+      }
     }
   }
+}
+
+function intersectSets<T>(set1: Set<T>, set2: Set<T>): Set<T> {
+  const result = new Set<T>();
+  for (const e of set1) {
+    if (set2.has(e)) result.add(e);
+  }
+  return result;
 }

--- a/packages/orm/src/IndexManager.ts
+++ b/packages/orm/src/IndexManager.ts
@@ -185,17 +185,16 @@ class FieldIndex {
   }
 
   private doAdd(value: any, entity: Entity): void {
-    if (!this.#valueToEntities.has(value)) {
-      this.#valueToEntities.set(value, new Set());
-    }
-    this.#valueToEntities.get(value)!.add(entity);
+    const set = this.#valueToEntities.get(value) ?? new Set();
+    if (set.size === 0) this.#valueToEntities.set(value, set);
+    set.add(entity);
   }
 
   private doRemove(value: any, entity: Entity): void {
-    const entities = this.#valueToEntities.get(value);
-    if (entities) {
-      entities.delete(entity);
-      if (entities.size === 0) {
+    const set = this.#valueToEntities.get(value);
+    if (set) {
+      set.delete(entity);
+      if (set.size === 0) {
         this.#valueToEntities.delete(value);
       }
     }

--- a/packages/orm/src/IndexManager.ts
+++ b/packages/orm/src/IndexManager.ts
@@ -18,7 +18,8 @@ type EntityTag = string;
 export class IndexManager {
   readonly #indexes: Map<EntityTag, Map<FieldName, FieldIndex>> = new Map();
   readonly #indexedTags: Set<EntityTag> = new Set();
-  readonly #indexThreshold = 1_000;
+  // The test reproducing a n^2 with n=500 went from 100ms to 50ms if indexed
+  readonly #indexThreshold = 500;
 
   /** @return if we should index entities of this type/count. */
   shouldIndexType(entityCount: number): boolean {

--- a/packages/orm/src/IndexManager.ts
+++ b/packages/orm/src/IndexManager.ts
@@ -7,6 +7,9 @@ type FieldValue = any;
 type FieldName = string;
 type EntityTag = string;
 
+// The test reproducing a n^2 with n=500 went from 100ms to 50ms if indexed
+const indexThreshold = 500;
+
 /**
  * IndexManager provides field-based indexing for entity queries to avoid O(n) linear scans of `em.entities`.
  *
@@ -17,12 +20,10 @@ type EntityTag = string;
  */
 export class IndexManager {
   readonly #indexes: Map<EntityTag, Map<FieldName, FieldIndex>> = new Map();
-  // The test reproducing a n^2 with n=500 went from 100ms to 50ms if indexed
-  readonly #indexThreshold = 500;
 
   /** @return if we should index entities of this type/count. */
   shouldIndexType(entityCount: number): boolean {
-    return entityCount >= this.#indexThreshold;
+    return entityCount >= indexThreshold;
   }
 
   /** Visible for testing. */

--- a/packages/orm/src/fields.ts
+++ b/packages/orm/src/fields.ts
@@ -89,6 +89,10 @@ export function setField(entity: Entity, fieldName: string, newValue: any): bool
   // "Un-dirty" our originalData if newValue is reverting to originalData
   if (fieldName in originalData) {
     if (equalOrSameEntity(originalData[fieldName], newValue)) {
+      const currentValue = getField(entity, fieldName);
+      // Update field indexes if the entity type is indexed
+      getEmInternalApi(em).indexManager.updateFieldIndex(entity, fieldName, currentValue, newValue);
+      
       data[fieldName] = newValue;
       delete originalData[fieldName];
       fieldLogger?.logSet(entity, fieldName, newValue);
@@ -112,6 +116,10 @@ export function setField(entity: Entity, fieldName: string, newValue: any): bool
   }
   fieldLogger?.logSet(entity, fieldName, newValue);
   getEmInternalApi(em).rm.queueDownstreamReactiveFields(entity, fieldName);
+  
+  // Update field indexes if the entity type is indexed
+  getEmInternalApi(em).indexManager.updateFieldIndex(entity, fieldName, currentValue, newValue);
+  
   data[fieldName] = newValue;
   return true;
 }

--- a/packages/orm/src/fields.ts
+++ b/packages/orm/src/fields.ts
@@ -92,7 +92,7 @@ export function setField(entity: Entity, fieldName: string, newValue: any): bool
       const currentValue = getField(entity, fieldName);
       // Update field indexes if the entity type is indexed
       getEmInternalApi(em).indexManager.updateFieldIndex(entity, fieldName, currentValue, newValue);
-      
+
       data[fieldName] = newValue;
       delete originalData[fieldName];
       fieldLogger?.logSet(entity, fieldName, newValue);
@@ -116,10 +116,10 @@ export function setField(entity: Entity, fieldName: string, newValue: any): bool
   }
   fieldLogger?.logSet(entity, fieldName, newValue);
   getEmInternalApi(em).rm.queueDownstreamReactiveFields(entity, fieldName);
-  
+
   // Update field indexes if the entity type is indexed
   getEmInternalApi(em).indexManager.updateFieldIndex(entity, fieldName, currentValue, newValue);
-  
+
   data[fieldName] = newValue;
   return true;
 }

--- a/packages/orm/src/fields.ts
+++ b/packages/orm/src/fields.ts
@@ -90,8 +90,7 @@ export function setField(entity: Entity, fieldName: string, newValue: any): bool
   if (fieldName in originalData) {
     if (equalOrSameEntity(originalData[fieldName], newValue)) {
       const currentValue = getField(entity, fieldName);
-      // Update field indexes if the entity type is indexed
-      getEmInternalApi(em).indexManager.updateFieldIndex(entity, fieldName, currentValue, newValue);
+      getEmInternalApi(em).indexManager.maybeUpdateFieldIndex(entity, fieldName, currentValue, newValue);
 
       data[fieldName] = newValue;
       delete originalData[fieldName];
@@ -117,8 +116,7 @@ export function setField(entity: Entity, fieldName: string, newValue: any): bool
   fieldLogger?.logSet(entity, fieldName, newValue);
   getEmInternalApi(em).rm.queueDownstreamReactiveFields(entity, fieldName);
 
-  // Update field indexes if the entity type is indexed
-  getEmInternalApi(em).indexManager.updateFieldIndex(entity, fieldName, currentValue, newValue);
+  getEmInternalApi(em).indexManager.maybeUpdateFieldIndex(entity, fieldName, currentValue, newValue);
 
   data[fieldName] = newValue;
   return true;

--- a/packages/tests/integration/src/EntityManager.factories.test.ts
+++ b/packages/tests/integration/src/EntityManager.factories.test.ts
@@ -29,8 +29,8 @@ import {
   SmallPublisher,
 } from "@src/entities";
 import { isPreloadingEnabled, newEntityManager, queries, resetQueryCount } from "@src/testEm";
-import { maybeNew, maybeNewPoly, newTestInstance, noValue, setFactoryWriter, testIndex } from "joist-orm";
 import ansiRegex from "ansi-regex";
+import { maybeNew, maybeNewPoly, newTestInstance, noValue, setFactoryWriter, testIndex } from "joist-orm";
 
 let factoryOutput: string[] = [];
 

--- a/packages/tests/integration/src/EntityManager.findWithNewOrChanged.test.ts
+++ b/packages/tests/integration/src/EntityManager.findWithNewOrChanged.test.ts
@@ -1,5 +1,6 @@
 import { insertAuthor, insertPublisher } from "@src/entities/inserts";
 import { newEntityManager } from "@src/testEm";
+import { zeroTo } from "src/utils";
 import { Author, newPublisher } from "./entities";
 
 describe("EntityManager.findWithNewOrChanged", () => {
@@ -35,6 +36,37 @@ describe("EntityManager.findWithNewOrChanged", () => {
     a2.firstName = "a1";
     const authors = await em.findWithNewOrChanged(Author, { firstName: "a1" });
     expect(authors).toMatchEntity([{ firstName: "a1" }]);
+  });
+
+  it("should handle large datasets efficiently with IndexManager", async () => {
+    const em = newEntityManager();
+    const n = 5_000;
+
+    // Create entities to trigger indexing
+    for (let i = 0; i < n; i++) {
+      em.create(Author, { firstName: `Author${i}` });
+    }
+
+    // Verify indexing is enabled after crossing threshold
+    const indexManager = (em as any)["__api"].indexManager;
+    expect(indexManager.indexedTypes.has("Author")).toBe(true);
+
+    // Test that searches are now efficient
+    const start = performance.now();
+    const promises = zeroTo(1000).map((i) => {
+      return em.findWithNewOrChanged(Author, { firstName: `Author${i}` });
+    });
+    const results = await Promise.all(promises);
+    const end = performance.now();
+
+    // Should complete much faster than linear O(n) search
+    expect(end - start).toBeLessThan(200); // 200ms for 1000 searches
+
+    // Verify all searches returned correct results
+    results.forEach((result, i) => {
+      expect(result.length).toBe(1);
+      expect(result[0].firstName).toBe(`Author${i}`);
+    });
   });
 
   it("ignores changed entities", async () => {
@@ -127,5 +159,136 @@ describe("EntityManager.findWithNewOrChanged", () => {
     const em = newEntityManager();
     const authors = await em.findWithNewOrChanged(Author, { publisher: null });
     expect(authors).toMatchEntity([{ firstName: "a3" }]);
+  });
+
+  describe("Performance with IndexManager", () => {
+    it("should perform efficiently with large entity counts using indexes", async () => {
+      const em = newEntityManager();
+      const n = 5_000;
+
+      // Create enough entities to trigger indexing (>1000)
+      const authors = [];
+      for (let i = 0; i < n; i++) {
+        authors.push(em.create(Author, { firstName: `Author${i}` }));
+      }
+
+      // Verify indexing is enabled
+      const indexManager = (em as any)["__api"].indexManager;
+      // expect(indexManager.indexedTypes.has("Author")).toBe(true);
+
+      // Test performance of multiple searches
+      const start = performance.now();
+
+      // Mimic and life-cycle hook running for all `n` entities, i.e. would be an `n^2` if findWithNewOrChanged is linear
+      const promises = [];
+      for (let i = 0; i < n; i++) {
+        const searchIndex = Math.floor(Math.random() * n);
+        promises.push(em.findWithNewOrChanged(Author, { firstName: `Author${searchIndex}` }));
+      }
+
+      const results = await Promise.all(promises);
+      const end = performance.now();
+
+      // Should complete in reasonable time (much faster than O(n) linear search)
+      expect(end - start).toBeLessThan(n); // allow Nms for n searches
+
+      // Verify correctness
+      results.forEach((result) => {
+        expect(result.length).toBe(1);
+      });
+    });
+
+    it("should handle updates efficiently with indexes", async () => {
+      const em = newEntityManager();
+      const n = 2_000;
+
+      // Create enough entities to trigger indexing
+      const authors = [];
+      for (let i = 0; i < n; i++) {
+        authors.push(em.create(Author, { firstName: `Author${i}` }));
+      }
+
+      const start = performance.now();
+
+      // Update many entities
+      for (let i = 0; i < 500; i++) {
+        authors[i].firstName = `Updated${i}`;
+      }
+
+      // Search for updated entities
+      const promises = [];
+      for (let i = 0; i < 100; i++) {
+        promises.push(em.findWithNewOrChanged(Author, { firstName: `Updated${i}` }));
+      }
+
+      const results = await Promise.all(promises);
+      const end = performance.now();
+
+      // Should complete efficiently
+      expect(end - start).toBeLessThan(50);
+
+      // Verify correctness
+      results.forEach((result, i) => {
+        expect(result.length).toBe(1);
+        expect(result[0].firstName).toBe(`Updated${i}`);
+      });
+    });
+
+    it("should handle m2o relationships efficiently with indexes", async () => {
+      const em = newEntityManager();
+      const n = 3_000;
+
+      // Create publishers
+      const publishers = [];
+      for (let i = 0; i < 10; i++) {
+        publishers.push(newPublisher(em, { name: `Publisher${i}` }));
+      }
+
+      // Create enough authors to trigger indexing
+      const authors = [];
+      for (let i = 0; i < n; i++) {
+        const publisher = publishers[i % 10];
+        authors.push(
+          em.create(Author, {
+            firstName: `Author${i}`,
+            publisher,
+          }),
+        );
+      }
+
+      const start = performance.now();
+
+      // Search by different publishers
+      const promises = [];
+      for (let i = 0; i < 50; i++) {
+        const publisherIndex = i % 10;
+        promises.push(em.findWithNewOrChanged(Author, { publisher: publishers[publisherIndex] }));
+      }
+
+      const results = await Promise.all(promises);
+      const end = performance.now();
+
+      // Should complete efficiently
+      expect(end - start).toBeLessThan(25);
+
+      // Verify correctness - each publisher should have n/10 authors
+      results.forEach((result) => {
+        expect(result.length).toBe(n / 10);
+      });
+    });
+
+    it("should gracefully fall back to linear search for small datasets", async () => {
+      const em = newEntityManager();
+
+      // Create small number of authors (below threshold) to test linear search
+      const authors = [];
+      for (let i = 0; i < 100; i++) {
+        authors.push(em.create(Author, { firstName: `SmallAuthor${i}` }));
+      }
+
+      // Should still work correctly with linear search (since we only have 100 authors)
+      const found = await em.findWithNewOrChanged(Author, { firstName: "SmallAuthor50" });
+      expect(found).toMatchEntity([authors[50]]);
+    });
   });
 });

--- a/packages/tests/integration/src/IndexManager.test.ts
+++ b/packages/tests/integration/src/IndexManager.test.ts
@@ -1,0 +1,221 @@
+import { newEntityManager } from "@src/testEm";
+import { Author, Publisher, newAuthor, newPublisher } from "./entities";
+
+describe("IndexManager", () => {
+  it("should not enable indexing for entity types with < 1000 entities", async () => {
+    const em = newEntityManager();
+    
+    // Create 999 authors
+    for (let i = 0; i < 999; i++) {
+      em.create(Author, { firstName: `Author${i}` });
+    }
+    
+    // IndexManager should not be enabled for Author type
+    const indexManager = (em as any)["__api"].indexManager;
+    expect(indexManager.indexedTypes.has("Author")).toBe(false);
+  });
+
+  it("should enable indexing when entity count reaches 1000", async () => {
+    const em = newEntityManager();
+    
+    // Create exactly 1000 authors
+    for (let i = 0; i < 1000; i++) {
+      em.create(Author, { firstName: `Author${i}` });
+    }
+    
+    // IndexManager should now be enabled for Author type
+    const indexManager = (em as any)["__api"].indexManager;
+    expect(indexManager.indexedTypes.has("Author")).toBe(true);
+  });
+
+  it("should find entities using indexes when enabled", async () => {
+    const em = newEntityManager();
+    
+    // Create 1100 authors to trigger indexing
+    const authors = [];
+    for (let i = 0; i < 1100; i++) {
+      authors.push(em.create(Author, { firstName: `Author${i}` }));
+    }
+    
+    // Should use indexed search
+    const found = await em.findWithNewOrChanged(Author, { firstName: "Author500" });
+    expect(found).toMatchEntity([authors[500]]);
+  });
+
+  it("should handle m2o fields with saved entities", async () => {
+    const em = newEntityManager();
+    
+    // Create publisher first and flush to get ID
+    const publisher = newPublisher(em, { name: "Test Publisher" });
+    // Create a dummy author for LargePublisher validation
+    const spotlightAuthor = em.create(Author, { firstName: "Spotlight" });
+    if ('spotlightAuthor' in publisher) {
+      (publisher as any).spotlightAuthor.set(spotlightAuthor);
+    }
+    await em.flush();
+    
+    // Create 1000+ authors to trigger indexing
+    const authors = [];
+    for (let i = 0; i < 1100; i++) {
+      const author = em.create(Author, { 
+        firstName: `Author${i}`,
+        publisher: i < 500 ? publisher : undefined
+      });
+      authors.push(author);
+    }
+    
+    // Should find authors by publisher using indexes
+    const found = await em.findWithNewOrChanged(Author, { publisher });
+    expect(found.length).toBe(500);
+    expect(found).toMatchEntity(authors.slice(0, 500));
+  });
+
+  it("should handle m2o fields with unsaved entities", async () => {
+    const em = newEntityManager();
+    
+    // Create unsaved publisher
+    const publisher = newPublisher(em, { name: "Unsaved Publisher" });
+    
+    // Create 1000+ authors to trigger indexing
+    const authors = [];
+    for (let i = 0; i < 1100; i++) {
+      const author = em.create(Author, { 
+        firstName: `Author${i}`,
+        publisher: i < 300 ? publisher : undefined
+      });
+      authors.push(author);
+    }
+    
+    // Should find authors by unsaved publisher using instance-based index
+    const found = await em.findWithNewOrChanged(Author, { publisher });
+    expect(found.length).toBe(300);
+    expect(found).toMatchEntity(authors.slice(0, 300));
+  });
+
+  it("should handle null/undefined m2o fields", async () => {
+    const em = newEntityManager();
+    
+    // Create 1000+ authors to trigger indexing
+    const authors = [];
+    for (let i = 0; i < 1100; i++) {
+      const author = em.create(Author, { 
+        firstName: `NullAuthor${i}`
+        // Don't set publisher to leave it undefined
+      });
+      authors.push(author);
+    }
+    
+    // Should find authors with null publisher
+    const found = await em.findWithNewOrChanged(Author, { publisher: undefined });
+    expect(found.length).toBe(1100);
+  });
+
+  it("should update indexes when field values change", async () => {
+    const em = newEntityManager();
+    
+    // Create 1000+ authors to trigger indexing
+    const authors = [];
+    for (let i = 0; i < 1100; i++) {
+      authors.push(em.create(Author, { firstName: `Author${i}` }));
+    }
+    
+    // Change an author's name
+    authors[500].firstName = "Changed Name";
+    
+    // Should find by new name
+    const foundByNew = await em.findWithNewOrChanged(Author, { firstName: "Changed Name" });
+    expect(foundByNew).toMatchEntity([authors[500]]);
+    
+    // Should not find by old name
+    const foundByOld = await em.findWithNewOrChanged(Author, { firstName: "Author500" });
+    expect(foundByOld).toMatchEntity([]);
+  });
+
+  it("should handle complex queries with multiple fields", async () => {
+    const em = newEntityManager();
+    
+    const publisher1 = newPublisher(em, { name: "Publisher 1" });
+    const publisher2 = newPublisher(em, { name: "Publisher 2" });
+    
+    // Create 1000+ authors to trigger indexing
+    for (let i = 0; i < 1100; i++) {
+      em.create(Author, { 
+        firstName: i % 2 === 0 ? "Even" : "Odd",
+        lastName: `Author${i}`,
+        publisher: i < 500 ? publisher1 : i < 800 ? publisher2 : undefined
+      });
+    }
+    
+    // Should find authors matching multiple criteria
+    const found = await em.findWithNewOrChanged(Author, { 
+      firstName: "Even",
+      publisher: publisher1
+    });
+    
+    // Should find even-numbered authors (0, 2, 4, ..., 498) with publisher1
+    expect(found.length).toBe(250); // 500 authors with publisher1, half are even
+  });
+
+  it("should fall back to linear search for non-indexed types", async () => {
+    const em = newEntityManager();
+    
+    // Create only 100 authors (below threshold) to test linear search
+    const authors = [];
+    for (let i = 0; i < 100; i++) {
+      authors.push(em.create(Author, { firstName: `TestAuthor${i}` }));
+    }
+    
+    // Should use linear search since we're below the threshold
+    const found = await em.findWithNewOrChanged(Author, { firstName: "TestAuthor50" });
+    expect(found).toMatchEntity([authors[50]]);
+    
+    // Verify Author type is not indexed (below threshold)
+    const indexManager = (em as any)["__api"].indexManager;
+    expect(indexManager.indexedTypes.has("Author")).toBe(false);
+  });
+
+  it("should handle entity deletion from indexes", async () => {
+    const em = newEntityManager();
+    
+    // Create 1000+ authors to trigger indexing
+    const authors = [];
+    for (let i = 0; i < 1100; i++) {
+      authors.push(em.create(Author, { firstName: `Author${i}` }));
+    }
+    
+    // Delete an author
+    em.delete(authors[500]);
+    
+    // Should not find deleted author
+    const found = await em.findWithNewOrChanged(Author, { firstName: "Author500" });
+    expect(found).toMatchEntity([]);
+  });
+
+  it("should maintain index consistency during field updates", async () => {
+    const em = newEntityManager();
+    
+    const publisher1 = newPublisher(em, { name: "Publisher 1" });
+    const publisher2 = newPublisher(em, { name: "Publisher 2" });
+    
+    // Create 1000+ authors to trigger indexing
+    const authors = [];
+    for (let i = 0; i < 1100; i++) {
+      authors.push(em.create(Author, { 
+        firstName: `Author${i}`,
+        publisher: publisher1
+      }));
+    }
+    
+    // Change publisher for some authors
+    for (let i = 0; i < 100; i++) {
+      authors[i].publisher.set(publisher2);
+    }
+    
+    // Verify correct distribution
+    const foundPub1 = await em.findWithNewOrChanged(Author, { publisher: publisher1 });
+    const foundPub2 = await em.findWithNewOrChanged(Author, { publisher: publisher2 });
+    
+    expect(foundPub1.length).toBe(1000); // 1100 - 100 = 1000
+    expect(foundPub2.length).toBe(100);
+  });
+});

--- a/packages/tests/integration/src/IndexManager.test.ts
+++ b/packages/tests/integration/src/IndexManager.test.ts
@@ -4,12 +4,10 @@ import { Author, newPublisher } from "./entities";
 import { zeroTo } from "./utils";
 
 describe("IndexManager", () => {
-  it("should not enable indexing for entity types with < 1000 entities", async () => {
+  it("should not enable indexing for entity types with < 500 entities", async () => {
     const em = newEntityManager();
-    // Create 999 authors
-    for (let i = 0; i < 999; i++) {
-      em.create(Author, { firstName: `Author${i}` });
-    }
+    // Create 499 authors
+    zeroTo(499).forEach((i) => em.create(Author, { firstName: `Author${i}` }));
     // And `find...` to potentially trigger index creation
     await em.findWithNewOrChanged(Author, { firstName: "..." });
     // Then indexing should not be enabled for Author type

--- a/packages/tests/integration/src/IndexManager.test.ts
+++ b/packages/tests/integration/src/IndexManager.test.ts
@@ -1,42 +1,37 @@
 import { newEntityManager } from "@src/testEm";
+import { getEmInternalApi } from "joist-orm";
 import { Author, newPublisher } from "./entities";
+import { zeroTo } from "./utils";
 
 describe("IndexManager", () => {
   it("should not enable indexing for entity types with < 1000 entities", async () => {
     const em = newEntityManager();
-
     // Create 999 authors
     for (let i = 0; i < 999; i++) {
       em.create(Author, { firstName: `Author${i}` });
     }
-
-    // IndexManager should not be enabled for Author type
-    const indexManager = (em as any)["__api"].indexManager;
-    expect(indexManager.indexedTypes.has("Author")).toBe(false);
+    // And `find...` to potentially trigger index creation
+    await em.findWithNewOrChanged(Author, { firstName: "..." });
+    // Then indexing should not be enabled for Author type
+    expect(getEmInternalApi(em).indexManager.isIndexed("a")).toBe(false);
   });
 
   it("should enable indexing when entity count reaches 1000", async () => {
     const em = newEntityManager();
-
-    // Create exactly 1000 authors
+    // Create 1000 authors
     for (let i = 0; i < 1000; i++) {
       em.create(Author, { firstName: `Author${i}` });
     }
-
+    // And `find...` to potentially trigger index creation
+    await em.findWithNewOrChanged(Author, { firstName: "..." });
     // IndexManager should now be enabled for Author type
-    const indexManager = (em as any)["__api"].indexManager;
-    expect(indexManager.indexedTypes.has("Author")).toBe(true);
+    expect(getEmInternalApi(em).indexManager.isIndexed("a")).toBe(true);
   });
 
   it("should find entities using indexes when enabled", async () => {
     const em = newEntityManager();
-
     // Create 1100 authors to trigger indexing
-    const authors = [];
-    for (let i = 0; i < 1100; i++) {
-      authors.push(em.create(Author, { firstName: `Author${i}` }));
-    }
-
+    const authors = zeroTo(1100).map((i) => em.create(Author, { firstName: `Author${i}` }));
     // Should use indexed search
     const found = await em.findWithNewOrChanged(Author, { firstName: "Author500" });
     expect(found).toMatchEntity([authors[500]]);
@@ -44,7 +39,6 @@ describe("IndexManager", () => {
 
   it("should handle m2o fields with saved entities", async () => {
     const em = newEntityManager();
-
     // Create publisher first and flush to get ID
     const publisher = newPublisher(em, { name: "Test Publisher" });
     // Create a dummy author for LargePublisher validation
@@ -53,17 +47,13 @@ describe("IndexManager", () => {
       (publisher as any).spotlightAuthor.set(spotlightAuthor);
     }
     await em.flush();
-
     // Create 1000+ authors to trigger indexing
-    const authors = [];
-    for (let i = 0; i < 1100; i++) {
-      const author = em.create(Author, {
+    const authors = zeroTo(1100).map((i) =>
+      em.create(Author, {
         firstName: `Author${i}`,
         publisher: i < 500 ? publisher : undefined,
-      });
-      authors.push(author);
-    }
-
+      }),
+    );
     // Should find authors by publisher using indexes
     const found = await em.findWithNewOrChanged(Author, { publisher });
     expect(found.length).toBe(500);
@@ -72,20 +62,15 @@ describe("IndexManager", () => {
 
   it("should handle m2o fields with unsaved entities", async () => {
     const em = newEntityManager();
-
     // Create unsaved publisher
     const publisher = newPublisher(em, { name: "Unsaved Publisher" });
-
     // Create 1000+ authors to trigger indexing
-    const authors = [];
-    for (let i = 0; i < 1100; i++) {
-      const author = em.create(Author, {
+    const authors = zeroTo(1100).map((i) =>
+      em.create(Author, {
         firstName: `Author${i}`,
         publisher: i < 300 ? publisher : undefined,
-      });
-      authors.push(author);
-    }
-
+      }),
+    );
     // Should find authors by unsaved publisher using instance-based index
     const found = await em.findWithNewOrChanged(Author, { publisher });
     expect(found.length).toBe(300);
@@ -94,17 +79,13 @@ describe("IndexManager", () => {
 
   it("should handle null/undefined m2o fields", async () => {
     const em = newEntityManager();
-
     // Create 1000+ authors to trigger indexing
-    const authors = [];
-    for (let i = 0; i < 1100; i++) {
-      const author = em.create(Author, {
+    const authors = zeroTo(1100).map((i) =>
+      em.create(Author, {
         firstName: `NullAuthor${i}`,
         // Don't set publisher to leave it undefined
-      });
-      authors.push(author);
-    }
-
+      }),
+    );
     // Should find authors with null publisher
     const found = await em.findWithNewOrChanged(Author, { publisher: undefined });
     expect(found.length).toBe(1100);
@@ -112,20 +93,13 @@ describe("IndexManager", () => {
 
   it("should update indexes when field values change", async () => {
     const em = newEntityManager();
-
     // Create 1000+ authors to trigger indexing
-    const authors = [];
-    for (let i = 0; i < 1100; i++) {
-      authors.push(em.create(Author, { firstName: `Author${i}` }));
-    }
-
+    const authors = zeroTo(1100).map((i) => em.create(Author, { firstName: `Author${i}` }));
     // Change an author's name
     authors[500].firstName = "Changed Name";
-
     // Should find by new name
     const foundByNew = await em.findWithNewOrChanged(Author, { firstName: "Changed Name" });
     expect(foundByNew).toMatchEntity([authors[500]]);
-
     // Should not find by old name
     const foundByOld = await em.findWithNewOrChanged(Author, { firstName: "Author500" });
     expect(foundByOld).toMatchEntity([]);
@@ -133,10 +107,8 @@ describe("IndexManager", () => {
 
   it("should handle complex queries with multiple fields", async () => {
     const em = newEntityManager();
-
     const publisher1 = newPublisher(em, { name: "Publisher 1" });
     const publisher2 = newPublisher(em, { name: "Publisher 2" });
-
     // Create 1000+ authors to trigger indexing
     for (let i = 0; i < 1100; i++) {
       em.create(Author, {
@@ -145,47 +117,32 @@ describe("IndexManager", () => {
         publisher: i < 500 ? publisher1 : i < 800 ? publisher2 : undefined,
       });
     }
-
     // Should find authors matching multiple criteria
     const found = await em.findWithNewOrChanged(Author, {
       firstName: "Even",
       publisher: publisher1,
     });
-
     // Should find even-numbered authors (0, 2, 4, ..., 498) with publisher1
     expect(found.length).toBe(250); // 500 authors with publisher1, half are even
   });
 
   it("should fall back to linear search for non-indexed types", async () => {
     const em = newEntityManager();
-
     // Create only 100 authors (below threshold) to test linear search
-    const authors = [];
-    for (let i = 0; i < 100; i++) {
-      authors.push(em.create(Author, { firstName: `TestAuthor${i}` }));
-    }
-
+    const authors = zeroTo(100).map((i) => em.create(Author, { firstName: `TestAuthor${i}` }));
     // Should use linear search since we're below the threshold
     const found = await em.findWithNewOrChanged(Author, { firstName: "TestAuthor50" });
     expect(found).toMatchEntity([authors[50]]);
-
     // Verify Author type is not indexed (below threshold)
-    const indexManager = (em as any)["__api"].indexManager;
-    expect(indexManager.indexedTypes.has("Author")).toBe(false);
+    expect(getEmInternalApi(em).indexManager.isIndexed("a")).toBe(false);
   });
 
   it("should handle entity deletion from indexes", async () => {
     const em = newEntityManager();
-
     // Create 1000+ authors to trigger indexing
-    const authors = [];
-    for (let i = 0; i < 1100; i++) {
-      authors.push(em.create(Author, { firstName: `Author${i}` }));
-    }
-
+    const authors = zeroTo(1100).map((i) => em.create(Author, { firstName: `Author${i}` }));
     // Delete an author
     em.delete(authors[500]);
-
     // Should not find deleted author
     const found = await em.findWithNewOrChanged(Author, { firstName: "Author500" });
     expect(found).toMatchEntity([]);
@@ -193,30 +150,24 @@ describe("IndexManager", () => {
 
   it("should maintain index consistency during field updates", async () => {
     const em = newEntityManager();
-
     const publisher1 = newPublisher(em, { name: "Publisher 1" });
     const publisher2 = newPublisher(em, { name: "Publisher 2" });
-
     // Create 1000+ authors to trigger indexing
-    const authors = [];
-    for (let i = 0; i < 1100; i++) {
-      authors.push(
-        em.create(Author, {
-          firstName: `Author${i}`,
-          publisher: publisher1,
-        }),
-      );
-    }
-
-    // Change publisher for some authors
+    const authors = zeroTo(1100).map((i) =>
+      em.create(Author, {
+        firstName: `Author${i}`,
+        publisher: publisher1,
+      }),
+    );
+    // Do an initial search to trigger indexing of authors
+    await em.findWithNewOrChanged(Author, { publisher: publisher1 });
+    // Then change publisher for some authors
     for (let i = 0; i < 100; i++) {
       authors[i].publisher.set(publisher2);
     }
-
     // Verify correct distribution
     const foundPub1 = await em.findWithNewOrChanged(Author, { publisher: publisher1 });
     const foundPub2 = await em.findWithNewOrChanged(Author, { publisher: publisher2 });
-
     expect(foundPub1.length).toBe(1000); // 1100 - 100 = 1000
     expect(foundPub2.length).toBe(100);
   });

--- a/packages/tests/integration/src/IndexManager.test.ts
+++ b/packages/tests/integration/src/IndexManager.test.ts
@@ -1,15 +1,15 @@
 import { newEntityManager } from "@src/testEm";
-import { Author, Publisher, newAuthor, newPublisher } from "./entities";
+import { Author, newPublisher } from "./entities";
 
 describe("IndexManager", () => {
   it("should not enable indexing for entity types with < 1000 entities", async () => {
     const em = newEntityManager();
-    
+
     // Create 999 authors
     for (let i = 0; i < 999; i++) {
       em.create(Author, { firstName: `Author${i}` });
     }
-    
+
     // IndexManager should not be enabled for Author type
     const indexManager = (em as any)["__api"].indexManager;
     expect(indexManager.indexedTypes.has("Author")).toBe(false);
@@ -17,12 +17,12 @@ describe("IndexManager", () => {
 
   it("should enable indexing when entity count reaches 1000", async () => {
     const em = newEntityManager();
-    
+
     // Create exactly 1000 authors
     for (let i = 0; i < 1000; i++) {
       em.create(Author, { firstName: `Author${i}` });
     }
-    
+
     // IndexManager should now be enabled for Author type
     const indexManager = (em as any)["__api"].indexManager;
     expect(indexManager.indexedTypes.has("Author")).toBe(true);
@@ -30,13 +30,13 @@ describe("IndexManager", () => {
 
   it("should find entities using indexes when enabled", async () => {
     const em = newEntityManager();
-    
+
     // Create 1100 authors to trigger indexing
     const authors = [];
     for (let i = 0; i < 1100; i++) {
       authors.push(em.create(Author, { firstName: `Author${i}` }));
     }
-    
+
     // Should use indexed search
     const found = await em.findWithNewOrChanged(Author, { firstName: "Author500" });
     expect(found).toMatchEntity([authors[500]]);
@@ -44,26 +44,26 @@ describe("IndexManager", () => {
 
   it("should handle m2o fields with saved entities", async () => {
     const em = newEntityManager();
-    
+
     // Create publisher first and flush to get ID
     const publisher = newPublisher(em, { name: "Test Publisher" });
     // Create a dummy author for LargePublisher validation
     const spotlightAuthor = em.create(Author, { firstName: "Spotlight" });
-    if ('spotlightAuthor' in publisher) {
+    if ("spotlightAuthor" in publisher) {
       (publisher as any).spotlightAuthor.set(spotlightAuthor);
     }
     await em.flush();
-    
+
     // Create 1000+ authors to trigger indexing
     const authors = [];
     for (let i = 0; i < 1100; i++) {
-      const author = em.create(Author, { 
+      const author = em.create(Author, {
         firstName: `Author${i}`,
-        publisher: i < 500 ? publisher : undefined
+        publisher: i < 500 ? publisher : undefined,
       });
       authors.push(author);
     }
-    
+
     // Should find authors by publisher using indexes
     const found = await em.findWithNewOrChanged(Author, { publisher });
     expect(found.length).toBe(500);
@@ -72,20 +72,20 @@ describe("IndexManager", () => {
 
   it("should handle m2o fields with unsaved entities", async () => {
     const em = newEntityManager();
-    
+
     // Create unsaved publisher
     const publisher = newPublisher(em, { name: "Unsaved Publisher" });
-    
+
     // Create 1000+ authors to trigger indexing
     const authors = [];
     for (let i = 0; i < 1100; i++) {
-      const author = em.create(Author, { 
+      const author = em.create(Author, {
         firstName: `Author${i}`,
-        publisher: i < 300 ? publisher : undefined
+        publisher: i < 300 ? publisher : undefined,
       });
       authors.push(author);
     }
-    
+
     // Should find authors by unsaved publisher using instance-based index
     const found = await em.findWithNewOrChanged(Author, { publisher });
     expect(found.length).toBe(300);
@@ -94,17 +94,17 @@ describe("IndexManager", () => {
 
   it("should handle null/undefined m2o fields", async () => {
     const em = newEntityManager();
-    
+
     // Create 1000+ authors to trigger indexing
     const authors = [];
     for (let i = 0; i < 1100; i++) {
-      const author = em.create(Author, { 
-        firstName: `NullAuthor${i}`
+      const author = em.create(Author, {
+        firstName: `NullAuthor${i}`,
         // Don't set publisher to leave it undefined
       });
       authors.push(author);
     }
-    
+
     // Should find authors with null publisher
     const found = await em.findWithNewOrChanged(Author, { publisher: undefined });
     expect(found.length).toBe(1100);
@@ -112,20 +112,20 @@ describe("IndexManager", () => {
 
   it("should update indexes when field values change", async () => {
     const em = newEntityManager();
-    
+
     // Create 1000+ authors to trigger indexing
     const authors = [];
     for (let i = 0; i < 1100; i++) {
       authors.push(em.create(Author, { firstName: `Author${i}` }));
     }
-    
+
     // Change an author's name
     authors[500].firstName = "Changed Name";
-    
+
     // Should find by new name
     const foundByNew = await em.findWithNewOrChanged(Author, { firstName: "Changed Name" });
     expect(foundByNew).toMatchEntity([authors[500]]);
-    
+
     // Should not find by old name
     const foundByOld = await em.findWithNewOrChanged(Author, { firstName: "Author500" });
     expect(foundByOld).toMatchEntity([]);
@@ -133,42 +133,42 @@ describe("IndexManager", () => {
 
   it("should handle complex queries with multiple fields", async () => {
     const em = newEntityManager();
-    
+
     const publisher1 = newPublisher(em, { name: "Publisher 1" });
     const publisher2 = newPublisher(em, { name: "Publisher 2" });
-    
+
     // Create 1000+ authors to trigger indexing
     for (let i = 0; i < 1100; i++) {
-      em.create(Author, { 
+      em.create(Author, {
         firstName: i % 2 === 0 ? "Even" : "Odd",
         lastName: `Author${i}`,
-        publisher: i < 500 ? publisher1 : i < 800 ? publisher2 : undefined
+        publisher: i < 500 ? publisher1 : i < 800 ? publisher2 : undefined,
       });
     }
-    
+
     // Should find authors matching multiple criteria
-    const found = await em.findWithNewOrChanged(Author, { 
+    const found = await em.findWithNewOrChanged(Author, {
       firstName: "Even",
-      publisher: publisher1
+      publisher: publisher1,
     });
-    
+
     // Should find even-numbered authors (0, 2, 4, ..., 498) with publisher1
     expect(found.length).toBe(250); // 500 authors with publisher1, half are even
   });
 
   it("should fall back to linear search for non-indexed types", async () => {
     const em = newEntityManager();
-    
+
     // Create only 100 authors (below threshold) to test linear search
     const authors = [];
     for (let i = 0; i < 100; i++) {
       authors.push(em.create(Author, { firstName: `TestAuthor${i}` }));
     }
-    
+
     // Should use linear search since we're below the threshold
     const found = await em.findWithNewOrChanged(Author, { firstName: "TestAuthor50" });
     expect(found).toMatchEntity([authors[50]]);
-    
+
     // Verify Author type is not indexed (below threshold)
     const indexManager = (em as any)["__api"].indexManager;
     expect(indexManager.indexedTypes.has("Author")).toBe(false);
@@ -176,16 +176,16 @@ describe("IndexManager", () => {
 
   it("should handle entity deletion from indexes", async () => {
     const em = newEntityManager();
-    
+
     // Create 1000+ authors to trigger indexing
     const authors = [];
     for (let i = 0; i < 1100; i++) {
       authors.push(em.create(Author, { firstName: `Author${i}` }));
     }
-    
+
     // Delete an author
     em.delete(authors[500]);
-    
+
     // Should not find deleted author
     const found = await em.findWithNewOrChanged(Author, { firstName: "Author500" });
     expect(found).toMatchEntity([]);
@@ -193,28 +193,30 @@ describe("IndexManager", () => {
 
   it("should maintain index consistency during field updates", async () => {
     const em = newEntityManager();
-    
+
     const publisher1 = newPublisher(em, { name: "Publisher 1" });
     const publisher2 = newPublisher(em, { name: "Publisher 2" });
-    
+
     // Create 1000+ authors to trigger indexing
     const authors = [];
     for (let i = 0; i < 1100; i++) {
-      authors.push(em.create(Author, { 
-        firstName: `Author${i}`,
-        publisher: publisher1
-      }));
+      authors.push(
+        em.create(Author, {
+          firstName: `Author${i}`,
+          publisher: publisher1,
+        }),
+      );
     }
-    
+
     // Change publisher for some authors
     for (let i = 0; i < 100; i++) {
       authors[i].publisher.set(publisher2);
     }
-    
+
     // Verify correct distribution
     const foundPub1 = await em.findWithNewOrChanged(Author, { publisher: publisher1 });
     const foundPub2 = await em.findWithNewOrChanged(Author, { publisher: publisher2 });
-    
+
     expect(foundPub1.length).toBe(1000); // 1100 - 100 = 1000
     expect(foundPub2.length).toBe(100);
   });

--- a/packages/tests/integration/src/relations/ReactiveReference.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveReference.test.ts
@@ -1,8 +1,8 @@
 import { Author, Book, BookReview, newAuthor, newPublisher, newSmallPublisher } from "@src/entities";
 import { insertAuthor, insertBook, insertBookReview, insertPublisher, select, update } from "@src/entities/inserts";
 import { newEntityManager, queries, resetQueryCount } from "@src/testEm";
-import { ReactionLogger, setReactionLogging } from "joist-orm";
 import ansiRegex from "ansi-regex";
+import { ReactionLogger, setReactionLogging } from "joist-orm";
 
 let reactionOutput: string[] = [];
 


### PR DESCRIPTION
I didn't really expect to "need in-memory indexing" for Joist, but we've had several lifecycle hooks (like `beforeFlush`) get invoked for ~1,000+ entities (in a large, bulk upload/bulk update), which if the lifecycle does an innocent-looking `em.findWithNewOrChanged`, would turn into a `O(N^2)`.

I.e. 1,000 entities all doing a linear-scan for "did any of the other 1,000 entities `entityMatches(...my find argument...)`".

We can avoid the `O(N^2)` by reverse indexing the field values of the 1,000 entities, and then doing map/set lookups for `entityMatches` instead of a linear scan. 

This test:

```ts
      const em = newEntityManager();
      const n = 5_000;
      // Create entities to trigger indexing
      zeroTo(n).forEach((i) => em.create(Author, { firstName: `Author${i}` }));
      // Test that searches are now efficient
      const start = performance.now();
      const results = await Promise.all(
        zeroTo(n).map((i) => em.findWithNewOrChanged(Author, { firstName: `Author${i}` })),
      );
      const end = performance.now();
```

Without indexing takes 7.5 seconds.

With indexing it takes 314 ms, which is a 23x speedup.

Even with `n=500`, unindexed takes 100ms and indexes takes 50ms. So I'm going to set the threshold at 500.

To avoid the overhead of indexing entities unnecessarily, we only enable the index when:

- There is at least 500 instances of a given entity type in memory, and
- `findWithNewOrChanged` (or `findOrCreate` in a follow-up PR) is called

...technically if we have 1,000 instances, and there is only _one_ call to `findWithNewOrChanged`, we have probably indexed unnecessarily, so we could potentially count the number of `findWithNewOrChanged` invocations and only index after ~2-3 calls, i.e. as a heuristic to guess "we're probably in an `O(n^2)`".
