### PR TITLE
fix: Fix findWithNewOrChanged on empty where clauses.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1998,6 +1998,11 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   filterEntities<T extends Entity>(cstr: EntityConstructor<T>, where: Partial<OptsOf<T>>): T[] {
     const meta = getMetadata(cstr);
     const entities = (this.#entitiesByTag.get(meta.tagName) as T[]) ?? [];
+    // Don't bother filtering if there's no where clause (particularly b/c IndexManager.findMatching
+    // really expects there to be at least 1 condition)
+    if (Object.entries(where).length === 0) {
+      return entities;
+    }
     if (this.#indexManager.shouldIndexType(entities.length)) {
       this.#indexManager.enableIndexingForType(meta, entities);
       return (

--- a/packages/orm/src/IndexManager.ts
+++ b/packages/orm/src/IndexManager.ts
@@ -95,7 +95,10 @@ export class IndexManager {
       // Early exit if no candidates remain
       if (candidates.size === 0) break;
     }
-    return candidates ? ([...candidates] as T[]) : [];
+    if (candidates === undefined) {
+      throw new Error(`Expected where clause with at least one condition`);
+    }
+    return [...candidates] as T[];
   }
 
   // `entities` should all be of the exact same subtype

--- a/packages/tests/integration/src/EntityManager.findWithNewOrChanged.test.ts
+++ b/packages/tests/integration/src/EntityManager.findWithNewOrChanged.test.ts
@@ -30,6 +30,16 @@ describe("EntityManager.findWithNewOrChanged", () => {
     expect(authors).toMatchEntity([{ firstName: "a1" }]);
   });
 
+  it("finds new entities with empty where and indexed", async () => {
+    // Create enough authors to enable indexing
+    for (let i = 1; i <= 1000; i++) await insertAuthor({ first_name: `a${i}` });
+    const em = newEntityManager();
+    // And we create one more
+    em.create(Author, { firstName: "a1" });
+    const authors = await em.findWithNewOrChanged(Author, {});
+    expect(authors.length).toBe(1001);
+  });
+
   it("finds changed entities", async () => {
     await insertAuthor({ first_name: "a2" });
     const em = newEntityManager();


### PR DESCRIPTION
Specifically when indexing kicks in, above 500 entities of the given type.