### PR TITLE
fix: assign ids and recalc reactables pending ids within recalcPendingReactables

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1411,8 +1411,6 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
     this.#fl.startLock();
 
-    this.#rm.clearSuppressedTypeErrors();
-
     await this.#fl.allowWrites(async () => {
       // Cascade deletes now that we're async (i.e. to keep `em.delete` synchronous).
       // Also do this before calling `recalcPendingReactables` to avoid recalculating
@@ -1612,6 +1610,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
       if (e instanceof InMemoryRollbackError) return [...allFlushedEntities];
       throw e;
     } finally {
+      this.#rm.clearSuppressedTypeErrors();
       this.#fl.releaseLock();
     }
   }

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1411,6 +1411,8 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
     this.#fl.startLock();
 
+    this.#rm.clearSuppressedTypeErrors();
+
     await this.#fl.allowWrites(async () => {
       // Cascade deletes now that we're async (i.e. to keep `em.delete` synchronous).
       // Also do this before calling `recalcPendingReactables` to avoid recalculating
@@ -1427,7 +1429,6 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     // Make sure two ReactiveQueryFields don't ping-pong each other forever
     let hookLoops = 0;
     let now = getNow();
-    this.#rm.clearSuppressedTypeErrors();
     const suppressedDefaultTypeErrors: Error[] = [];
 
     // Make a lambda that we can invoke multiple times, if we loop for ReactiveQueryFields

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1478,13 +1478,14 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
             if (this.#rm.hasFieldsPendingAssignedIds) {
               await this.assignNewIds();
-              await this.#rm.recalcRelationsPendingAssignedIds();
+              await this.#rm.recalcReactablesPendingAssignedIds();
             }
 
             if (loops++ > 50) {
               fail("recalc looped too many times, probably a circular dependency");
             }
-            // recalcRelationsPendingAssignedIds could have dirtied additional fields, so re-run until we've settled
+            // recalcReactablesPendingAssignedIds could have dirtied additional fields that have their own dependent
+            // reactables, so re-run until we've settled
           } while (this.#rm.hasPendingReactables);
 
           for (const e of pendingHooks) hooksInvoked.add(e);

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1472,8 +1472,8 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
           // The hooks could have deleted this-loop or prior-loop entities, so re-cascade again.
           await this.flushDeletes();
           let loops = 0;
-          // The hooks could have changed fields, so recalc again.
           do {
+            // The hooks could have changed fields, so recalc again.
             await this.#rm.recalcPendingReactables("reactables");
 
             if (this.#rm.hasFieldsPendingAssignedIds) {
@@ -1481,11 +1481,9 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
               await this.#rm.recalcReactablesPendingAssignedIds();
             }
 
-            if (loops++ > 50) {
-              fail("recalc looped too many times, probably a circular dependency");
-            }
-            // recalcReactablesPendingAssignedIds could have dirtied additional fields that have their own dependent
-            // reactables, so re-run until we've settled
+            if (loops++ > 50) fail("recalc looped too many times, probably a circular dependency");
+            // recalcReactablesPendingAssignedIds could have changed more fields or even created new entities, so we
+            // need to loop until we've settled completely.
           } while (this.#rm.hasPendingReactables);
 
           for (const e of pendingHooks) hooksInvoked.add(e);

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1471,13 +1471,21 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
           // The hooks could have deleted this-loop or prior-loop entities, so re-cascade again.
           await this.flushDeletes();
+          let loops = 0;
           // The hooks could have changed fields, so recalc again.
-          await this.#rm.recalcPendingReactables("reactables");
+          do {
+            await this.#rm.recalcPendingReactables("reactables");
 
-          if (this.#rm.hasFieldsPendingAssignedIds) {
-            await this.assignNewIds();
-            await this.#rm.recalcRelationsPendingAssignedIds();
-          }
+            if (this.#rm.hasFieldsPendingAssignedIds) {
+              await this.assignNewIds();
+              await this.#rm.recalcRelationsPendingAssignedIds();
+            }
+
+            if (loops++ > 50) {
+              fail("recalc looped too many times, probably a circular dependency");
+            }
+            // recalcRelationsPendingAssignedIds could have dirtied additional fields, so re-run until we've settled
+          } while (this.#rm.hasPendingReactables);
 
           for (const e of pendingHooks) hooksInvoked.add(e);
           pendingHooks.clear();
@@ -1542,7 +1550,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
               await this.driver.flushJoinTables(this, joinRowTodos);
             }
             // Now that we've flushed, look for ReactiveQueries that need to be recalculated
-            if (this.#rm.hasPendingReactiveQueries()) {
+            if (this.#rm.hasPendingReactiveQueries) {
               // Reset all flushed entities to we only flush net-new changes
               for (const e of entitiesToFlush) {
                 if (e.isNewEntity && !e.isDeletedEntity) this.#entitiesById.set(e.idTagged, e);

--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -122,10 +122,6 @@ export class ReactionsManager {
     return this.getDirtyFields(getMetadata(entity)).has(fieldName);
   }
 
-  hasPendingReactiveQueries(): boolean {
-    return this.needsRecalc.query;
-  }
-
   /**
    * Given source `Reactable` "reverse indexes" that have been queued as dirty by calls
    * to setters, `em.register`, or `em.delete`, asynchronously walks/crawls to the downstream
@@ -221,6 +217,14 @@ export class ReactionsManager {
 
   get hasFieldsPendingAssignedIds(): boolean {
     return this.actionsPendingAssignedIds.size > 0;
+  }
+
+  get hasPendingReactiveQueries(): boolean {
+    return this.needsRecalc.query;
+  }
+
+  get hasPendingReactables(): boolean {
+    return this.needsRecalc.populate || this.needsRecalc.reaction;
   }
 
   async recalcRelationsPendingAssignedIds(): Promise<void> {

--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -2,7 +2,7 @@ import { Entity } from "./Entity";
 import { EntityMetadata, getMetadata } from "./EntityMetadata";
 import { getReactables, getReactablesIncludingReadOnly } from "./caches";
 import { Reactable } from "./config";
-import { EntityManager, getEmInternalApi, NoIdError } from "./index";
+import { EntityManager, fail, getEmInternalApi, NoIdError } from "./index";
 import { globalLogger, ReactionLogger } from "./logging/ReactionLogger";
 import { followReverseHint } from "./reactiveHints";
 
@@ -203,9 +203,7 @@ export class ReactionsManager {
       // This should generally not happen, only if two reactive fields depend on each other,
       // which in theory should probably be caught/blow up in the `configureMetadata` step,
       // but if it's not caught sooner, at least don't infinite loop.
-      if (loops++ > 50) {
-        throw new Error("recalc looped too many times, probably a circular dependency");
-      }
+      if (loops++ > 50) fail("recalc looped too many times, probably a circular dependency");
     }
   }
 

--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -227,7 +227,7 @@ export class ReactionsManager {
     return this.needsRecalc.populate || this.needsRecalc.reaction;
   }
 
-  async recalcRelationsPendingAssignedIds(): Promise<void> {
+  async recalcReactablesPendingAssignedIds(): Promise<void> {
     const actions = [...this.actionsPendingAssignedIds.values()];
     this.actionsPendingAssignedIds.clear();
 

--- a/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveQueryField.test.ts
@@ -42,8 +42,8 @@ describe("ReactiveQueryField", () => {
     // After the INSERTs, there is a SELECT to calc the data, and then an `UPDATE`
     expect(queries).toMatchInlineSnapshot(`
      [
-       "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::character varying), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find WHERE a.deleted_at IS NULL AND a.last_name = _find.arg0 GROUP BY a.id ORDER BY a.id ASC LIMIT $5",
        "select nextval('publishers_id_seq') from generate_series(1, 1) UNION ALL select nextval('authors_id_seq') from generate_series(1, 1) UNION ALL select nextval('books_id_seq') from generate_series(1, 2) UNION ALL select nextval('book_reviews_id_seq') from generate_series(1, 2)",
+       "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::character varying), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, a.* FROM authors AS a CROSS JOIN _find AS _find WHERE a.deleted_at IS NULL AND a.last_name = _find.arg0 GROUP BY a.id ORDER BY a.id ASC LIMIT $5",
        "BEGIN;",
        "INSERT INTO "publishers" ("id", "name", "latitude", "longitude", "huge_number", "number_of_book_reviews", "deleted_at", "titles_of_favorite_books", "book_advance_titles_snapshot", "number_of_book_advances_snapshot", "base_sync_default", "base_async_default", "created_at", "updated_at", "favorite_author_name", "rating", "size_id", "type_id", "favorite_author_id", "group_id", "spotlight_author_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)",
        "INSERT INTO "large_publishers" ("id", "shared_column", "country") VALUES ($1, $2, $3)",


### PR DESCRIPTION
This PR addresses the following scenario:

1. the initial run of a reactable during flush fails due to a missing id
2. when the reactable runs again during `recalcReactablesPendingAssignedIds` it mutates a field that has its own reactive dependencies
3. the mutated field is on an entity that is already in `alreadyRanHooks` 
4. `findPendingFlushEntities` puts nothing in `pendingHooks`
5. the dependencies of the mutated field are never re-run

 