### PR TITLE
perf(wip): Use Object.setPrototype in newEntity

### DIFF
--- a/packages/tests/integration/src/benchmarks/newEntity.ts
+++ b/packages/tests/integration/src/benchmarks/newEntity.ts
@@ -1,0 +1,58 @@
+import { getMetadata, InstanceData } from "joist-orm";
+import { Author } from "src/entities";
+
+async function main() {
+  const mitata = await import("mitata");
+  const { run, bench } = mitata;
+  const meta = getMetadata(Author);
+
+  bench("Object.create with prop", () => {
+    Object.create(Author.prototype, {
+      __data: {
+        value: new InstanceData(null!, meta, true),
+        enumerable: false,
+        writable: false,
+        configurable: false,
+      },
+    });
+  });
+
+  bench("Object.create only value", () => {
+    Object.create(Author.prototype, {
+      __data: {
+        value: new InstanceData(null!, meta, true),
+      },
+    });
+  });
+
+  bench("Object.create defineProperty", () => {
+    const author = Object.create(Author.prototype);
+    Object.defineProperty(author, "__data", {
+      value: new InstanceData(null!, meta, true),
+    });
+  });
+
+  bench("Object.setPrototypeOf", () => {
+    const entity = { __data: new InstanceData(null!, meta, true) };
+    Object.setPrototypeOf(entity, Author.prototype);
+  });
+
+  bench("Object.setPrototypeOf defineProperty", () => {
+    const entity = {};
+    Object.setPrototypeOf(entity, Author.prototype);
+    Object.defineProperty(entity, "__data", {
+      value: new InstanceData(null!, meta, true),
+    });
+  });
+
+  bench("new Author", () => {
+    new (Author as any)(null!, true);
+  });
+
+  await run({});
+}
+
+// yarn clinic flame -- node --env-file .env --import=tsx ./src/benchmarks/loading-authors.ts
+// yarn env-cmd tsx ./src/benchmarks/loading-authors.ts
+// bun src/saving-authors.ts
+main();


### PR DESCRIPTION
```
clk: ~4.76 GHz
cpu: 12th Gen Intel(R) Core(TM) i9-12900K
runtime: node 23.1.0 (x64-linux)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
Object.create                283.07 ns/iter 287.55 ns  █ ▂
                    (271.96 ns … 330.07 ns) 315.75 ns ▂█▄██
                    (576.79  b …   1.07 kb) 832.36  b ██████▆▅▅▆▅▃▄▅▂▃▂▂▂▁▂

Object.create only value     266.58 ns/iter 271.80 ns    ▃█▃
                    (249.09 ns … 362.65 ns) 309.26 ns   ████▃▂
                    (387.97  b … 999.10  b) 808.57  b ▄███████▇▆▆▇▄▃▄▂▁▂▁▁▂

setPrototypeOf                76.24 ns/iter  76.05 ns  ▂█▂
                     (69.60 ns … 140.40 ns) 106.88 ns  ███
                    ( 33.92  b … 542.34  b) 360.40  b ▃████▃▂▁▁▁▂▃▃▂▂▁▁▁▁▁▁

new Author                     2.16 µs/iter   2.19 µs  █      ▅█
                        (2.09 µs … 2.37 µs)   2.28 µs ▆███ ▆████▃▆ ▃ ▃ ▆  ▆
                    (  1.84 kb …   2.32 kb)   2.16 kb ████▄███████████▁█▁▁█
```