### PR TITLE
fix: m2o cascade delete not working for DB loaded entities 

### DIFF
--- a/packages/core/src/relations/ManyToOneReference.ts
+++ b/packages/core/src/relations/ManyToOneReference.ts
@@ -250,8 +250,15 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
   maybeCascadeDelete(): void {
     if (this.isCascadeDelete) {
       const current = this.current({ withDeleted: true });
-      if (current !== undefined && typeof current !== "string") {
-        this.entity.em.delete(current as U);
+      if (current !== undefined) {
+        if (typeof current === "string") {
+          // We're invoked twice, once sync on em.delete, and again in em.flush when we're loaded;
+          // but even when loaded, current might still be the tagged id, but we can find the entity in the EM
+          const other = this.entity.em.getEntity(current);
+          if (other) this.entity.em.delete(other as U);
+        } else {
+          this.entity.em.delete(current as U);
+        }
       }
     }
   }

--- a/packages/tests/integration/src/entities/Book.ts
+++ b/packages/tests/integration/src/entities/Book.ts
@@ -163,4 +163,7 @@ config.afterCommit((book) => {
   }
 });
 
+// For testing cascadeDelete on a m2o
+config.cascadeDelete("randomComment");
+
 function noop(_: any): void {}

--- a/packages/tests/integration/src/entities/inserts.ts
+++ b/packages/tests/integration/src/entities/inserts.ts
@@ -81,6 +81,7 @@ export function insertBook(row: {
   author_id: number | null;
   reviewer_id?: number | null;
   prequel_id?: number | null;
+  random_comment_id?: number | null;
   deleted_at?: Date;
   order?: number;
 }) {

--- a/packages/tests/integration/src/relations/ManyToOneReference.test.ts
+++ b/packages/tests/integration/src/relations/ManyToOneReference.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@jest/globals";
 import { NoIdError } from "joist-orm";
-import { insertAuthor, insertBook, insertPublisher, select, update } from "src/entities/inserts";
+import { insertAuthor, insertBook, insertComment, insertPublisher, select, update } from "src/entities/inserts";
 import { newEntityManager, numberOfQueries, resetQueryCount } from "src/testEm";
 
 import { Author, Book, newAuthor, newBook, newPublisher, newUser } from "../entities";
@@ -195,5 +195,46 @@ describe("ManyToOneReference", () => {
     const em = newEntityManager();
     const book = newBook(em);
     expect(() => book.author.idIfSet).toThrow(new NoIdError("Reference Book#1.author is assigned to a new entity"));
+  });
+
+  it("can cascade delete when set in this em", async () => {
+    const em = newEntityManager();
+    // Given a book that was pointed at its comment by `set`, so `data.randomComment` holds the entity
+    const b1 = newBook(em, { randomComment: {} });
+    await em.flush();
+    em.delete(b1);
+    await em.flush();
+    // Then the comment is cascade deleted
+    expect(await select("comments")).toHaveLength(0);
+  });
+
+  it("can cascade delete when loaded from the database", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertComment({ text: "c1" });
+    await insertBook({ title: "b1", author_id: 1, random_comment_id: 1 });
+    const em = newEntityManager();
+    // Given a book whose m2o came from the db, so `data.randomComment` is the tagged id `comment:1`,
+    // and we've explicitly populated the relation before deleting
+    const b1 = await em.load(Book, "b:1", "randomComment");
+    expect(b1.randomComment.get).toBeDefined();
+    em.delete(b1);
+    await em.flush();
+    // Then the comment is still cascade deleted
+    expect(await select("comments")).toHaveLength(0);
+  });
+
+  it("can cascade delete when not loaded until the flush", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertComment({ text: "c1" });
+    await insertBook({ title: "b1", author_id: 1, random_comment_id: 1 });
+    const em = newEntityManager();
+    // Given the m2o is still an unloaded foreign key when we delete, so `flushDeletes` is the
+    // one that has to `load()` it before cascading
+    const b1 = await em.load(Book, "b:1");
+    expect(b1.randomComment.isLoaded).toBe(false);
+    em.delete(b1);
+    await em.flush();
+    // Then the comment is still cascade deleted
+    expect(await select("comments")).toHaveLength(0);
   });
 });


### PR DESCRIPTION
`config.cascadeDelete("someM2o")` only deletes the child when the m2o was `set()` in the current EM. For any entity loaded from the database, the cascade is silently skipped.

Testes were added to https://github.com/joist-orm/joist-orm/blob/6a556ff11afe8fe4dc471745d08f03eba81d9efe/packages/tests/integration/src/relations/ManyToOneReference.test.ts#L200-L238 to reproduce the issue.

`ManyToOneReferenceImpl.maybeCascadeDelete` reads `current()`:

```ts
maybeCascadeDelete(): void {
    if (this.isCascadeDelete) {
      const current = this.current({ withDeleted: true });
      if (current !== undefined && typeof current !== "string") {
        this.entity.em.delete(current as U);
      }
    }
  } 
```

`current()` returns the raw data[fieldName], which is the tagged id ("comment:1") for a db-loaded m2o. Loading the relation (`populate hint` or `load()`) makes `current()` return a string, so the `typeof current !== "string"` guard skips the delete.