### PR TITLE
feat: add runOnce option to addReaction

### DIFF
--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -200,11 +200,10 @@ export class ReactionsManager {
         }
       });
       if (failures.length > 0) throw failures[0];
-      // Record any succesful actions that should only run once so we don't run them again
+      // Record any successful actions that should only run once so we don't run them again
       actions.forEach(({ key, r }) => {
         if (r.runOnce) this.processedActions.add(key);
       });
-
       // This should generally not happen, only if two reactive fields depend on each other,
       // which in theory should probably be caught/blow up in the `configureMetadata` step,
       // but if it's not caught sooner, at least don't infinite loop.

--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -6,7 +6,7 @@ import { EntityManager, getEmInternalApi, NoIdError } from "./index";
 import { globalLogger, ReactionLogger } from "./logging/ReactionLogger";
 import { followReverseHint } from "./reactiveHints";
 
-export type ReactiveAction = { r: Reactable; entity: Entity };
+export type ReactiveAction = { key: string; r: Reactable; entity: Entity };
 /**
  * Manages the reactivity of tracking which source fields have changed and finding/recalculating
  * their downstream derived fields.
@@ -32,6 +32,7 @@ export class ReactionsManager {
    * try again during `em.flush`.
    */
   private actionsPendingAssignedIds: Map<string, ReactiveAction> = new Map();
+  private processedActions: Set<string> = new Set();
   private needsRecalc = { populate: false, query: false, reaction: false };
   private logger: ReactionLogger | undefined = globalLogger;
   private em: EntityManager;
@@ -169,7 +170,10 @@ export class ReactionsManager {
             const key = `${entity}_${r.name}`;
             // We could arrive at the same reactable from multiple paths (eg, 2 dependent fields changed), so we need to
             // dedupe based on the entity and reactable to only run each action once for any given entity per loop
-            if (!actionsMap.has(key)) actionsMap.set(key, { r, entity });
+            if (actionsMap.has(key)) return;
+            // If this reactable has already run and shouldn't run again, then skip it
+            if ("runOnce" in r && r.runOnce && this.processedActions.has(key)) return;
+            actionsMap.set(key, { key, r, entity });
           });
         }),
       );
@@ -197,6 +201,10 @@ export class ReactionsManager {
         }
       });
       if (failures.length > 0) throw failures[0];
+      // Record any succesful actions that should only run once so we don't run them again
+      actions.forEach(({ key, r }) => {
+        if ("runOnce" in r && r.runOnce) this.processedActions.add(key);
+      });
 
       // This should generally not happen, only if two reactive fields depend on each other,
       // which in theory should probably be caught/blow up in the `configureMetadata` step,
@@ -210,6 +218,7 @@ export class ReactionsManager {
   /** Clears all the pending source fields, i.e. after `em.flush` is complete. */
   clear(): void {
     this.pendingReactables = new Map();
+    this.processedActions.clear();
   }
 
   get hasFieldsPendingAssignedIds(): boolean {

--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -193,8 +193,7 @@ export class ReactionsManager {
           // Let `author.id` and `book.author.get.firstName` errors run again after flush/hooks fills them in
           if (result.reason instanceof NoIdError || result.reason instanceof TypeError) {
             const action = actions[i];
-            const key = `${action.entity}_${action.r.name}`;
-            this.actionsPendingAssignedIds.set(key, action);
+            this.actionsPendingAssignedIds.set(action.key, action);
           } else {
             failures.push(result.reason);
           }

--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -172,7 +172,7 @@ export class ReactionsManager {
             // dedupe based on the entity and reactable to only run each action once for any given entity per loop
             if (actionsMap.has(key)) return;
             // If this reactable has already run and shouldn't run again, then skip it
-            if ("runOnce" in r && r.runOnce && this.processedActions.has(key)) return;
+            if (r.runOnce && this.processedActions.has(key)) return;
             actionsMap.set(key, { key, r, entity });
           });
         }),
@@ -203,7 +203,7 @@ export class ReactionsManager {
       if (failures.length > 0) throw failures[0];
       // Record any succesful actions that should only run once so we don't run them again
       actions.forEach(({ key, r }) => {
-        if ("runOnce" in r && r.runOnce) this.processedActions.add(key);
+        if (r.runOnce) this.processedActions.add(key);
       });
 
       // This should generally not happen, only if two reactive fields depend on each other,

--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -30,6 +30,8 @@ export type EntityHook =
   | "afterCommit";
 type HookFn<T extends Entity, C> = (entity: T, ctx: C) => MaybePromise<unknown>;
 
+type AddReactionOpts<T extends Entity, C> = { runOnce?: boolean; fn: HookFn<T, C> };
+
 export const constraintNameToValidationError: Record<string, string> = {};
 
 type Settable<T extends Entity> = keyof SettableFields<FieldsOf<T>> & string;
@@ -191,6 +193,23 @@ export class ConfigApi<T extends Entity, C> {
    */
   addReaction<H extends ReactiveHint<T>>(hint: H, fn: HookFn<Loaded<T, H>, C>): void;
   /**
+   * Adds a reaction that runs during flush whenever fields in the `hint` change.
+   *
+   * Reactions are somewhere in between hooks and reactive fields/references:
+   * 1. Can make arbitrary changes to any entity like a hook
+   * 2. Only run when the provided hint has changes, not on every flush, like an RF/RR
+   * 3. Run when the entity itself has no changes, like an RF/RF
+   * 4. Can run multiple times per flush, like an RF/RF.  Be careful to avoid creating
+   *    circular dependencies in the hint and to make the function idempotent.
+   *
+   * @param hint The fields to watch for changes and load before running the reaction
+   * @param opts Options object containing:
+   *  - runOnce - If true, the reaction will only run once per flush, not every time the hint changes. Optional.
+   *   default: false.
+   *   - fn - The reaction function to run
+   */
+  addReaction<H extends ReactiveHint<T>>(hint: H, fn: AddReactionOpts<Loaded<T, H>, C>): void;
+  /**
    * Adds a named reaction that runs during flush whenever fields in the `hint` change.
    *
    * Reactions are somewhere in between hooks and reactive fields/references:
@@ -205,15 +224,35 @@ export class ConfigApi<T extends Entity, C> {
    * @param fn The reaction function to run
    */
   addReaction<H extends ReactiveHint<T>>(name: string, hint: H, fn: HookFn<Loaded<T, H>, C>): void;
+  /**
+   * Adds a named reaction that runs during flush whenever fields in the `hint` change.
+   *
+   * Reactions are somewhere in between hooks and reactive fields/references:
+   * 1. Can make arbitrary changes to any entity like a hook
+   * 2. Only run when `hint` has changes, not on every flush, like an RF/RR
+   * 3. Can run when the entity itself has no changes, like an RF/RF
+   * 4. Can run multiple times per flush, like an RF/RF.  Be careful to avoid creating
+   *    circular dependencies in the hint and to make the function idempotent.
+   *
+   * @param name A name to identify this reaction for debugging
+   * @param hint The fields to watch for changes and load before running the reaction
+   * @param opts Options object containing:
+   *   - runOnce - If true, the reaction will only run once per flush, not every time the hint changes. Optional.
+   *   default: false.
+   *   - fn - The reaction function to run
+   */
+  addReaction<H extends ReactiveHint<T>>(name: string, hint: H, opts: AddReactionOpts<Loaded<T, H>, C>): void;
   addReaction<H extends ReactiveHint<T>>(
     nameOrHint: string | H,
-    hintOrFn: H | HookFn<Loaded<T, H>, C>,
-    maybeFn?: HookFn<Loaded<T, H>, C>,
+    hintOrFnOrOpts: H | HookFn<Loaded<T, H>, C> | AddReactionOpts<Loaded<T, H>, C>,
+    maybeFnOrOpts?: HookFn<Loaded<T, H>, C> | AddReactionOpts<Loaded<T, H>, C>,
   ): void {
     // Keep the name so we can uniquely identify this reaction later and also aid debugging/tracing
-    const name = typeof maybeFn === "function" ? (nameOrHint as string) : getCallerName();
-    const hint = (maybeFn ? hintOrFn : nameOrHint) as H;
-    const fn = (maybeFn ?? hintOrFn) as HookFn<Loaded<T, H>, C>;
+    const name = maybeFnOrOpts ? (nameOrHint as string) : getCallerName();
+    const hint = (maybeFnOrOpts ? hintOrFnOrOpts : nameOrHint) as H;
+    const fnOrOpts = (maybeFnOrOpts ?? hintOrFnOrOpts) as HookFn<Loaded<T, H>, C> | AddReactionOpts<Loaded<T, H>, C>;
+    const opts = typeof fnOrOpts === "function" ? { fn: fnOrOpts } : fnOrOpts;
+    const { fn, runOnce = false } = opts;
     this.ensurePreBoot(name, "addReaction");
     let loadHint: LoadHint<T>;
     // Create a wrapper around the user's function to populate
@@ -226,7 +265,7 @@ export class ConfigApi<T extends Entity, C> {
       }
       return fn(entity as Loaded<T, H>, ctx);
     };
-    this.__data.reactions.push({ name, fn: wrappedFn, hint });
+    this.__data.reactions.push({ name, fn: wrappedFn, hint, runOnce });
   }
 
   /** Adds a synchronous default for `fieldName` to a hard-coded `value`. */
@@ -363,6 +402,8 @@ export interface Reaction {
   path: string[];
   /** The downstream reaction function. */
   fn: HookFn<any, any>;
+  /** If true, the reaction should only run once per flush, not every time the hint changes. */
+  runOnce: boolean;
 }
 
 export type Reactable = ReactiveField | Reaction;
@@ -371,6 +412,7 @@ interface ReactionInternal<T extends Entity, H extends ReactiveHint<T>, C> {
   name: string;
   fn: HookFn<Reacted<T, H>, C>;
   hint: H;
+  runOnce: boolean;
 }
 
 type AfterMetadataCallback<T extends Entity> = (meta: EntityMetadata<T>) => void;

--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -384,6 +384,7 @@ export interface ReactiveField {
   path: string[];
   /** The name of the reactive field in the downstream entity to recalc. */
   name: string;
+  runOnce: false;
 }
 
 export interface Reaction {

--- a/packages/orm/src/configure.ts
+++ b/packages/orm/src/configure.ts
@@ -253,6 +253,7 @@ function reverseIndexReactivity(metas: EntityMetadata[]): void {
             name: field.fieldName,
             path,
             fields,
+            runOnce: false,
           });
         }
       }

--- a/packages/orm/src/configure.ts
+++ b/packages/orm/src/configure.ts
@@ -208,7 +208,7 @@ function reverseIndexReactivity(metas: EntityMetadata[]): void {
     }
 
     // Look for reactions to reverse
-    for (const { name, hint, fn } of meta.config.__data.reactions) {
+    for (const { name, hint, fn, runOnce } of meta.config.__data.reactions) {
       const reversals = reverseReactiveHint(meta.cstr, meta.cstr, hint);
       // For each reversal, tell its config about the reverse hint to force-rerun
       // the original reaction's instance any time it changes.
@@ -222,6 +222,7 @@ function reverseIndexReactivity(metas: EntityMetadata[]): void {
           fields,
           path,
           fn,
+          runOnce,
         });
       }
     }

--- a/packages/tests/integration/src/EntityManager.reactions.test.ts
+++ b/packages/tests/integration/src/EntityManager.reactions.test.ts
@@ -682,6 +682,12 @@ describe("EntityManager.reactions", () => {
       // Then the reaction runs exactly once
       expect(a.nickNames).toEqual(["a1ster"]);
       expect(a.transientFields.reactions.runOnce).toBe(1);
+      // When we set the value again and flush
+      a.nickNames = [];
+      await em.flush();
+      // Then the reaction has run one more time
+      expect(a.nickNames).toEqual(["a1ster"]);
+      expect(a.transientFields.reactions.runOnce).toBe(2);
     });
   });
 });

--- a/packages/tests/integration/src/EntityManager.reactiveRules.test.tsx
+++ b/packages/tests/integration/src/EntityManager.reactiveRules.test.tsx
@@ -391,6 +391,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfBooks",
       fields: ["author", "deletedAt"],
       path: ["author"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -398,6 +399,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "bookComments",
       fields: ["author", "deletedAt"],
       path: ["author"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -405,6 +407,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfPublicReviews",
       fields: ["author", "deletedAt"],
       path: ["author"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -412,6 +415,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfPublicReviews2",
       fields: ["author", "deletedAt"],
       path: ["author"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -419,6 +423,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "tagsOfAllBooks",
       fields: ["author", "deletedAt", "tags"],
       path: ["author"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -426,6 +431,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "search",
       fields: ["author", "deletedAt", "title"],
       path: ["author"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -433,6 +439,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "rangeOfBooks",
       fields: ["author", "deletedAt"],
       path: ["author"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -440,6 +447,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "favoriteBook",
       fields: ["author", "deletedAt"],
       path: ["author"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -447,6 +455,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "search",
       fields: ["author", "title"],
       path: [],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -454,6 +463,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "isPublic",
       fields: ["author"],
       path: ["reviews"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -461,6 +471,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "parentTags",
       fields: ["tags"],
       path: ["comments"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "query",
@@ -468,6 +479,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfBookReviews",
       fields: ["author", "deletedAt"],
       path: ["author", "publisher@LargePublisher"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -475,6 +487,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "titlesOfFavoriteBooks",
       fields: ["title"],
       path: ["favoriteAuthor", "publisher@LargePublisher"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -482,6 +495,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "favoriteAuthor",
       fields: ["author", "deletedAt"],
       path: ["author", "publisher@LargePublisher"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "query",
@@ -489,6 +503,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfBookReviews",
       fields: ["author", "deletedAt"],
       path: ["author", "publisher"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -496,6 +511,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "titlesOfFavoriteBooks",
       fields: ["title"],
       path: ["favoriteAuthor", "publisher"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -503,6 +519,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "favoriteAuthor",
       fields: ["author", "deletedAt"],
       path: ["author", "publisher"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "query",
@@ -510,6 +527,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfBookReviewsFormatted",
       fields: ["author", "deletedAt"],
       path: ["author", "publisher", "group"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "query",
@@ -517,6 +535,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfBookReviews",
       fields: ["author", "deletedAt"],
       path: ["author", "publisher@SmallPublisher"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -524,6 +543,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "titlesOfFavoriteBooks",
       fields: ["title"],
       path: ["favoriteAuthor", "publisher@SmallPublisher"],
+      runOnce: false,
     });
     expect(bRfs[i++]).toEqual({
       kind: "populate",
@@ -531,6 +551,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "favoriteAuthor",
       fields: ["author", "deletedAt"],
       path: ["author", "publisher@SmallPublisher"],
+      runOnce: false,
     });
 
     i = 0;
@@ -541,6 +562,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfPublicReviews",
       fields: ["isPublic", "rating"],
       path: ["book", "author"],
+      runOnce: false,
     });
     expect(brRfs[i++]).toEqual({
       kind: "populate",
@@ -548,6 +570,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfPublicReviews2",
       fields: ["isPublic", "isTest", "rating"],
       path: ["book", "author"],
+      runOnce: false,
     });
     expect(brRfs[i++]).toEqual({
       kind: "populate",
@@ -555,15 +578,31 @@ describe("EntityManager.reactiveRules", () => {
       name: "favoriteBook",
       fields: ["rating"],
       path: ["book", "author"],
+      runOnce: false,
     });
-    expect(brRfs[i++]).toEqual({ kind: "populate", cstr: "BookReview", name: "isPublic", fields: [], path: [] });
-    expect(brRfs[i++]).toEqual({ kind: "populate", cstr: "BookReview", name: "isTest", fields: [], path: [] });
+    expect(brRfs[i++]).toEqual({
+      kind: "populate",
+      cstr: "BookReview",
+      name: "isPublic",
+      fields: [],
+      path: [],
+      runOnce: false,
+    });
+    expect(brRfs[i++]).toEqual({
+      kind: "populate",
+      cstr: "BookReview",
+      name: "isTest",
+      fields: [],
+      path: [],
+      runOnce: false,
+    });
     expect(brRfs[i++]).toEqual({
       kind: "populate",
       cstr: "BookReview",
       name: "isTestChain",
       fields: ["isTest"],
       path: [],
+      runOnce: false,
     });
     expect(brRfs[i++]).toEqual({
       kind: "populate",
@@ -571,6 +610,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "parentTags",
       fields: ["isPublic"],
       path: ["book", "comments"],
+      runOnce: false,
     });
     expect(brRfs[i++]).toEqual({
       kind: "populate",
@@ -578,6 +618,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "parentTags",
       fields: ["tags"],
       path: ["comment"],
+      runOnce: false,
     });
     expect(brRfs[i++]).toEqual({
       kind: "query",
@@ -585,6 +626,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfBookReviews",
       fields: [],
       path: ["book", "author", "publisher@LargePublisher"],
+      runOnce: false,
     });
     expect(brRfs[i++]).toEqual({
       kind: "query",
@@ -592,6 +634,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfBookReviews",
       fields: [],
       path: ["book", "author", "publisher"],
+      runOnce: false,
     });
     expect(brRfs[i++]).toEqual({
       kind: "query",
@@ -599,6 +642,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfBookReviewsFormatted",
       fields: [],
       path: ["book", "author", "publisher", "group"],
+      runOnce: false,
     });
     expect(brRfs[i++]).toEqual({
       kind: "query",
@@ -606,6 +650,7 @@ describe("EntityManager.reactiveRules", () => {
       name: "numberOfBookReviews",
       fields: [],
       path: ["book", "author", "publisher@SmallPublisher"],
+      runOnce: false,
     });
   });
 

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -147,6 +147,7 @@ export class Author extends AuthorCodegen {
       setViaHook: 0,
       immutable: 0,
       afterMetadata: 0,
+      runOnce: 0,
     },
   };
 
@@ -447,6 +448,14 @@ config.afterMetadata(() => {
   config.addReaction("ssn", (a) => {
     a.transientFields.reactions.afterMetadata += 1;
   });
+});
+
+config.addReaction("runOnce", "nickNames", {
+  runOnce: true,
+  fn: (a) => {
+    if (a.nickNames !== undefined && a.nickNames.length === 0) a.nickNames = [a.firstName + "ster"];
+    a.transientFields.reactions.runOnce += 1;
+  },
 });
 
 // Example accessing ctx from beforeFlush

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -450,12 +450,9 @@ config.afterMetadata(() => {
   });
 });
 
-config.addReaction("runOnce", "nickNames", {
-  runOnce: true,
-  fn: (a) => {
-    if (a.nickNames !== undefined && a.nickNames.length === 0) a.nickNames = [a.firstName + "ster"];
-    a.transientFields.reactions.runOnce += 1;
-  },
+config.addReaction({ name: "runOnce", runOnce: true }, "nickNames", (a) => {
+  if (a.nickNames !== undefined && a.nickNames.length === 0) a.nickNames = [a.firstName + "ster"];
+  a.transientFields.reactions.runOnce += 1;
 });
 
 // Example accessing ctx from beforeFlush


### PR DESCRIPTION
adds an optional `runOnce` flag to `addReaction` that causes it to operate more like a traditional hook, eg only once per flush call regardless of additional changes