### PR TITLE
fix: Fix batching of jsonpath operators.

### DIFF
--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -196,6 +196,12 @@ export function collectAndReplaceArgs(query: ParsedFindQuery): { columnName: str
           args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
           args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
           return rewriteToRawCondition(c, argsIndex);
+        } else if (kind === "jsonPathExists" || kind === "jsonPathPredicate") {
+          // The CTE needs to use `::jsonpath` instead of `::jsonb`, otherwise we'll get an invalid
+          // operator error for `jsonb @@ jsonb`. ...maybe the `ColumnCondition` should have a dbType
+          // baked into its ADT? Then we could avoid this special case handling.
+          args.push({ columnName: `arg${args.length}`, dbType: "jsonpath" });
+          return rewriteToRawCondition(c, argsIndex);
         } else {
           args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
           return rewriteToRawCondition(c, argsIndex);

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2848,6 +2848,17 @@ describe("EntityManager.queries", () => {
       expect(authors.length).toEqual(2);
     });
 
+    it("can use aliases for jsonb path exists in a batch", async () => {
+      await insertAuthor({ first_name: "a1", address: { street: "rr1" } });
+      await insertAuthor({ first_name: "a2", address: { street: "rr2" } });
+      const em = newEntityManager();
+      const a = alias(Author);
+      await Promise.all([
+        em.find(Author, { as: a }, { conditions: { and: [a.address.pathExists(`$.street`)] } }),
+        em.find(Author, { as: a }, { conditions: { and: [a.address.pathExists(`$.city`)] } }),
+      ]);
+    });
+
     it("can use aliases for jsonb path predicate", async () => {
       await insertAuthor({ first_name: "a1", address: { street: "rr1" } });
       await insertAuthor({ first_name: "a2", address: { street: "rr2" } });
@@ -2859,6 +2870,17 @@ describe("EntityManager.queries", () => {
         { conditions: { and: [a.address.pathIsTrue(`$.street == "rr2"`)] } },
       );
       expect(authors.length).toEqual(1);
+    });
+
+    it("can use aliases for jsonb path predicate in a batch", async () => {
+      await insertAuthor({ first_name: "a1", address: { street: "rr1" } });
+      await insertAuthor({ first_name: "a2", address: { street: "rr2" } });
+      const em = newEntityManager();
+      const a = alias(Author);
+      await Promise.all([
+        em.find(Author, { as: a }, { conditions: { and: [a.address.pathIsTrue(`$.street == "rr1"`)] } }),
+        em.find(Author, { as: a }, { conditions: { and: [a.address.pathIsTrue(`$.street == "rr2"`)] } }),
+      ]);
     });
 
     it("prunes unused joins", async () => {


### PR DESCRIPTION
When creating CTE values, we'd been casting them to the default type, which was the columns jsonb type.

But we need them treated as jsonpath types, so that the @@/@? operators work.