### PR TITLE
fix: Prune undefined exists conditions

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -115,8 +115,8 @@ export type QueryCondition =
       | { and: Array<QueryCondition | undefined>; or?: never; exists?: never; notExists?: never }
       | { or: Array<QueryCondition | undefined>; and?: never; exists?: never; notExists?: never }
     ) & { pruneIfUndefined?: "any" | "all" })
-  | { exists: ExistsQuery; notExists?: never; and?: never; or?: never }
-  | { notExists: ExistsQuery; exists?: never; and?: never; or?: never };
+  | { exists: ExistsQuery | undefined; notExists?: never; and?: never; or?: never }
+  | { notExists: ExistsQuery | undefined; exists?: never; and?: never; or?: never };
 
 /** Phantom type information carried by a table-shaped subquery. */
 export interface SubqueryBrand<R, Name extends string> {
@@ -1687,7 +1687,8 @@ function orderByToSql(o: QueryOrderBy, ctx: Ctx): SqlFragment {
 export function conditionToSql(cond: QueryCondition | undefined, ctx: Ctx, topLevel: boolean): SqlFragment | undefined {
   checkCondition(cond);
   if (cond === undefined) return undefined;
-  const resolved = resolveDeferredConditions(resolveQueryCondition(cond, ctx), ctx)!;
+  const resolved = resolveDeferredConditions(resolveQueryCondition(cond, ctx), ctx);
+  if (resolved === undefined) return undefined;
   const filter: ConditionGroup<ConditionInput> = isFilter(resolved) ? resolved : { and: [resolved] };
   const cb = new ConditionBuilder();
   cb.maybeAddExpression(filter);
@@ -1700,7 +1701,8 @@ export function conditionToSql(cond: QueryCondition | undefined, ctx: Ctx, topLe
 
 /**
  * Rejects malformed predicates throughout a condition tree before pruning can discard a restriction.
- * I.e. an invalid Author-name condition stays invalid even inside a group that would otherwise prune.
+ * I.e. an invalid Author-name condition stays invalid even inside a group that would otherwise prune,
+ * while an explicitly omitted query-valued condition is allowed to prune.
  */
 function checkCondition(value: unknown): void {
   if (
@@ -1730,6 +1732,7 @@ function checkCondition(value: unknown): void {
     const key = "exists" in condition ? "exists" : "notExists";
     checkConditionKeys(condition, [key], "Query existence condition");
     const query = condition[key];
+    if (query === undefined) return;
     if (!(query instanceof SubqueryExpr) && !isReadQueryValue(query)) fail(`Query ${key} requires a query(...) value`);
     toQuery(query);
   } else if (condition.kind === "raw") {
@@ -1827,8 +1830,10 @@ function resolveQueryCondition(cond: QueryCondition | undefined, ctx: Ctx): Cond
     return { or: cond.or.map((child) => resolveQueryCondition(child, ctx)), pruneIfUndefined: cond.pruneIfUndefined };
   }
   if ("exists" in cond || "notExists" in cond) {
-    const positive = cond.exists !== undefined;
-    const plan = parseQuery(toQuery(positive ? cond.exists : cond.notExists), ctx, ctx.assigner);
+    const positive = "exists" in cond;
+    const subquery = positive ? cond.exists : cond.notExists;
+    if (subquery === undefined) return undefined;
+    const plan = parseQuery(toQuery(subquery), ctx, ctx.assigner);
     return {
       kind: "raw",
       condition: `${positive ? "EXISTS" : "NOT EXISTS"} (${plan.sql})`,

--- a/packages/tests/integration/src/EntityManager.rawQueries.test.ts
+++ b/packages/tests/integration/src/EntityManager.rawQueries.test.ts
@@ -1,6 +1,7 @@
 import { expectTypeOf } from "expect-type";
 import {
   type ColumnCondition,
+  type ExistsQuery,
   type Loaded,
   type PredicateBrand,
   Query,
@@ -961,6 +962,44 @@ describe("EntityManager.rawQueries", () => {
   });
 
   describe("exists conditions", () => {
+    it("prunes undefined exists and notExists queries", async () => {
+      // Given an Author whose name should remain after optional filters are omitted
+      await insertAuthor({ first_name: "optional" });
+      // And omitted existence queries represented by undefined
+      const optionalExists: ExistsQuery | undefined = undefined;
+      const optionalNotExists: ExistsQuery | undefined = undefined;
+      const em = newEntityManager();
+      const a = table(Author);
+      resetQueryCount();
+
+      // When selecting with omitted existence conditions inside an AND group
+      const grouped = await em.query({
+        from: a,
+        select: a.first_name,
+        where: { and: [a.first_name.eq("optional"), { exists: optionalExists }, { notExists: optionalNotExists }] },
+      });
+      // Then the remaining Author filter still determines the result
+      expect(grouped).toEqual(["optional"]);
+
+      // When selecting with each omitted existence condition at the top level
+      const existsOmitted = await em.query({ from: a, select: a.first_name, where: { exists: optionalExists } });
+      const notExistsOmitted = await em.query({
+        from: a,
+        select: a.first_name,
+        where: { notExists: optionalNotExists },
+      });
+      // Then both omitted conditions contribute no SQL restriction
+      expect(existsOmitted).toEqual(["optional"]);
+      expect(notExistsOmitted).toEqual(["optional"]);
+      expect(queries).toMatchInlineSnapshot(`
+       [
+         "SELECT a.first_name AS value FROM authors AS a WHERE (a.first_name = $1) AND a.deleted_at IS NULL",
+         "SELECT a.first_name AS value FROM authors AS a WHERE a.deleted_at IS NULL",
+         "SELECT a.first_name AS value FROM authors AS a WHERE a.deleted_at IS NULL",
+       ]
+      `);
+    });
+
     it("correlates scalar and entity queries inside nested and/or conditions", async () => {
       // Given an Author with two Books, who must appear only once
       await insertAuthor({ first_name: "published", age: 30 });

--- a/packages/tests/integration/src/EntityManager.rawQueries.types.test.ts
+++ b/packages/tests/integration/src/EntityManager.rawQueries.types.test.ts
@@ -5,6 +5,7 @@ import {
   type ExprBrand,
   type ExpressionCondition,
   type ExpressionFilter,
+  type ExistsQuery,
   type Loaded,
   type PredicateBrand,
   type Query,
@@ -131,6 +132,13 @@ function predicateTypeAssertions() {
     or: [sqlGroup, { exists: query({ from: b, where: b.author_id.eq(a.id), select: b.id }) }],
   } satisfies QueryCondition;
   em.query({ from: a, where: exists, select: a.id });
+  // And optional existence queries that are omitted by the caller
+  const optionalExists: ExistsQuery | undefined = undefined;
+  const optionalNotExists: ExistsQuery | undefined = undefined;
+  const optionalExistence = {
+    and: [{ exists: optionalExists }, { notExists: optionalNotExists }],
+  } satisfies QueryCondition;
+  em.query({ from: a, where: optionalExistence, select: a.id });
 
   // When predicates cross the domain and SQL boundary, even inside boolean groups
   // Then all public condition entry points reject the foreign brand

--- a/packages/tests/integration/src/EntityManager.rawQueries.types.test.ts
+++ b/packages/tests/integration/src/EntityManager.rawQueries.types.test.ts
@@ -1,11 +1,11 @@
 import { expectTypeOf } from "expect-type";
 import {
   type ColumnCondition,
+  type ExistsQuery,
   type Expr,
   type ExprBrand,
   type ExpressionCondition,
   type ExpressionFilter,
-  type ExistsQuery,
   type Loaded,
   type PredicateBrand,
   type Query,


### PR DESCRIPTION
## Summary

Allow `{ exists: undefined }` and `{ notExists: undefined }` to follow the existing optional-condition pruning behavior.

The change preserves validation for non-undefined invalid existence operands and adds runtime and type-level integration coverage.

## Verification

- `yarn workspace joist-tests-integration test-stock --runTestsByPath src/EntityManager.rawQueries.test.ts`
- `yarn typecheck:packages`
- `yarn typecheck:consumers`
- `yarn oxfmt --check packages/core/src/query.ts packages/tests/integration/src/EntityManager.rawQueries.test.ts packages/tests/integration/src/EntityManager.rawQueries.types.test.ts`