### PR TITLE
chore: disallow `this` in property callbacks

### DIFF
--- a/packages/orm/src/getProperties.ts
+++ b/packages/orm/src/getProperties.ts
@@ -1,7 +1,7 @@
 import { BaseEntity } from "./BaseEntity";
 import { EntityMetadata } from "./EntityMetadata";
 import { LazyField } from "./newEntity";
-import { partition } from "./utils";
+import { fail, partition } from "./utils";
 
 /**
  * Returns the relations in `meta`, both those defined in the codegen file + any user-defined `CustomReference`s.
@@ -92,8 +92,19 @@ export function getProperties(meta: EntityMetadata): Record<string, any> {
     ),
   );
 
+  // Since our fake instance is actually generating the callbacks for our lazy fields, it will be captured in any
+  // lambdas created.  If any of them reference `this`, then they'll actually be referencing the fake instance.  So we
+  // need to clear out any properties directly on the fake instance now that we're done with it and use a proxy to
+  // intercept any attempts to access `this` from within the callbacks and fail.
+  Object.setPrototypeOf(instance, instancePrototypeProxy);
+  for (const prop of Object.getOwnPropertyNames(instance)) {
+    if (prop !== "__data") delete instance[prop];
+  }
+
   return cached;
 }
+
+const instancePrototypeProxy = new Proxy({}, { get: () => fail("Cannot use 'this' in a property callback") });
 
 /**
  * Returns the `LazyField`s (...and transientField) for `meta`.

--- a/packages/orm/src/getProperties.ts
+++ b/packages/orm/src/getProperties.ts
@@ -96,7 +96,7 @@ export function getProperties(meta: EntityMetadata): Record<string, any> {
   // lambdas created.  If any of them reference `this`, then they'll actually be referencing the fake instance.  So we
   // need to clear out any properties directly on the fake instance now that we're done with it and use a proxy to
   // intercept any attempts to access `this` from within the callbacks and fail.
-  Object.setPrototypeOf(instance, instancePrototypeProxy);
+  Object.setPrototypeOf(instance, afterGetPropertiesInstancePrototypeProxy);
   for (const prop of Object.getOwnPropertyNames(instance)) {
     if (prop !== "__data") delete instance[prop];
   }
@@ -104,7 +104,10 @@ export function getProperties(meta: EntityMetadata): Record<string, any> {
   return cached;
 }
 
-const instancePrototypeProxy = new Proxy({}, { get: () => fail("Cannot use 'this' in a property callback") });
+const afterGetPropertiesInstancePrototypeProxy = new Proxy(
+  {},
+  { get: () => fail("Cannot use 'this' in a property callback") },
+);
 
 /**
  * Returns the `LazyField`s (...and transientField) for `meta`.

--- a/packages/tests/integration/src/Entity.test.ts
+++ b/packages/tests/integration/src/Entity.test.ts
@@ -179,6 +179,13 @@ describe("Entity", () => {
       expect(a1.firstName).toEqual("a1");
     });
   });
+
+  it("fails when trying to use `this` inside a property callback", async () => {
+    const em = newEntityManager();
+    const author = newAuthor(em);
+    const result = author.thisTestProp.load();
+    await expect(result).rejects.toThrow("Cannot use 'this' in a property callback");
+  });
 });
 
 // Based on the deep copy that was tripping up Webstorm

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -687,11 +687,4 @@ describe("Author", () => {
     const authors = await em.find(Author, { certificate: { eq: new Uint8Array([11, 22]) } });
     expect(authors.length).toBe(1);
   });
-
-  it("fails when trying to use this inside a property callback", async () => {
-    const em = newEntityManager();
-    const author = newAuthor(em);
-    const result = author.thisTestProp.load();
-    await expect(result).rejects.toThrow("Cannot use 'this' in a property callback");
-  });
 });

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -687,4 +687,11 @@ describe("Author", () => {
     const authors = await em.find(Author, { certificate: { eq: new Uint8Array([11, 22]) } });
     expect(authors.length).toBe(1);
   });
+
+  it("fails when trying to use this inside a property callback", async () => {
+    const em = newEntityManager();
+    const author = newAuthor(em);
+    const result = author.thisTestProp.load();
+    await expect(result).rejects.toThrow("Cannot use 'this' in a property callback");
+  });
 });

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -112,6 +112,9 @@ export class Author extends AuthorCodegen {
     (a.nickNames ?? []).map((n) => n.toUpperCase()),
   );
 
+  // this prop should fail if loaded to test preventing `this` usage in props/relations/fields
+  readonly thisTestProp: AsyncProperty<Author, any> = hasAsyncProperty({}, () => this.search);
+
   public transientFields = {
     beforeFlushRan: false,
     beforeCreateRan: false,


### PR DESCRIPTION
Due to the changes in #1586, `this` inside a property initialization callback (such as for `hasAsyncProp`) no longer refers to the instance being instantiated, but rather to the fake instance generated by `getProperties`.  This can result in unpredictable behavior and is tricky to debug, as often the error won't reveal itself immediately upon access.  This PR addresses this by making any access of a property on `this` inside one of these callbacks immediately throw an error.  We accomplish this by deleting the "own" properties on the fake instance and then installing a proxy as its prototype, which allows us to respond to any access by immediately failing.