### PR TITLE
fix: Fix soft-delete resurrection not triggering reactivity.

### DIFF
--- a/packages/core/src/reactiveHints.ts
+++ b/packages/core/src/reactiveHints.ts
@@ -10,6 +10,7 @@ import {
   type OneToOneField,
   type PolymorphicFieldComponent,
   getBaseAndSelfMetas,
+  getBaseMeta,
   getMetadata,
 } from "./EntityMetadata.ts";
 import { getProperties } from "./getProperties.ts";
@@ -362,7 +363,7 @@ function reverseSubHint(
       maybeRecursive.push({
         kind: isReadOnly ? "read-only" : "update",
         entity: entityType,
-        fields: [m2oFieldName],
+        fields: recursiveMembershipFields(meta, m2oFieldName),
         path: [otherFieldName],
       });
       // Any reactables who were watching `parentsRecursive`, we'll back down to by going through `childrenRecursive`
@@ -382,7 +383,7 @@ function reverseSubHint(
       maybeRecursive.push({
         kind: isReadOnly ? "read-only" : "update",
         entity: entityType,
-        fields: [m2oFieldName], // i.e. parent
+        fields: recursiveMembershipFields(meta, m2oFieldName), // i.e. parent
         path: [otherFieldName], // i.e. parentsRecursive to tell them "observe your new childrenRecursive"
       });
       // Any reactables who were watching `childrenRecursive`, we'll up to by going through `parentsRecursive`
@@ -403,7 +404,7 @@ function reverseSubHint(
       maybeRecursive.push({
         kind: isReadOnly ? "read-only" : "update",
         entity: entityType,
-        fields: [m2mFieldName],
+        fields: recursiveMembershipFields(meta, m2mFieldName),
         path: [otherFieldName],
       });
       // Any reactables who were watching this recursive collection, we'll reach via the other direction
@@ -505,7 +506,7 @@ export async function followReverseHint(
       // If we're going from Book.author back to Author to re-validate the Author.books collection,
       // see if Book.author has changed, so we can re-validate both the old author's books and the
       // new author's books.
-      const fieldKind = getMetadata(c).fields[fieldName]?.kind;
+      const fieldKind = getMetadata(c).allFields[fieldName]?.kind;
       const isReference = fieldKind === "m2o" || fieldKind === "poly";
       const isManyToMany = fieldKind === "m2m";
       // See jsdoc comment about why this is only necessary for references...
@@ -699,6 +700,12 @@ function appendPath(reverseField: string): (rt: ReactiveTarget) => ReactiveTarge
     rt.path = [...rt.path, reverseField];
     return rt;
   };
+}
+
+/** Recursive membership changes on soft deletion or resurrection, even when the underlying relation is unchanged. */
+function recursiveMembershipFields(meta: EntityMetadata, fieldName: string): string[] {
+  const deletedAt = getBaseMeta(meta).timestampFields?.deletedAt;
+  return deletedAt ? [fieldName, deletedAt] : [fieldName];
 }
 
 function isAllReadOnly(hint: any): boolean {

--- a/packages/tests/integration/src/EntityManager.findOrCreate.test.ts
+++ b/packages/tests/integration/src/EntityManager.findOrCreate.test.ts
@@ -1,8 +1,31 @@
-import { insertAuthor, insertBook, insertComment, insertPublisher, insertTag } from "src/entities/inserts";
+import {
+  insertAuthor,
+  insertBook,
+  insertBookReview,
+  insertComment,
+  insertLargePublisher,
+  insertPublisher,
+  insertPublisherGroup,
+  insertTag,
+  select,
+  update,
+} from "src/entities/inserts";
 import { newEntityManager, numberOfQueries, resetQueryCount } from "src/testEm";
 import { zeroTo } from "src/utils";
 
-import { Author, Book, Comment, Publisher, Tag, newAuthor, newBook, newPublisher, newTag } from "./entities";
+import {
+  Author,
+  Book,
+  Comment,
+  LargePublisher,
+  Publisher,
+  PublisherGroup,
+  Tag,
+  newAuthor,
+  newBook,
+  newPublisher,
+  newTag,
+} from "./entities";
 import { jan1 } from "./testDates";
 
 describe("EntityManager.findOrCreate", () => {
@@ -127,6 +150,71 @@ describe("EntityManager.findOrCreate", () => {
 
     const rows = await em.find(Author, { ssn: "123" }, { softDeletes: "include" });
     expect(rows).toMatchEntity([{ id: "a:1", deletedAt: undefined }]);
+  });
+
+  it("recalculates rootMentor when resurrecting an Author", async () => {
+    // Given a soft-deleted mentor
+    await insertAuthor({ id: 1, first_name: "a1", ssn: "123", deleted_at: jan1 });
+    // And a mentee whose rootMentor is unset because its only ancestor is soft-deleted
+    await insertAuthor({ id: 2, first_name: "a2", mentor_id: 1 });
+    const em = newEntityManager();
+
+    // When resurrection also updates graduated, which does not independently trigger rootMentor
+    const mentor = await em.findOrCreate(Author, { ssn: "123" }, { firstName: "a1" }, { graduated: jan1 });
+    await em.flush();
+
+    // Then the simultaneous graduated update is applied to the resurrected mentor
+    expect(mentor).toMatchEntity({ id: "a:1", graduated: jan1, deletedAt: undefined });
+
+    // Then the mentee's rootMentor is the resurrected Author
+    expect(await select("authors")).toMatchObject([
+      { id: 1, graduated: jan1, deleted_at: null },
+      { id: 2, root_mentor_id: 1 },
+    ]);
+  });
+
+  it("recalculates the old PublisherGroup when resurrecting and moving a LargePublisher", async () => {
+    // Given the original PublisherGroup pg1
+    await insertPublisherGroup({ id: 1, name: "pg1" });
+    // And an empty destination PublisherGroup pg2
+    await insertPublisherGroup({ id: 2, name: "pg2" });
+    // And pg1's stored count includes the review below even while its publisher is soft-deleted,
+    // because the query uses m2o joins
+    await update("publisher_groups", { id: 1, number_of_book_reviews_formatted: "count=1" });
+    // And an Author to satisfy LargePublisher's required spotlightAuthor
+    await insertAuthor({ id: 1, first_name: "a1" });
+    // And a LargePublisher whose inherited group relation points to pg1
+    await insertLargePublisher({ id: 1, name: "lp1", group_id: 1, spotlight_author_id: 1 });
+    // And the Author belongs to that LargePublisher
+    await update("authors", { id: 1, publisher_id: 1 });
+    // And the Author has a Book
+    await insertBook({ id: 1, title: "b1", author_id: 1 });
+    // And the Book has the review counted by pg1
+    await insertBookReview({ id: 1, book_id: 1, rating: 5 });
+    // And the LargePublisher is soft-deleted without changing its group
+    await update("publishers", { id: 1, deleted_at: jan1 });
+    // And the spotlight Author and destination PublisherGroup are loaded, but the original group is not
+    const em = newEntityManager();
+    const spotlightAuthor = await em.load(Author, "a:1");
+    const newGroup = await em.load(PublisherGroup, "pg:2");
+
+    // When findOrCreate resurrects the LargePublisher and moves it to pg2 in the same call
+    const publisher = await em.findOrCreate(
+      LargePublisher,
+      { name: "lp1" },
+      { rating: 5, spotlightAuthor },
+      { group: newGroup },
+    );
+    await em.flush();
+
+    // Then the LargePublisher is active and belongs to pg2
+    expect(publisher).toMatchEntity({ id: "p:1", group: newGroup, deletedAt: undefined });
+
+    // Then both PublisherGroups recalculate, removing the review from pg1's count and adding it to pg2's
+    expect(await select("publisher_groups")).toMatchObject([
+      { id: 1, number_of_book_reviews_formatted: "count=0" },
+      { id: 2, number_of_book_reviews_formatted: "count=1" },
+    ]);
   });
 
   it("findOrCreate doesn't compile if required field is missing", async () => {

--- a/packages/tests/integration/src/EntityManager.reactiveRules.test.ts
+++ b/packages/tests/integration/src/EntityManager.reactiveRules.test.ts
@@ -270,7 +270,7 @@ describe("EntityManager.reactiveRules", () => {
       { cstr: "Author", name: sm(/Author.ts:\d+/), fields: [], path: [], fn },
       // Author's addCycleRule for mentorsRecursive
       { cstr: "Author", name: sm(/Author.ts:\d+/), fields: ["mentor"], path: [], fn },
-      { cstr: "Author", name: sm(/Author.ts:\d+/), fields: ["mentor"], path: ["menteesRecursive"], fn },
+      { cstr: "Author", name: sm(/Author.ts:\d+/), fields: ["mentor", "deletedAt"], path: ["menteesRecursive"], fn },
       { cstr: "Author", name: sm(/Author.ts:\d+/), fields: [], path: ["menteesRecursive"], fn },
       // Book's noop author.firstName rule, only depends on firstName
       { cstr: "Book", name: sm(/Book.ts:\d+/), fields: ["firstName"], path: ["books"], fn },

--- a/packages/tests/integration/src/reactiveHints.test.ts
+++ b/packages/tests/integration/src/reactiveHints.test.ts
@@ -19,6 +19,7 @@ import {
   Critic,
   Publisher,
   PublisherGroup,
+  TaskOld,
   User,
   newAuthor,
   newLargePublisher,
@@ -153,7 +154,7 @@ describe("reactiveHints", () => {
   it("can do recursive relations", () => {
     expect(reverse(Author, Author, { mentorsRecursive: "firstName" })).toEqual([
       { entity: "Author", fields: ["mentor"], path: [] },
-      { entity: "Author", fields: ["mentor"], path: ["menteesRecursive"] },
+      { entity: "Author", fields: ["mentor", "deletedAt"], path: ["menteesRecursive"] },
       { entity: "Author", fields: ["firstName"], path: ["menteesRecursive"] },
     ]);
     expect(reverse(Book, Book, { author: { mentorsRecursive: { publisher: "name" } } })).toEqual([
@@ -162,12 +163,48 @@ describe("reactiveHints", () => {
       // When `a2.mentor` changes to `a3`, we *could* recalc through `a3.menteesRecursive`, but that would over
       // fetch, so instead we (as a new mentee) ping our books directly + our own mentees.
       { entity: "Author", fields: ["mentor"], path: ["books"] },
-      { entity: "Author", fields: ["mentor"], path: ["menteesRecursive", "books"] },
+      { entity: "Author", fields: ["mentor", "deletedAt"], path: ["menteesRecursive", "books"] },
       // When I am the mentor, and my publisher changes, tell my mentee's books
       { entity: "Author", fields: ["publisher"], path: ["menteesRecursive", "books"] },
       // When I am the Publisher, tell my authors, who if they're mentors, will tell their mentees
       // (which will get us to the `author` level in the hint, to invalidate their books.)
       { entity: "Publisher", fields: ["name"], path: ["authors", "menteesRecursive", "books"] },
+    ]);
+  });
+
+  it("includes soft-delete dependencies for recursive children", () => {
+    expect(reverse(Author, Author, { menteesRecursive: "firstName" })).toEqual([
+      { entity: "Author", fields: ["mentor"], path: [] },
+      { entity: "Author", fields: ["mentor", "deletedAt"], path: ["mentorsRecursive"] },
+      { entity: "Author", fields: ["firstName"], path: ["mentorsRecursive"] },
+    ]);
+  });
+
+  it("keeps recursive soft-delete dependencies read-only for read-only hints", () => {
+    expect(reverse(Author, Author, "mentorsRecursive:ro")).toEqual([
+      { entity: "Author", fields: [], path: [] },
+      { entity: "Author", kind: "read-only", fields: ["mentor"], path: [] },
+      { entity: "Author", kind: "read-only", fields: ["mentor", "deletedAt"], path: ["menteesRecursive"] },
+      { entity: "Author", fields: [], path: ["menteesRecursive"] },
+    ]);
+    expect(reverse(Author, Author, "menteesRecursive:ro")).toEqual([
+      { entity: "Author", fields: [], path: [] },
+      { entity: "Author", kind: "read-only", fields: ["mentor"], path: [] },
+      { entity: "Author", kind: "read-only", fields: ["mentor", "deletedAt"], path: ["mentorsRecursive"] },
+      { entity: "Author", fields: [], path: ["mentorsRecursive"] },
+    ]);
+  });
+
+  it("includes inherited soft-delete dependencies for recursive relations", () => {
+    expect(reverse(TaskOld, TaskOld, "parentOldTasksRecursive")).toEqual([
+      { entity: "TaskOld", fields: ["parentOldTask"], path: [] },
+      { entity: "TaskOld", fields: ["parentOldTask", "deletedAt"], path: ["tasksRecursive"] },
+      { entity: "TaskOld", fields: [], path: ["tasksRecursive"] },
+    ]);
+    expect(reverse(TaskOld, TaskOld, "tasksRecursive")).toEqual([
+      { entity: "TaskOld", fields: ["parentOldTask"], path: [] },
+      { entity: "TaskOld", fields: ["parentOldTask", "deletedAt"], path: ["parentOldTasksRecursive"] },
+      { entity: "TaskOld", fields: [], path: ["parentOldTasksRecursive"] },
     ]);
   });
 

--- a/packages/tests/integration/src/relations/ReactiveField.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveField.test.ts
@@ -564,6 +564,39 @@ describe("ReactiveField", () => {
     }
   });
 
+  it("reacts to soft deletion and resurrection through recursive relations", async () => {
+    // Given three Authors in a mentor chain with current persisted reactive fields
+    const em = newEntityManager();
+    const a1 = newAuthor(em, { firstName: "a1" });
+    // And a2 is both a mentee of a1 and a mentor of a3
+    const a2 = newAuthor(em, { firstName: "a2", mentor: a1 });
+    // And a3 observes both ancestors through mentorsRecursive
+    newAuthor(em, { firstName: "a3", mentor: a2 });
+    await em.flush();
+
+    // When the middle Author is soft-deleted without changing its name or mentor
+    a2.softDelete();
+    await em.flush();
+
+    // Then a1 loses the branch, while a3 still sees a1 through its soft-deleted mentor
+    expect(await select("authors")).toMatchObject([
+      { id: 1, mentee_names: null },
+      { id: 2, mentor_names: "a1", mentee_names: "a3" },
+      { id: 3, mentor_names: "a1" },
+    ]);
+
+    // When the middle Author is resurrected
+    a2.deletedAt = undefined;
+    await em.flush();
+
+    // Then both recursive directions have their original membership
+    expect(await select("authors")).toMatchObject([
+      { id: 1, mentee_names: "a2, a3" },
+      { id: 2, mentor_names: "a1", mentee_names: "a3" },
+      { id: 3, mentor_names: "a2, a1" },
+    ]);
+  });
+
   it("throws validation rules instead of NPEs in lambdas accessing unset required relations", async () => {
     const em = newEntityManager();
     newBook(em, { author: noValue() });


### PR DESCRIPTION
To someone reactively watching `a.books.get`, we previously triggered on `book.author_id` changing, but we also need to trigger on `book.deleted_at`.