### PR TITLE
Add circular-imports examples: CJS and ESM fixes

### DIFF
--- a/circular-imports/README.md
+++ b/circular-imports/README.md
@@ -1,0 +1,42 @@
+# circular-imports
+
+Four small standalone TypeScript projects that walk through the circular
+dependency problem described in
+[*How to fix nasty circular dependency issues once and for all*](https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de)
+and apply the "internal module" fix, first in CommonJS and then in ESM.
+
+Each project is self-contained — its own `package.json`, its own
+`node_modules`, its own `tsconfig.json`. They are deliberately NOT part of
+the root yarn workspace.
+
+| Project | Module system | Status | What it shows |
+| --- | --- | --- | --- |
+| [`a/`](./a) | CommonJS | ❌ fails deterministically | Reproduces `TypeError: Class extends value undefined is not a constructor or null` |
+| [`b/`](./b) | CommonJS | ✅ passes | Fixes it with the internal-module pattern |
+| [`c/`](./c) | ESM | ❌ fails deterministically | Reproduces `ReferenceError: Cannot access 'AbstractNode' before initialization` |
+| [`d/`](./d) | ESM | ✅ passes | Internal-module fix ported to ESM, plus brainstorm of alternative ESM-only fixes |
+
+## The reproduction, in one paragraph
+
+An abstract base class (`AbstractNode`) has a static factory
+`AbstractNode.from(value)` that picks between two subclasses (`Leaf` and
+`Node`). To do that, `AbstractNode.ts` has to import `Leaf.ts` and
+`Node.ts` at the top of the file. But those subclass files also import
+`AbstractNode` (for `class Leaf extends AbstractNode {}`). That's a
+circular import. When the entry point happens to hit `AbstractNode.ts`
+first, its imports of `Leaf`/`Node` cause those files to start
+evaluating before `AbstractNode`'s own `class ... {}` declaration has
+assigned anything to the module's exports — and then the subclass's
+`extends` clause blows up.
+
+## Running everything
+
+```bash
+for p in a b c d; do
+  echo "--- $p ---"
+  (cd "$p" && npm install --loglevel=error >/dev/null && npm run -s run-repro; echo "exit=$?")
+done
+```
+
+You should see `a` and `c` exit non-zero with a runtime error, and `b`
+and `d` print `{ name: "joist", kind: "orm", stars: 42 }` and exit 0.

--- a/circular-imports/a/.gitignore
+++ b/circular-imports/a/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+package-lock.json

--- a/circular-imports/a/README.md
+++ b/circular-imports/a/README.md
@@ -1,0 +1,51 @@
+# circular-imports/a — CommonJS reproducer
+
+Reproduces the runtime error described in
+<https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de>
+using three TypeScript classes compiled to CommonJS.
+
+## Layout
+
+```
+src/
+  index.ts          entry, imports AbstractNode
+  AbstractNode.ts   base class, imports Leaf and Node (for its static factory)
+  Leaf.ts           extends AbstractNode
+  Node.ts           extends AbstractNode
+```
+
+`AbstractNode` ↔ `Leaf` and `AbstractNode` ↔ `Node` form two import cycles,
+and because `AbstractNode.ts` imports its subclasses at the *top* of the file
+(before the `class AbstractNode` declaration has populated `module.exports`),
+the subclass modules see an empty `exports` object when they try to extend it.
+
+## Running
+
+```bash
+npm install
+npm run run-repro
+```
+
+## Expected output
+
+```
+TypeError: Class extends value undefined is not a constructor or null
+    at Object.<anonymous> (.../dist/Leaf.js:...)
+    ...
+```
+
+## Why it fails
+
+1. Node begins executing `dist/index.js`, which `require`s `./AbstractNode`.
+2. `AbstractNode.js` is added to the require cache with an empty `exports`
+   object, then its body starts running.
+3. Its first statement is `require("./Leaf")`.
+4. `Leaf.js` starts running. Its first statement is `require("./AbstractNode")`
+   — which is already in the cache, so it gets back the *empty* `exports`.
+5. `Leaf.js` runs `class Leaf extends AbstractNode {}`. `AbstractNode` is
+   `undefined` on the partial exports object, so V8 throws
+   `TypeError: Class extends value undefined is not a constructor or null`.
+6. `AbstractNode.js`'s own `class AbstractNode { ... }` statement — the one
+   that would actually populate `exports.AbstractNode` — never runs.
+
+See `circular-imports/b` for the fix.

--- a/circular-imports/a/package.json
+++ b/circular-imports/a/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "circular-imports-a",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Reproduces the circular-dependency runtime error from the Medium article in CommonJS.",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "run-repro": "tsc -p tsconfig.json && node dist/index.js"
+  },
+  "devDependencies": {
+    "typescript": "5.9.2"
+  }
+}

--- a/circular-imports/a/src/AbstractNode.ts
+++ b/circular-imports/a/src/AbstractNode.ts
@@ -1,0 +1,26 @@
+// AbstractNode is the base class. It imports its own subclasses so that it can
+// offer a static `from(...)` factory that picks Leaf vs Node based on the input.
+//
+// This is the shape the Medium article warns about: the base class has a
+// compile-time reference to its subclasses.
+import { Leaf } from "./Leaf";
+import { Node } from "./Node";
+
+export abstract class AbstractNode {
+  constructor(public readonly parent: AbstractNode | null = null) {}
+
+  getDepth(): number {
+    return this.parent === null ? 0 : this.parent.getDepth() + 1;
+  }
+
+  // Factory that constructs a Leaf for primitives and a Node for objects.
+  // The references to `Leaf` and `Node` here are what force the circular import.
+  static from(value: unknown, parent: AbstractNode | null = null): AbstractNode {
+    if (value !== null && typeof value === "object") {
+      return new Node(value as Record<string, unknown>, parent);
+    }
+    return new Leaf(value, parent);
+  }
+
+  abstract print(): string;
+}

--- a/circular-imports/a/src/Leaf.ts
+++ b/circular-imports/a/src/Leaf.ts
@@ -1,0 +1,14 @@
+import { AbstractNode } from "./AbstractNode";
+
+export class Leaf extends AbstractNode {
+  constructor(
+    public readonly value: unknown,
+    parent: AbstractNode | null = null,
+  ) {
+    super(parent);
+  }
+
+  print(): string {
+    return JSON.stringify(this.value);
+  }
+}

--- a/circular-imports/a/src/Node.ts
+++ b/circular-imports/a/src/Node.ts
@@ -1,0 +1,17 @@
+import { AbstractNode } from "./AbstractNode";
+
+export class Node extends AbstractNode {
+  constructor(
+    public readonly value: Record<string, unknown>,
+    parent: AbstractNode | null = null,
+  ) {
+    super(parent);
+  }
+
+  print(): string {
+    const entries = Object.entries(this.value).map(
+      ([k, v]) => `${k}: ${AbstractNode.from(v, this).print()}`,
+    );
+    return `{ ${entries.join(", ")} }`;
+  }
+}

--- a/circular-imports/a/src/index.ts
+++ b/circular-imports/a/src/index.ts
@@ -1,0 +1,16 @@
+// The entry point imports the base class first. Because AbstractNode.ts itself
+// imports ./Leaf and ./Node at the top, CommonJS will:
+//
+//   1. begin evaluating AbstractNode.ts
+//   2. synchronously require ./Leaf
+//   3. Leaf.ts requires ./AbstractNode -- which is already in the require cache
+//      in a PARTIALLY initialized state (module.exports is still `{}`)
+//   4. `class Leaf extends AbstractNode {}` executes while AbstractNode is
+//      undefined
+//   5. Node throws: "Class extends value undefined is not a constructor or null"
+//
+// So this file never even gets to run its own body.
+import { AbstractNode } from "./AbstractNode";
+
+const tree = AbstractNode.from({ name: "joist", kind: "orm", stars: 42 });
+console.log(tree.print());

--- a/circular-imports/a/tsconfig.json
+++ b/circular-imports/a/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": false,
+    "declaration": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/circular-imports/b/.gitignore
+++ b/circular-imports/b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+package-lock.json

--- a/circular-imports/b/README.md
+++ b/circular-imports/b/README.md
@@ -1,0 +1,65 @@
+# circular-imports/b — CommonJS fix
+
+Takes the exact same classes from [`../a`](../a) and applies the
+"internal module" pattern from the Medium article to fix the circular
+dependency.
+
+## Layout
+
+```
+src/
+  index.ts          entry; imports ONLY from ./internal
+  internal.ts       re-exports every sibling, in dependency order
+  AbstractNode.ts   imports Leaf/Node from ./internal (used inside methods only)
+  Node.ts           imports AbstractNode from ./internal, then extends it
+  Leaf.ts           imports AbstractNode from ./internal, then extends it
+```
+
+The key rule: **no file imports from a sibling directly; everyone imports
+from `./internal`**. That makes `internal.ts` the single arbiter of load
+order.
+
+## Running
+
+```bash
+npm install
+npm run run-repro
+```
+
+## Expected output
+
+```
+{ name: "joist", kind: "orm", stars: 42 }
+```
+
+## Why it works
+
+`internal.ts` re-exports the three class modules in a specific order:
+
+```ts
+export * from "./AbstractNode";
+export * from "./Node";
+export * from "./Leaf";
+```
+
+Execution now goes:
+
+1. Node begins executing `dist/index.js`, which requires `./internal`.
+2. `internal.js` is added to the require cache; its body starts running.
+3. First statement: `require("./AbstractNode")`.
+4. `AbstractNode.js` starts. Its first statement is `require("./internal")`
+   — which is in the cache already, partial. No problem: the only names
+   `AbstractNode.js` pulls off it (`Leaf`, `Node`) are referenced inside
+   method bodies, not at module-top-level.
+5. `AbstractNode.js` finishes. `exports.AbstractNode` is now populated.
+6. Back in `internal.js`: `require("./Node")` runs. `Node.js` does
+   `require("./internal")` and pulls `AbstractNode` off it — which is now
+   real — and `class Node extends AbstractNode {}` succeeds.
+7. Same for `./Leaf`.
+8. `internal.js` finishes; `index.js` continues.
+
+The trick is that `AbstractNode`'s references to its subclasses are all
+behind function boundaries, so they don't need to be resolved until after
+the whole module graph has loaded. The subclasses' references to their
+parent, though, DO need to be resolved synchronously (for `class X
+extends Y {}`), so `AbstractNode` is listed first in `internal.ts`.

--- a/circular-imports/b/package.json
+++ b/circular-imports/b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "circular-imports-b",
+  "private": true,
+  "version": "0.0.0",
+  "description": "CommonJS fix for the circular-import problem using the 'internal module' pattern.",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "run-repro": "tsc -p tsconfig.json && node dist/index.js"
+  },
+  "devDependencies": {
+    "typescript": "5.9.2"
+  }
+}

--- a/circular-imports/b/src/AbstractNode.ts
+++ b/circular-imports/b/src/AbstractNode.ts
@@ -1,0 +1,27 @@
+// Note: we import Leaf and Node via ./internal, NOT directly from ./Leaf or
+// ./Node. When this file is evaluated, ./internal is already "in flight" --
+// internal.ts is the module that kicked off loading AbstractNode in the first
+// place -- so the `Leaf` and `Node` bindings we pull off it will still be
+// undefined at this point in time.
+//
+// That's fine! The only place we reference them is inside the body of
+// `static from(...)`, which doesn't run until *after* all three modules have
+// finished loading and `internal.ts`'s re-exports have been fully populated.
+import { Leaf, Node } from "./internal";
+
+export abstract class AbstractNode {
+  constructor(public readonly parent: AbstractNode | null = null) {}
+
+  getDepth(): number {
+    return this.parent === null ? 0 : this.parent.getDepth() + 1;
+  }
+
+  static from(value: unknown, parent: AbstractNode | null = null): AbstractNode {
+    if (value !== null && typeof value === "object") {
+      return new Node(value as Record<string, unknown>, parent);
+    }
+    return new Leaf(value, parent);
+  }
+
+  abstract print(): string;
+}

--- a/circular-imports/b/src/Leaf.ts
+++ b/circular-imports/b/src/Leaf.ts
@@ -1,0 +1,14 @@
+import { AbstractNode } from "./internal";
+
+export class Leaf extends AbstractNode {
+  constructor(
+    public readonly value: unknown,
+    parent: AbstractNode | null = null,
+  ) {
+    super(parent);
+  }
+
+  print(): string {
+    return JSON.stringify(this.value);
+  }
+}

--- a/circular-imports/b/src/Node.ts
+++ b/circular-imports/b/src/Node.ts
@@ -1,0 +1,17 @@
+import { AbstractNode } from "./internal";
+
+export class Node extends AbstractNode {
+  constructor(
+    public readonly value: Record<string, unknown>,
+    parent: AbstractNode | null = null,
+  ) {
+    super(parent);
+  }
+
+  print(): string {
+    const entries = Object.entries(this.value).map(
+      ([k, v]) => `${k}: ${AbstractNode.from(v, this).print()}`,
+    );
+    return `{ ${entries.join(", ")} }`;
+  }
+}

--- a/circular-imports/b/src/index.ts
+++ b/circular-imports/b/src/index.ts
@@ -1,0 +1,6 @@
+// Entry points import from ./internal too, so that THEY also play by the
+// rules of the centralized load order.
+import { AbstractNode } from "./internal";
+
+const tree = AbstractNode.from({ name: "joist", kind: "orm", stars: 42 });
+console.log(tree.print());

--- a/circular-imports/b/src/internal.ts
+++ b/circular-imports/b/src/internal.ts
@@ -1,0 +1,11 @@
+// The "internal module" pattern from the Medium article.
+//
+// Every file in this project imports from `./internal` instead of from its
+// siblings directly. That centralizes the module-load order in ONE place:
+// the order of these re-exports below.
+//
+// The rule: list modules from least-dependent to most-dependent. The base
+// class must finish evaluating before any subclass runs `class X extends Y {}`.
+export * from "./AbstractNode";
+export * from "./Node";
+export * from "./Leaf";

--- a/circular-imports/b/tsconfig.json
+++ b/circular-imports/b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": false,
+    "declaration": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/circular-imports/c/.gitignore
+++ b/circular-imports/c/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+package-lock.json

--- a/circular-imports/c/README.md
+++ b/circular-imports/c/README.md
@@ -1,0 +1,52 @@
+# circular-imports/c — ESM reproducer
+
+Same source structure as [`../a`](../a), ported to native ES modules:
+
+- `package.json` sets `"type": "module"`
+- `tsconfig.json` uses `module: "NodeNext"` and `moduleResolution: "NodeNext"`
+- sibling imports use explicit `.js` extensions, per the NodeNext
+  resolution rules
+
+## Running
+
+```bash
+npm install
+npm run run-repro
+```
+
+## Expected output
+
+```
+ReferenceError: Cannot access 'AbstractNode' before initialization
+    at file://.../dist/Leaf.js:... (the `class Leaf extends AbstractNode` line)
+```
+
+## Why it fails — ESM flavor
+
+In CJS (`../a`), the failure mode is "subclass module sees an empty
+`module.exports` because CJS hands out partial exports during cycles". The
+subclass extends `undefined`.
+
+In ESM there is no partial-exports object; every export is a live binding.
+But live bindings can be in the TDZ. Evaluation order is:
+
+1. The module graph is fully parsed and linked.
+2. Starting from `index.js`, Node performs a DFS through imports.
+3. To evaluate `index.js`, its dependency `AbstractNode.js` must evaluate
+   first.
+4. To evaluate `AbstractNode.js`, ITS dependencies `Leaf.js` and `Node.js`
+   must evaluate first (in source order).
+5. To evaluate `Leaf.js`, its dependency `AbstractNode.js` must evaluate.
+   But `AbstractNode.js` is already on the evaluation stack — cycle — so
+   Node proceeds to run `Leaf.js`'s body anyway.
+6. `Leaf.js` body runs: `class Leaf extends AbstractNode {}`. The
+   `AbstractNode` binding exists (ESM imports are hoisted) but the class
+   declaration inside `AbstractNode.js` has not executed yet, so the
+   binding is still in the TDZ.
+7. V8 throws `ReferenceError: Cannot access 'AbstractNode' before
+   initialization`.
+
+Same root cause as CJS (module-top-level `extends` inside a cycle), just
+a different error class.
+
+See `../d` for the fix.

--- a/circular-imports/c/package.json
+++ b/circular-imports/c/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "circular-imports-c",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Reproduces the circular-dependency runtime error in ESM. Same source shape as circular-imports/a but with `type: module` and NodeNext resolution.",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "run-repro": "tsc -p tsconfig.json && node dist/index.js"
+  },
+  "devDependencies": {
+    "typescript": "5.9.2"
+  }
+}

--- a/circular-imports/c/src/AbstractNode.ts
+++ b/circular-imports/c/src/AbstractNode.ts
@@ -1,0 +1,19 @@
+import { Leaf } from "./Leaf.js";
+import { Node } from "./Node.js";
+
+export abstract class AbstractNode {
+  constructor(public readonly parent: AbstractNode | null = null) {}
+
+  getDepth(): number {
+    return this.parent === null ? 0 : this.parent.getDepth() + 1;
+  }
+
+  static from(value: unknown, parent: AbstractNode | null = null): AbstractNode {
+    if (value !== null && typeof value === "object") {
+      return new Node(value as Record<string, unknown>, parent);
+    }
+    return new Leaf(value, parent);
+  }
+
+  abstract print(): string;
+}

--- a/circular-imports/c/src/Leaf.ts
+++ b/circular-imports/c/src/Leaf.ts
@@ -1,0 +1,14 @@
+import { AbstractNode } from "./AbstractNode.js";
+
+export class Leaf extends AbstractNode {
+  constructor(
+    public readonly value: unknown,
+    parent: AbstractNode | null = null,
+  ) {
+    super(parent);
+  }
+
+  print(): string {
+    return JSON.stringify(this.value);
+  }
+}

--- a/circular-imports/c/src/Node.ts
+++ b/circular-imports/c/src/Node.ts
@@ -1,0 +1,17 @@
+import { AbstractNode } from "./AbstractNode.js";
+
+export class Node extends AbstractNode {
+  constructor(
+    public readonly value: Record<string, unknown>,
+    parent: AbstractNode | null = null,
+  ) {
+    super(parent);
+  }
+
+  print(): string {
+    const entries = Object.entries(this.value).map(
+      ([k, v]) => `${k}: ${AbstractNode.from(v, this).print()}`,
+    );
+    return `{ ${entries.join(", ")} }`;
+  }
+}

--- a/circular-imports/c/src/index.ts
+++ b/circular-imports/c/src/index.ts
@@ -1,0 +1,21 @@
+// Same layout as ../a, but running as native ESM instead of CommonJS.
+//
+// ESM fails the cycle differently than CJS:
+//
+//   - In CJS, partially-loaded modules hand out an empty `exports` object, so
+//     the importing file sees `undefined` for its named imports. Extending
+//     `undefined` throws "Class extends value undefined is not a constructor
+//     or null" at module-top-level.
+//
+//   - In ESM, bindings are always "live" but can be in the Temporal Dead
+//     Zone. Reading them before the exporting module has initialized them
+//     throws "Cannot access 'AbstractNode' before initialization"
+//     (ReferenceError) the first time `class Leaf extends AbstractNode {}`
+//     tries to resolve the parent class.
+//
+// Either way: module-top-level `class X extends Y {}` inside a cycle is a
+// time bomb.
+import { AbstractNode } from "./AbstractNode.js";
+
+const tree = AbstractNode.from({ name: "joist", kind: "orm", stars: 42 });
+console.log(tree.print());

--- a/circular-imports/c/tsconfig.json
+++ b/circular-imports/c/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": false,
+    "declaration": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/circular-imports/d/.gitignore
+++ b/circular-imports/d/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+package-lock.json

--- a/circular-imports/d/README.md
+++ b/circular-imports/d/README.md
@@ -1,0 +1,198 @@
+# circular-imports/d — ESM fix (and brainstorm)
+
+Same classes as [`../c`](../c), with the internal-module pattern from
+[`../b`](../b) ported to ESM.
+
+## Running
+
+```bash
+npm install
+npm run run-repro
+```
+
+## Expected output
+
+```
+{ name: "joist", kind: "orm", stars: 42 }
+```
+
+## Why this works in ESM
+
+The fix carries over more or less verbatim from CJS. The *mechanism* is
+different, but the result is the same.
+
+When `index.js` imports `./internal.js`, Node builds the module graph and
+then performs a DFS evaluation starting from `internal.js`'s re-exports
+in source order:
+
+```ts
+// internal.ts
+export * from "./AbstractNode.js";
+export * from "./Node.js";
+export * from "./Leaf.js";
+```
+
+1. `internal.js` evaluation begins.
+2. DFS: evaluate `AbstractNode.js` first.
+3. `AbstractNode.js` imports `Leaf`/`Node` from `./internal.js`, but
+   `internal.js` is already on the eval stack → cycle, skip recursion.
+4. `AbstractNode.js`'s body runs: `class AbstractNode {}` is declared and
+   the binding is now initialized.
+5. DFS continues: evaluate `Node.js`. It imports `AbstractNode` from
+   `./internal.js` (cycle-skip), but the binding for `AbstractNode` is now
+   out of the TDZ, so `class Node extends AbstractNode {}` succeeds.
+6. Same for `Leaf.js`.
+7. `internal.js` finishes; `index.js` proceeds.
+
+Key invariant: inside the cycle, the only files that run
+`class X extends Y {}` at module-top-level are the leaf files (`Node.js`,
+`Leaf.js`), and they only run AFTER `internal.js` has forced
+`AbstractNode.js` to fully evaluate first.
+
+## Brainstorm: other ways to fix this in ESM
+
+The internal-module pattern is one option, but ESM gives us more tools
+than CJS did. Some alternatives, in rough order of invasiveness:
+
+### 1. The internal-module pattern (this project)
+
+**Pros**
+
+- Works identically in CJS and ESM.
+- Zero changes to consumer code outside the package.
+- Single file controls evaluation order — easy to audit.
+
+**Cons**
+
+- Every sibling import becomes `from "./internal"`, which can obscure the
+  real dependency graph and defeat tree-shaking at leaf package
+  boundaries.
+- Newcomers have to learn the convention.
+
+### 2. Lift the factory out of the base class
+
+Turn `AbstractNode.from(...)` into a standalone `createNode(...)` helper
+in its own file. `AbstractNode.ts` no longer imports its subclasses, so
+the cycle goes away entirely.
+
+**Pros**
+
+- No cycle at all — the cleanest fix.
+- No special conventions.
+
+**Cons**
+
+- Public API change. Callers write `createNode(x)` instead of
+  `AbstractNode.from(x)`.
+- Doesn't help when the "factory on the base class" is specifically what
+  you want for ergonomics.
+
+### 3. Lazy subclass access inside the base class
+
+Keep the `static from(...)` on `AbstractNode`, but don't import `Leaf`
+and `Node` at the top of the file. Instead, use a dynamic `import()` or
+a lazy indirection:
+
+```ts
+// AbstractNode.ts — no top-level imports of Leaf/Node
+export abstract class AbstractNode {
+  static async from(value: unknown): Promise<AbstractNode> {
+    const { Leaf } = await import("./Leaf.js");
+    const { Node } = await import("./Node.js");
+    return typeof value === "object" && value !== null
+      ? new Node(value as Record<string, unknown>)
+      : new Leaf(value);
+  }
+}
+```
+
+**Pros**
+
+- No cycle at graph-construction time; ESM evaluates `AbstractNode.js`
+  without ever touching `Leaf.js` or `Node.js`.
+- Works without any convention file.
+
+**Cons**
+
+- `from` becomes async, which infects callers.
+- Dynamic imports have a runtime cost on first hit.
+- You can cache them, but now you're hand-rolling a registry.
+
+### 4. Inversion: subclasses register themselves with the base
+
+Have the base class own a small registry and have subclasses call
+`AbstractNode.register(...)` at module-init time:
+
+```ts
+// AbstractNode.ts
+export abstract class AbstractNode {
+  private static matchers: Array<{
+    test: (v: unknown) => boolean;
+    make: (v: unknown) => AbstractNode;
+  }> = [];
+  static register(m: (typeof AbstractNode.matchers)[number]) {
+    AbstractNode.matchers.push(m);
+  }
+  static from(value: unknown): AbstractNode {
+    const m = AbstractNode.matchers.find((x) => x.test(value));
+    if (!m) throw new Error("no matcher");
+    return m.make(value);
+  }
+}
+```
+
+```ts
+// Leaf.ts
+import { AbstractNode } from "./AbstractNode.js";
+export class Leaf extends AbstractNode { ... }
+AbstractNode.register({ test: (v) => typeof v !== "object", make: (v) => new Leaf(v) });
+```
+
+**Pros**
+
+- Base class has no static knowledge of its subclasses — clean DAG.
+- Scales gracefully to N subclasses added by N different files (or even
+  by downstream packages).
+
+**Cons**
+
+- Whoever calls `AbstractNode.from(...)` has to have somehow imported the
+  subclass files first (otherwise they never registered).
+  That is often solved with a barrel file that imports every subclass
+  for its side effects — which is basically the internal-module pattern
+  again, just with side-effect imports.
+- The set of matchers is now mutable global state.
+
+### 5. Put the `extends` relationship behind a class factory
+
+Not really ESM-specific, but: instead of `class Leaf extends AbstractNode
+{}` at module top-level, wrap it:
+
+```ts
+// Leaf.ts
+import type { AbstractNodeType } from "./AbstractNode.js";
+export const makeLeaf = (Base: AbstractNodeType) => class Leaf extends Base { ... };
+```
+
+and have `internal.ts` or a consumer instantiate it after `AbstractNode`
+is known. This defers the `extends` check past the cycle entirely.
+
+**Pros**
+
+- Fundamentally side-steps the "can't extend a TDZ binding" problem.
+
+**Cons**
+
+- Awkward to use. `instanceof Leaf` no longer makes sense because the
+  `Leaf` class identity depends on who called `makeLeaf`.
+- Often more ceremony than it's worth.
+
+### Recommendation
+
+For a library like Joist, where cycles emerge between base entities and
+their subclasses / meta / factory methods, option 1 (the internal-module
+pattern) is almost always the right default: it's mechanical, it's
+greppable (every import outside `./internal` is a red flag), and it
+works the same in both CJS and ESM builds. Option 2 (refactor the cycle
+out of existence) is better when feasible but is not always possible to
+retrofit.

--- a/circular-imports/d/package.json
+++ b/circular-imports/d/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "circular-imports-d",
+  "private": true,
+  "version": "0.0.0",
+  "description": "ESM version of the internal-module fix. Same classes as c/, plus internal.ts.",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "run-repro": "tsc -p tsconfig.json && node dist/index.js"
+  },
+  "devDependencies": {
+    "typescript": "5.9.2"
+  }
+}

--- a/circular-imports/d/src/AbstractNode.ts
+++ b/circular-imports/d/src/AbstractNode.ts
@@ -1,0 +1,22 @@
+// As in circular-imports/b, we pull `Leaf` and `Node` off ./internal rather
+// than from their sibling files directly. Those bindings may still be in the
+// TDZ when THIS module evaluates, but we only use them inside method bodies
+// that don't run until well after the whole graph has finished loading.
+import { Leaf, Node } from "./internal.js";
+
+export abstract class AbstractNode {
+  constructor(public readonly parent: AbstractNode | null = null) {}
+
+  getDepth(): number {
+    return this.parent === null ? 0 : this.parent.getDepth() + 1;
+  }
+
+  static from(value: unknown, parent: AbstractNode | null = null): AbstractNode {
+    if (value !== null && typeof value === "object") {
+      return new Node(value as Record<string, unknown>, parent);
+    }
+    return new Leaf(value, parent);
+  }
+
+  abstract print(): string;
+}

--- a/circular-imports/d/src/Leaf.ts
+++ b/circular-imports/d/src/Leaf.ts
@@ -1,0 +1,14 @@
+import { AbstractNode } from "./internal.js";
+
+export class Leaf extends AbstractNode {
+  constructor(
+    public readonly value: unknown,
+    parent: AbstractNode | null = null,
+  ) {
+    super(parent);
+  }
+
+  print(): string {
+    return JSON.stringify(this.value);
+  }
+}

--- a/circular-imports/d/src/Node.ts
+++ b/circular-imports/d/src/Node.ts
@@ -1,0 +1,17 @@
+import { AbstractNode } from "./internal.js";
+
+export class Node extends AbstractNode {
+  constructor(
+    public readonly value: Record<string, unknown>,
+    parent: AbstractNode | null = null,
+  ) {
+    super(parent);
+  }
+
+  print(): string {
+    const entries = Object.entries(this.value).map(
+      ([k, v]) => `${k}: ${AbstractNode.from(v, this).print()}`,
+    );
+    return `{ ${entries.join(", ")} }`;
+  }
+}

--- a/circular-imports/d/src/index.ts
+++ b/circular-imports/d/src/index.ts
@@ -1,0 +1,4 @@
+import { AbstractNode } from "./internal.js";
+
+const tree = AbstractNode.from({ name: "joist", kind: "orm", stars: 42 });
+console.log(tree.print());

--- a/circular-imports/d/src/internal.ts
+++ b/circular-imports/d/src/internal.ts
@@ -1,0 +1,10 @@
+// Same "internal module" pattern as circular-imports/b, but for ESM.
+//
+// In ESM the ordering semantics are a little different -- evaluation is a
+// DFS through the module graph, and the graph is fully built before any
+// body runs -- but the fix is identical: put the base class first so that
+// by the time a subclass's `class X extends Y` line runs, the parent
+// class has already been initialized in its own module.
+export * from "./AbstractNode.js";
+export * from "./Node.js";
+export * from "./Leaf.js";

--- a/circular-imports/d/tsconfig.json
+++ b/circular-imports/d/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": false,
+    "declaration": false
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

This PR adds a comprehensive educational resource demonstrating circular dependency problems and solutions in both CommonJS and ESM module systems. Four self-contained TypeScript projects walk through the issue and its fix using the "internal module" pattern.

## Key Changes

- **circular-imports/a**: CommonJS reproducer that demonstrates the circular dependency problem with a base class that imports its subclasses for a static factory method. Shows the `TypeError: Class extends value undefined is not a constructor or null` failure.

- **circular-imports/b**: CommonJS fix using the "internal module" pattern, where all sibling imports go through a centralized `internal.ts` file that controls module evaluation order.

- **circular-imports/c**: ESM reproducer with identical source structure to (a), ported to native ES modules. Demonstrates the ESM variant of the same problem: `ReferenceError: Cannot access 'AbstractNode' before initialization`.

- **circular-imports/d**: ESM fix applying the internal-module pattern from (b) to ESM, plus extensive documentation brainstorming five alternative approaches to solving circular dependencies in ESM (lazy imports, factory functions, registration patterns, etc.).

Each project includes:
- Self-contained `package.json`, `tsconfig.json`, and `.gitignore`
- Detailed README explaining the problem, why it occurs, and how the fix works
- Runnable reproduction with `npm run run-repro`

## Notable Implementation Details

- The internal-module pattern works identically in both CJS and ESM despite their different evaluation semantics (partial exports vs. temporal dead zones)
- All projects use TypeScript compiled to their respective module systems
- ESM projects use `"type": "module"` and `NodeNext` resolution with explicit `.js` extensions
- The brainstorm section in (d) documents trade-offs of alternative approaches, providing context for when the internal-module pattern is appropriate vs. when refactoring the cycle out entirely is better

https://claude.ai/code/session_013BDkSXQA4UBmx4sVBKjjLq