### PR TITLE
feat: Add indexing to m2m JoinRows.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -17,7 +17,6 @@ import { Driver } from "./drivers";
 import { Entity, Entity as EntityW, IdType, isEntity } from "./Entity";
 import { FlushLock } from "./FlushLock";
 import {
-  BaseEntity,
   CustomCollection,
   CustomReference,
   DeepPartialOrNull,
@@ -2045,10 +2044,7 @@ async function validateReactiveRules(
   });
 
   const p2 = Object.values(joinRowTodos).flatMap((todo) => {
-    // Cheat and use `Object.values` + `filter instanceof BaseEntity` to handle the variable keys
-    const entities: Entity[] = [...todo.newRows, ...todo.deletedRows]
-      .flatMap((jr) => Object.values(jr))
-      .filter((e) => e instanceof BaseEntity) as any;
+    const entities = [...todo.newRows, ...todo.deletedRows].flatMap((jr) => Object.values(jr.columns));
     // Do the first side
     const p1 = getReactiveRules(todo.m2m.meta)
       .filter((rule) => rule.fields.includes(todo.m2m.fieldName))

--- a/packages/orm/src/drivers/PostgresDriver.ts
+++ b/packages/orm/src/drivers/PostgresDriver.ts
@@ -157,8 +157,8 @@ export class PostgresDriver implements Driver<Knex.Transaction> {
         const meta2 = m2m.otherMeta;
         const bindings = newRows.flatMap((row) => {
           return [
-            keyToNumber(meta1, maybeResolveReferenceToId(row[m2m.columnName] as any))!,
-            keyToNumber(meta2, maybeResolveReferenceToId(row[m2m.otherColumnName] as any))!,
+            keyToNumber(meta1, maybeResolveReferenceToId(row.columns[m2m.columnName] as any))!,
+            keyToNumber(meta2, maybeResolveReferenceToId(row.columns[m2m.otherColumnName] as any))!,
           ];
         });
         const { rows } = await knex.raw(sql, bindings);
@@ -185,8 +185,8 @@ export class PostgresDriver implements Driver<Knex.Transaction> {
             .map(
               (e) =>
                 [
-                  deTagId(m2m.meta, maybeResolveReferenceToId(e[m2m.columnName] as any)!),
-                  deTagId(m2m.otherMeta, maybeResolveReferenceToId(e[m2m.otherColumnName] as any)!),
+                  deTagId(m2m.meta, maybeResolveReferenceToId(e.columns[m2m.columnName] as any)!),
+                  deTagId(m2m.otherMeta, maybeResolveReferenceToId(e.columns[m2m.otherColumnName] as any)!),
                 ] as any,
             )
             // Watch for m2m rows that got added-then-removed to entities that were themselves added-then-removed,


### PR DESCRIPTION
Before, loading ~10k m2ms would become slow b/c of a `this.rows.find` linear scan that was invoked in a loop:

![image](https://github.com/user-attachments/assets/2590c95d-0a88-45b0-a22c-5d821d5fcf65)

After:

![image](https://github.com/user-attachments/assets/19a5d199-c775-4940-891d-6499c217d01e)

