### PR TITLE
fix: address issues with em.fork

### DIFF
--- a/packages/orm/src/relations/PolymorphicReference.ts
+++ b/packages/orm/src/relations/PolymorphicReference.ts
@@ -119,12 +119,23 @@ export class PolymorphicReferenceImpl<T extends Entity, U extends Entity, N exte
     return this._isLoaded;
   }
 
+  /**
+   * Looks for an entity in `EntityManager`, b/c we may have it in memory even if
+   * our reference is not specifically loaded.
+   */
+  maybeFindEntity(): U | undefined {
+    // Check this.loaded first b/c a new entity won't have an id yet
+    const { idTaggedMaybe } = this;
+    return this.loaded ?? (idTaggedMaybe !== undefined ? (this.entity.em.getEntity(idTaggedMaybe) as U) : undefined);
+  }
+
   get isPreloaded(): boolean {
-    return false;
+    return !!this.maybeFindEntity();
   }
 
   preload(): void {
-    throw new Error("Not implemented");
+    this.loaded = this.maybeFindEntity();
+    this._isLoaded = true;
   }
 
   private doGet(opts?: { withDeleted?: boolean }): U | N {


### PR DESCRIPTION
* add support for forking an `em` with pending changes
* correctly build each new `row` from combination of `data` / `originalData` / `row`
  * requires a new method on each `...Serde` to convert entity data into what that data would look like coming out of postgres 
* implement preloading for `PolymorphicReference`
* update `Temporal.ZonedDateTime` mapper to correctly account for offset
* additional tests